### PR TITLE
I've added the Ignore method to the non-generic IMemberConfigurationExpression

### DIFF
--- a/src/AutoMapper/IMappingExpression.cs
+++ b/src/AutoMapper/IMappingExpression.cs
@@ -36,6 +36,7 @@ namespace AutoMapper
         IResolutionExpression ResolveUsing(IValueResolver valueResolver);
         IResolverConfigurationExpression ResolveUsing(Type valueResolverType);
         IResolverConfigurationExpression ResolveUsing<TValueResolver>();
+        void Ignore();
     }
 
     public interface IMemberConfigurationExpression<TSource>

--- a/src/AutoMapper/Internal/MappingExpression.cs
+++ b/src/AutoMapper/Internal/MappingExpression.cs
@@ -84,6 +84,11 @@ namespace AutoMapper
 
             return new ResolutionExpression(_typeMap.SourceType, _propertyMap);
         }
+
+	    public void Ignore()
+	    {
+	        _propertyMap.Ignore();
+	    }
 	}
 
 	internal class MappingExpression<TSource, TDestination> : IMappingExpression<TSource, TDestination>, IMemberConfigurationExpression<TSource>, IFormatterCtorConfigurator


### PR DESCRIPTION
I needed this change on my project, which is dynamically generating mappings between Entity Framework models and business objects. It's just a copy of the Ignore method in the generic version of MappingExpression.
