### PR TITLE
Split the mapping method in two to allow for type inference.

### DIFF
--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -212,5 +212,26 @@ namespace AutoMapper
 	    {
             Configuration.AddGlobalIgnore(startingwith);
 	    }
+
+		public struct MappingHelper<TSource>
+		{
+			private readonly TSource _source;
+
+			internal MappingHelper(TSource source)
+			{
+				_source = source;
+			}
+
+			public TDestination To<TDestination>()
+			{
+				return Map<TSource, TDestination>(_source);
+			}
+		}
+
+		public static MappingHelper<TSource> Map<TSource>(TSource source)
+		{
+			return new MappingHelper<TSource>(source);
+		}
+
 	}
 }


### PR DESCRIPTION
I have implemented as a suggestion a method to simplify the use of the Mapper class.
Insteaf of
  myDestination = Mapper.Map< SourceType, DestinationType >(mySource);

One can write:
  myDestination = Mapper.Map(mySource).To< DestinationType>();

Does this make sense, or am I missing something?

With this syntax, the source type could even be anonymous, although I am not sure if that would be useful at all.
