### PR TITLE
Fixes issue #28

### DIFF
--- a/src/AutoMapper/Mappers/CollectionMapper.cs
+++ b/src/AutoMapper/Mappers/CollectionMapper.cs
@@ -48,11 +48,25 @@ namespace AutoMapper.Mappers
 
             protected override TCollection CreateDestinationObjectBase(Type destElementType, int sourceLength)
             {
-                var list = typeof(TCollection).IsInterface 
-                                  ? new List<TElement>() 
-                                  : ObjectCreator.CreateDefaultValue(typeof (TCollection));
+                Object collection;
+                
+                if (typeof(TCollection).IsInterface)
+                {
+                    if (typeof(TCollection).Name == "ISet`1")
+                    {
+                        collection = new HashSet<TElement>();
+                    }
+                    else
+                    {
+                        collection = new List<TElement>();
+                    }
+                }
+                else
+                {
+                    collection = ObjectCreator.CreateDefaultValue(typeof(TCollection));
+                }
 
-                return (TCollection) list;
+                return (TCollection)collection;
             }
         }
 

--- a/src/UnitTests/Bug/CollectionMapperMapsISetIncorrectly.cs
+++ b/src/UnitTests/Bug/CollectionMapperMapsISetIncorrectly.cs
@@ -1,0 +1,52 @@
+﻿
+using System.Collections.Generic;
+using System.Linq;
+using AutoMapper.Mappers;
+using NUnit.Framework;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    [TestFixture]
+    public class CollectionMapperMapsIEnumerableToISetIncorrectly
+    {
+        public class TypeWithStringProperty
+        {
+            public string Value { get; set; }
+        }
+
+        public class SourceWithIEnumerable
+        {
+            public IEnumerable<TypeWithStringProperty> Stuff { get; set; }
+        }
+
+        public class TargetWithISet
+        {
+            public ISet<string> Stuff { get; set; }
+        }
+
+        [Test]
+        public void ShouldMapToNewISet()
+        {
+            var config = new ConfigurationStore(new TypeMapFactory(), MapperRegistry.AllMappers());
+            config.CreateMap<SourceWithIEnumerable, TargetWithISet>()
+                  .ForMember(dest => dest.Stuff, opt => opt.MapFrom(src => src.Stuff.Select(s => s.Value)));
+
+            config.AssertConfigurationIsValid();
+
+            var engine = new MappingEngine(config);
+
+            var source = new SourceWithIEnumerable
+            {
+                Stuff = new[]
+                            {
+                                new TypeWithStringProperty { Value = "Microphone" }, 
+                                new TypeWithStringProperty { Value = "Check" }, 
+                                new TypeWithStringProperty { Value = "1, 2" }, 
+                                new TypeWithStringProperty { Value = "What is this?" }
+                            }
+            };
+
+            var target = engine.Map<SourceWithIEnumerable, TargetWithISet>(source);
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -114,6 +114,7 @@
     <Compile Include="Bug\AllMembersNullSubstitute.cs" />
     <Compile Include="Bug\AllowNullDestinationValuesBugs.cs" />
     <Compile Include="Bug\AssignableCollectionBug.cs" />
+    <Compile Include="Bug\CollectionMapperMapsISetIncorrectly.cs" />
     <Compile Include="Bug\CustomIEnumerableBug.cs" />
     <Compile Include="Bug\AddingConfigurationForNonMatchingDestinationMemberBug.cs" />
     <Compile Include="Bug\DuplicateValuesBug.cs" />


### PR DESCRIPTION
Permits targets with properties of type ISet<T> to be mapped from IEnumerable<T>
