### PR TITLE
Add bidirectional support to TypeConverter mapping

### DIFF
--- a/src/UnitTests/General.cs
+++ b/src/UnitTests/General.cs
@@ -186,7 +186,7 @@ namespace AutoMapper.UnitTests
 			public void Should_throw_a_mapping_exception()
 			{
 				var model = new ModelObject();
-				model.NullableDate = new DateTime(2007, 8, 4).ToString();
+				model.NullableDate = "Lorem Ipsum";
 				
 				typeof(AutoMapperMappingException).ShouldBeThrownBy(() => Mapper.Map<ModelObject, ModelDto>(model));
 			}

--- a/src/UnitTests/TypeConverters.cs
+++ b/src/UnitTests/TypeConverters.cs
@@ -151,10 +151,18 @@ namespace AutoMapper.UnitTests
 							OtherValue = ((Source) value).Value + 10
 						};
 				}
+				public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+				{
+					return sourceType == typeof(Destination);
+				}
+				public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+				{
+					return new Source {Value = ((Destination) value).OtherValue - 10};
+				}
 			}
 
 			[Test]
-			public void Should_convert_type_using_the_custom_type_converter()
+			public void Should_convert_from_type_using_the_custom_type_converter()
 			{
 				var source = new Source
 					{
@@ -163,6 +171,18 @@ namespace AutoMapper.UnitTests
 				var destination = Mapper.Map<Source, Destination>(source);
 
 				destination.OtherValue.ShouldEqual(15);
+			}
+
+			[Test]
+			public void Should_convert_to_type_using_the_custom_type_converter()
+			{
+				var source = new Destination()
+				{
+					OtherValue = 15
+				};
+				var destination = Mapper.Map<Destination, Source>(source);
+
+				destination.Value.ShouldEqual(5);
 			}
 		}
 


### PR DESCRIPTION
TypeConverterMapper would only work when the converter for the source type could convert from the source type to the destination type.  Added additional logic so that if the destination type's converter can convert from the source type that is used.

Also added associated unit test and fixed a unit test that started failing with the new feature:

enum Foo
{
}
[TypeConverter(WrapperConverter)] // can convert to and from Foo
class Bar
{
}

old behavior:

Foo f

Bar b = Mapper.Map<Foo, Bar>(f); // would fail because enum converter knows nothing about Bar.

new behavior passes because the mapper will also look at the destination type converter and see if it supports mapping from Foo.
