### PR TITLE
Added a cache for DataMapperReader.Build objects

### DIFF
--- a/src/AutoMapper/Mappers/DataReaderMapper.cs
+++ b/src/AutoMapper/Mappers/DataReaderMapper.cs
@@ -1,5 +1,6 @@
 using System;
-using System.ComponentModel;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Data;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -8,6 +9,8 @@ namespace AutoMapper.Mappers
 {
 	public class DataReaderMapper : IObjectMapper
 	{
+		private static ConcurrentDictionary<BuilderKey, Build> _builderCache = new ConcurrentDictionary<BuilderKey, Build>();
+
 		public object Map(ResolutionContext context, IMappingEngineRunner mapper)
 		{
 			if (IsDataReader(context))
@@ -66,6 +69,13 @@ namespace AutoMapper.Mappers
 
 		private static Build CreateBuilder(Type destinationType, IDataRecord dataRecord)
 		{
+			Build builder;
+			BuilderKey builderKey = new BuilderKey(destinationType, dataRecord);
+			if (_builderCache.TryGetValue(builderKey, out builder))
+			{
+				return builder;
+			}
+
 			var method = new DynamicMethod("DynamicCreate", destinationType, new[] { typeof(IDataRecord) }, destinationType, true);
 			var generator = method.GetILGenerator();
 
@@ -75,7 +85,7 @@ namespace AutoMapper.Mappers
 
 			for (var i = 0; i < dataRecord.FieldCount; i++)
 			{
-				var propertyInfo = destinationType.GetProperty(dataRecord.GetName(i));
+				var propertyInfo = destinationType.GetProperty(dataRecord.GetName(i), BindingFlags.Public | BindingFlags.IgnoreCase | BindingFlags.Instance);
 				var endIfLabel = generator.DefineLabel();
 
 				if (propertyInfo != null && propertyInfo.GetSetMethod(true) != null)
@@ -116,7 +126,9 @@ namespace AutoMapper.Mappers
 			generator.Emit(OpCodes.Ldloc, result);
 			generator.Emit(OpCodes.Ret);
 
-			return (Build)method.CreateDelegate(typeof(Build));
+			builder = (Build)method.CreateDelegate(typeof(Build));
+			_builderCache[builderKey] = builder;
+			return builder;
 		}
 
 		private static void MapPropertyValues(ResolutionContext context, IMappingEngineRunner mapper, object result)
@@ -160,5 +172,48 @@ namespace AutoMapper.Mappers
 			typeof(IDataRecord).GetMethod("get_Item", new[] { typeof(int) });
 		private static readonly MethodInfo isDBNullMethod =
 			typeof(IDataRecord).GetMethod("IsDBNull", new[] { typeof(int) });
+
+		private class BuilderKey
+		{
+			private readonly List<string> _dataRecordNames;
+			private readonly Type _destinationType;
+
+			public BuilderKey(Type destinationType, IDataRecord record)
+			{
+				_destinationType = destinationType;
+				_dataRecordNames = new List<string>(record.FieldCount);
+				for (int i = 0; i < record.FieldCount; i++)
+				{
+					_dataRecordNames.Add(record.GetName(i));
+				}
+			}
+
+			public override int GetHashCode()
+			{
+				int hash = _destinationType.GetHashCode();
+				foreach (var name in _dataRecordNames)
+				{
+					hash = hash * 37 + name.GetHashCode();
+				}
+				return hash;
+			}
+
+			public override bool Equals(object obj)
+			{
+				var builderKey = obj as BuilderKey;
+				if (builderKey == null)
+					return false;
+
+				if (this._dataRecordNames.Count != builderKey._dataRecordNames.Count)
+					return false;
+
+				for (int i = 0; i < _dataRecordNames.Count; i++)
+				{
+					if (this._dataRecordNames[i] != builderKey._dataRecordNames[i])
+						return false;
+				}
+				return true;
+			}
+		}
 	}
 }

--- a/src/UnitTests/DataReaderMapping.cs
+++ b/src/UnitTests/DataReaderMapping.cs
@@ -88,8 +88,22 @@ namespace AutoMapper.UnitTests
             }
 
 
-            private DTOObject _result;
-            private IDataReader _dataReader;
+            protected DTOObject _result;
+            protected IDataReader _dataReader;
+        }
+
+        /// <summary>
+        /// The purpose of this test is to exercise the internal caching logic of DataReaderMapper.
+        /// </summary>
+        public class When_mapping_a_data_reader_to_a_dto_twice : When_mapping_a_data_reader_to_a_dto
+        {
+            protected override void Establish_context()
+            {
+                base.Establish_context();
+
+                _dataReader = new DataBuilder().BuildDataReader();
+                _result = Mapper.Map<IDataReader, IEnumerable<DTOObject>>(_dataReader).FirstOrDefault();
+            }
         }
 
         public class When_mapping_a_single_data_record_to_a_dto : AutoMapperSpecBase


### PR DESCRIPTION
Performance suffers when the DataMapperReader is used heavily due to the expense of generating the Build delegate method.  This commit adds a cache for the 'Build'ers so that they're generated only once.
