### PR TITLE
NameValueCollectionMapper

### DIFF
--- a/src/AutoMapper/AutoMapper.csproj
+++ b/src/AutoMapper/AutoMapper.csproj
@@ -90,6 +90,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Mappers\NameValueCollectionMapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="AutoMapperMappingException.cs" />
     <Compile Include="Configuration\MapperConfiguration.cs" />

--- a/src/AutoMapper/Mappers/MapperRegistry.cs
+++ b/src/AutoMapper/Mappers/MapperRegistry.cs
@@ -16,6 +16,9 @@ namespace AutoMapper.Mappers
             new EnumMapper(),
             new ArrayMapper(),
 			new EnumerableToDictionaryMapper(),
+#if !SILVERLIGHT
+            new NameValueCollectionMapper(), 
+#endif
             new DictionaryMapper(),
 #if !SILVERLIGHT
             new ListSourceMapper(),

--- a/src/AutoMapper/Mappers/NameValueCollectionMapper.cs
+++ b/src/AutoMapper/Mappers/NameValueCollectionMapper.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Specialized;
+
+namespace AutoMapper.Mappers
+{
+    public class NameValueCollectionMapper : IObjectMapper
+    {
+        public object Map(ResolutionContext context, IMappingEngineRunner mapper)
+        {
+            if (!IsMatch(context) || context.SourceValue == null)
+                return null;
+            
+            var nvc = new NameValueCollection();
+            var source = context.SourceValue as NameValueCollection;
+            foreach (var s in source.AllKeys)
+                nvc.Add(s, source[s]);
+
+            return nvc;
+        }
+
+        public bool IsMatch(ResolutionContext context)
+        {
+            return 
+                context.SourceType == typeof(NameValueCollection) &&
+                context.DestinationType == typeof (NameValueCollection);
+        }
+    }
+}

--- a/src/UnitTests/CollectionMapping.cs
+++ b/src/UnitTests/CollectionMapping.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using NUnit.Framework;
 using Should;
 #if !SILVERLIGHT
@@ -271,6 +272,19 @@ namespace AutoMapper.UnitTests
 
             Assert.That(master.Details, Is.Not.SameAs(originalCollection));
         }
+
+#if !SILVERLIGHT
+        [Test]
+        public void Should_map_to_NameValueCollection() {
+            // initially results in the following exception:
+            // ----> System.InvalidCastException : Unable to cast object of type 'System.Collections.Specialized.NameValueCollection' to type 'System.Collections.IList'.
+            // this was fixed by adding NameValueCollectionMapper to the MapperRegistry.
+            var c = new NameValueCollection();
+            var mappedCollection = Mapper.Map<NameValueCollection, NameValueCollection>(c);
+
+            Assert.IsNotNull(mappedCollection);
+        }
+#endif
 
 #if SILVERLIGHT
         public class HashSet<T> : Collection<T>

--- a/src/UnitTests/Mappers/NameValueCollectionMapperTests.cs
+++ b/src/UnitTests/Mappers/NameValueCollectionMapperTests.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Specialized;
+using AutoMapper;
+using AutoMapper.Mappers;
+using NUnit.Framework;
+
+namespace Automapper.UnitTests.Mappers
+{
+    [TestFixture]
+    public class NameValueCollectionMapperTests
+    {
+        [TestFixture]
+        public class IsMatch
+        {
+            [Test]
+            public void ReturnsTrueWhenBothSourceAndDestinationTypesAreNameValueCollection()
+            {
+                var rc = new ResolutionContext(null, null, null, typeof(NameValueCollection), typeof(NameValueCollection), null);
+                var nvcm = new NameValueCollectionMapper();
+
+                var result = nvcm.IsMatch(rc);
+
+                Assert.IsTrue(result);
+            }
+
+            [Test]
+            public void ReturnsIsFalseWhenDestinationTypeIsNotNameValueCollection()
+            {
+                var rc = new ResolutionContext(null, null, null, typeof(NameValueCollection), typeof(Object), null);
+                var nvcm = new NameValueCollectionMapper();
+
+                var result = nvcm.IsMatch(rc);
+
+                Assert.IsFalse(result);
+            }            
+
+            [Test]
+            public void ReturnsIsFalseWhenSourceTypeIsNotNameValueCollection()
+            {
+                var rc = new ResolutionContext(null, null, null, typeof(Object), typeof(NameValueCollection), null);
+                var nvcm = new NameValueCollectionMapper();
+
+                var result = nvcm.IsMatch(rc);
+
+                Assert.IsFalse(result);
+            }            
+        }
+
+        [TestFixture]
+        public class Map
+        {
+            [Test]
+            public void ReturnsNullIfSourceTypeIsNotNameValueCollection()
+            {
+                var rc = new ResolutionContext(null, new Object(), new NameValueCollection(), typeof(Object), typeof(NameValueCollection), null);
+                var nvcm = new NameValueCollectionMapper();
+
+                var result = nvcm.Map(rc, null);
+
+                Assert.IsNull(result);
+            }
+
+            [Test]
+            public void ReturnsNullIfSourceValueIsNull()
+            {
+                var rc = new ResolutionContext(null, null, new NameValueCollection(), typeof(NameValueCollection), typeof(NameValueCollection), null);
+                var nvcm = new NameValueCollectionMapper();
+
+                var result = nvcm.Map(rc, null);
+
+                Assert.IsNull(result);
+            }
+
+            [Test]
+            public void ReturnsEmptyCollectionWhenSourceCollectionIsEmpty()
+            {
+                var sourceValue = new NameValueCollection();
+                var rc = new ResolutionContext(null, sourceValue, new NameValueCollection(), typeof(NameValueCollection), typeof(NameValueCollection), null);
+                var nvcm = new NameValueCollectionMapper();
+
+                var result = nvcm.Map(rc, null) as NameValueCollection;
+
+                Assert.IsEmpty(result); 
+            }
+
+            [Test]
+            public void ReturnsMappedObjectWithExpectedValuesWhenSourceCollectionHasOneItem()
+            {
+                var sourceValue = new NameValueCollection() { { "foo", "bar" } };
+                var rc = new ResolutionContext(null, sourceValue, new NameValueCollection(), typeof(NameValueCollection), typeof(NameValueCollection), null);
+
+                var nvcm = new NameValueCollectionMapper();
+
+                var result = nvcm.Map(rc, null) as NameValueCollection;
+
+                Assert.AreEqual(1, result.Count);
+                Assert.AreEqual("foo", result.AllKeys[0]);
+                Assert.AreEqual("bar", result["foo"]);
+            }
+        }
+        
+    }
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -145,6 +145,7 @@
     <Compile Include="Internal\PrimitiveExtensionsTester.cs" />
     <Compile Include="Internationalization.cs" />
     <Compile Include="Bug\LazyCollectionMapping.cs" />
+    <Compile Include="Mappers\NameValueCollectionMapperTests.cs" />
     <Compile Include="Mappers\TypeHelperTests.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
Added NameValueCollectionMapper so that NameValueCollections can be mapped. Fixes existing issue where the mappin attempt falls back to an IList, resulting in an InvalidCastException
