### PR TITLE
Fix: Linq autoprojecting

### DIFF
--- a/src/AutoMapper/MappingEngine.cs
+++ b/src/AutoMapper/MappingEngine.cs
@@ -409,7 +409,8 @@ namespace AutoMapper
 
             protected override Expression VisitParameter(ParameterExpression node)
             {
-                return newParameter; // replace all old param references with new ones
+                // replace all old param references with new ones
+                return node.Type == oldParameter.Type ? newParameter : node; 
             }
 
             protected override Expression VisitMember(MemberExpression node)


### PR DESCRIPTION
Hi, 

Those commits resolves two problems with the autoprojecting mechanism. 
One it's related to using properties with an enum type in a destination class and underlying type of that enum in a source class. It may looks like:

```
Mapper.CreateMap<Source, Destination>()
        .ForMember(dest => dest.Color, opt => opt.MapFrom(src => (Colors)src.Color))
              ;
```

where the dest.Color is an enum : int Colors { Red, Black } and the src.Color is an integer.

The second problem it's related to the CoversionVisitor which should replace in an expression only parameters of source type. 

Here's the example:

```
Mapper.CreateMap<Source, Destination>()
      .ForMember(m => m.Sum, opt => opt.MapFrom(src => src.Collection.Sum(a => a % 2 == 0 ? 1 : 0))
      ;

var source = new [] { 
                        new Source(),
                        new Source(),
                        new Source()
                    };

var destination = source.AsQueryable().Project()
                                      .To<Destination>()
                                      .Where(a => a.Sum > 4);
destination.Dump();

public class Source
{
    public ICollection<int> Collection 
    { 
        get 
        { 
            return Enumerable.Range(1, 100).ToList(); 
        }    
    }
}

public class Destination
{    
    public int Sum { get; set; }
}
```

Old version of ConversionVisitor would replace the parameter of the sum expression which generates the exception. I've tested it with EF 4.2.
Sorry for a lack of test cases... but I've got no time to prepare them. 
