### PR TITLE
Not all use cases want the enumeration here

### DIFF
--- a/src/AutoMapper/MappingEngine.cs
+++ b/src/AutoMapper/MappingEngine.cs
@@ -10,6 +10,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using AutoMapper.Internal;
 using AutoMapper.Mappers;
+using System.Collections;
 
 namespace AutoMapper
 {
@@ -269,7 +270,7 @@ namespace AutoMapper
                                 currentChild,
                                 transformedExpression);
 
-                    if (prop.PropertyType.GetInterface("IList", true) != null)
+                    if (typeof(IList).IsAssignableFrom(prop.PropertyType))
                     {
                         MethodCallExpression toListCallExpression = Expression.Call(
                             typeof(Enumerable),


### PR DESCRIPTION
Not all use cases need the enumeration here. Allowing the enumeration to be deferred here allows for chaining of expression tree projection (i.e. DTO layer -> Entity layer -> SQL layer (via EF)). This is a really cool use case for this, but also means client programmers may get a couple bugs if they previously map to an ienumerable and rely on the automapper's enumeration call.
