### PR TITLE
TypePair.GetHashCode() returns a precalculated value in an unchecked context

### DIFF
--- a/src/AutoMapper/Internal/TypePair.cs
+++ b/src/AutoMapper/Internal/TypePair.cs
@@ -10,7 +10,7 @@ namespace AutoMapper.Internal
 		{
 			_sourceType = sourceType;
 			_destinationType = destinationType;
-			_hashcode = (_sourceType.GetHashCode()*397) ^ _destinationType.GetHashCode();
+			_hashcode = unchecked((_sourceType.GetHashCode()*397) ^ _destinationType.GetHashCode());
 		}
 
         private readonly Type _destinationType;
@@ -41,10 +41,7 @@ namespace AutoMapper.Internal
 
 		public override int GetHashCode()
 		{
-			unchecked
-			{
-				return _hashcode;
-			}
+			return _hashcode;			
 		}
 	}
 }


### PR DESCRIPTION
Hash code was calculated in the TypePair constructor outside of an unchecked context, whilst GetHashCode() returned the precalculated value inside of an unchecked context. Looks like a relic from when the hash code calculation was moved into the constructor.
