### PR TITLE
Allow mapping-by-constructor to be disabled via configuration

### DIFF
--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -92,7 +92,12 @@ namespace AutoMapper
 	        get { return GetProfile(DefaultProfileName).Aliases; }
 	    }
 
-		bool IProfileConfiguration.MapNullSourceValuesAsNull
+	    public bool ConstructorMappingEnabled
+	    {
+	        get { return GetProfile(DefaultProfileName).ConstructorMappingEnabled; }
+	    }
+
+	    bool IProfileConfiguration.MapNullSourceValuesAsNull
 		{
 			get { return AllowNullDestinationValues; }
 		}
@@ -137,7 +142,12 @@ namespace AutoMapper
 			_serviceCtor = constructor;
 		}
 
-		public void Seal()
+	    public void DisableConstructorMapping()
+	    {
+	        GetProfile(DefaultProfileName).ConstructorMappingEnabled = false;
+	    }
+
+	    public void Seal()
 		{
 			_typeMaps.Each(typeMap => typeMap.Seal());
 		}

--- a/src/AutoMapper/IFormatterExpression.cs
+++ b/src/AutoMapper/IFormatterExpression.cs
@@ -38,7 +38,7 @@ namespace AutoMapper
         void RecognizeDestinationPrefixes(params string[] prefixes);
         void RecognizeDestinationPostfixes(params string[] postfixes);
         void AddGlobalIgnore(string propertyNameStartingWith);
-    }
+	}
 
 	public interface IConfiguration : IProfileExpression
 	{
@@ -47,6 +47,7 @@ namespace AutoMapper
 		void AddProfile(Profile profile);
 		void AddProfile<TProfile>() where TProfile : Profile, new();
 		void ConstructServicesUsing(Func<Type, object> constructor);
+	    void DisableConstructorMapping();
 		void Seal();
 	}
 }

--- a/src/AutoMapper/INamingConvention.cs
+++ b/src/AutoMapper/INamingConvention.cs
@@ -19,6 +19,7 @@ namespace AutoMapper
 	    IEnumerable<string> DestinationPrefixes { get; }
 	    IEnumerable<string> DestinationPostfixes { get; }
 	    IEnumerable<AliasedMember> Aliases { get; }
+	    bool ConstructorMappingEnabled { get; }
     }
 
 	public class PascalCaseNamingConvention : INamingConvention

--- a/src/AutoMapper/Internal/FormatterExpression.cs
+++ b/src/AutoMapper/Internal/FormatterExpression.cs
@@ -23,6 +23,7 @@ namespace AutoMapper
 			DestinationMemberNamingConvention = new PascalCaseNamingConvention();
 		    RecognizePrefixes("Get");
 			AllowNullDestinationValues = true;
+	        ConstructorMappingEnabled = true;
 		}
 
 		public bool AllowNullDestinationValues { get; set; }
@@ -34,8 +35,9 @@ namespace AutoMapper
         public IEnumerable<string> DestinationPrefixes { get { return _destinationPrefixes; } }
         public IEnumerable<string> DestinationPostfixes { get { return _destinationPostfixes; } }
         public IEnumerable<AliasedMember> Aliases { get { return _aliases; } }
+        public bool ConstructorMappingEnabled { get; set; }
 
-		public IFormatterCtorExpression<TValueFormatter> AddFormatter<TValueFormatter>() where TValueFormatter : IValueFormatter
+        public IFormatterCtorExpression<TValueFormatter> AddFormatter<TValueFormatter>() where TValueFormatter : IValueFormatter
 		{
 			var formatter = new DeferredInstantiatedFormatter(BuildCtor(typeof(TValueFormatter)));
 

--- a/src/AutoMapper/Internal/TypeMapFactory.cs
+++ b/src/AutoMapper/Internal/TypeMapFactory.cs
@@ -55,8 +55,12 @@ namespace AutoMapper
                                                 IMappingOptions options)
         {
             var parameters = new List<ConstructorParameterMap>();
+            var ctorParameters = destCtor.GetParameters();
 
-            foreach (var parameter in destCtor.GetParameters())
+            if (ctorParameters.Length > 0 && !options.ConstructorMappingEnabled)
+                return false;
+
+            foreach (var parameter in ctorParameters)
             {
                 var members = new LinkedList<MemberInfo>();
 

--- a/src/AutoMapper/Profile.cs
+++ b/src/AutoMapper/Profile.cs
@@ -68,6 +68,11 @@ namespace AutoMapper
 	        get { throw new NotImplementedException(); }
 	    }
 
+	    public bool ConstructorMappingEnabled
+	    {
+	        get { return _configurator.ConstructorMappingEnabled; }
+	    }
+
 	    public IFormatterCtorExpression<TValueFormatter> AddFormatter<TValueFormatter>() where TValueFormatter : IValueFormatter
 		{
 			return GetProfile().AddFormatter<TValueFormatter>();

--- a/src/UnitTests/Constructors.cs
+++ b/src/UnitTests/Constructors.cs
@@ -208,6 +208,53 @@ namespace AutoMapper.UnitTests
             }
         }
 
+        public class When_mapping_to_an_object_with_multiple_constructors_and_constructor_mapping_is_disabled : AutoMapperSpecBase
+        {
+            private Dest _dest;
+
+            public class Source
+            {
+                public int Foo { get; set; }
+                public int Bar { get; set; }
+            }
+
+            public class Dest
+            {
+                public int Foo { get; set; }
+
+                public int Bar { get; set; }
+
+                public Dest(int foo)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public Dest() { }
+            }
+
+            protected override void Establish_context()
+            {
+                Mapper.Initialize(cfg =>
+                                      {
+                                          cfg.DisableConstructorMapping();
+                                          cfg.CreateMap<Source, Dest>();
+                                      }
+                    );
+            }
+
+            protected override void Because_of()
+            {
+                _dest = Mapper.Map<Source, Dest>(new Source { Foo = 5, Bar = 10 });
+            }
+
+            [Test]
+            public void Should_map_the_existing_properties()
+            {
+                _dest.Foo.ShouldEqual(5);
+                _dest.Bar.ShouldEqual(10);
+            }
+        }
+
         [TestFixture]
         public class UsingMappingEngineToResolveConstructorArguments : AutoMapperSpecBase
         {

--- a/src/UnitTests/Tests/TypeMapFactorySpecs.cs
+++ b/src/UnitTests/Tests/TypeMapFactorySpecs.cs
@@ -60,6 +60,11 @@ namespace AutoMapper.UnitTests.Tests
         {
             get { return _aliases; }
         }
+
+        public bool ConstructorMappingEnabled
+        {
+            get { return true; }
+        }
     }
 
     public class When_constructing_type_maps_with_matching_property_names : SpecBase


### PR DESCRIPTION
I've added a method to the Mapper configuration that allows mapping-by-constructor to be disabled. While a useful feature, it would be helpful if it could be disabled and for the parameterless constructor to always be used to construct an object. Mapping-by-constructor remains on by default so this is not a breaking change.

Paul
