### PR TITLE
Added public overload to allow assertion of configuration valid for single type map.

### DIFF
--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -191,6 +191,11 @@ namespace AutoMapper
 			ConfigurationProvider.AssertConfigurationIsValid();
 		}
 
+		public static void AssertConfigurationIsValid(TypeMap tm)
+		{
+			ConfigurationProvider.AssertConfigurationIsValid(tm);
+		}
+
 		public static void AssertConfigurationIsValid(string profileName)
 		{
 			ConfigurationProvider.AssertConfigurationIsValid(profileName);


### PR DESCRIPTION
This allows newly created maps to be checked without needing to check all type maps.
