### PR TITLE
Issue with auto-mapping of void methods

### DIFF
--- a/src/AutoMapper/TypeInfo.cs
+++ b/src/AutoMapper/TypeInfo.cs
@@ -94,11 +94,11 @@ namespace AutoMapper
     			                               (m is PropertyInfo && ((PropertyInfo)m).CanRead && !((PropertyInfo)m).GetIndexParameters().Any()), null));
     	}
 
-    	private MethodInfo[] BuildPublicNoArgMethods()
-        {
-            return Type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
-                .Where(m => (m.ReturnType != null) && (m.GetParameters().Length == 0) && (m.MemberType == MemberTypes.Method))
-                .ToArray();
-        }
+		private MethodInfo[] BuildPublicNoArgMethods()
+		{
+			return Type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+				.Where(m => (m.ReturnType != typeof(void)) && (m.GetParameters().Length == 0) && (m.MemberType == MemberTypes.Method))
+				.ToArray();
+		}
     }
 }

--- a/src/UnitTests/ConfigurationValidation.cs
+++ b/src/UnitTests/ConfigurationValidation.cs
@@ -408,7 +408,56 @@ namespace AutoMapper.UnitTests
                 typeof(AutoMapperConfigurationException).ShouldNotBeThrownBy(Mapper.AssertConfigurationIsValid);
             }
         }
+		
+		public class When_testing_a_dto_with_setter_only_peroperty_member : NonValidatingSpecBase
+		{
+			public class Source
+			{
+				public string Value { set { } }
+			}
 
+			public class Destination
+			{
+				public string Value { get; set; }
+			}
+
+			protected override void Establish_context()
+			{
+				Mapper.Initialize(cfg => cfg.CreateMap<Source, Destination>());
+			}
+
+			[Test]
+			public void Should_fail_a_configuration_check()
+			{
+				typeof(AutoMapperConfigurationException).ShouldBeThrownBy(Mapper.AssertConfigurationIsValid);
+			}
+		}
+
+		public class When_testing_a_dto_with_matching_void_method_member : NonValidatingSpecBase
+		{
+			public class Source
+			{
+				public void Method()
+				{
+				}
+			}
+
+			public class Destination
+			{
+				public string Method { get; set; }
+			}
+
+			protected override void Establish_context()
+			{
+				Mapper.Initialize(cfg => cfg.CreateMap<Source, Destination>());
+			}
+
+			[Test]
+			public void Should_fail_a_configuration_check()
+			{
+				typeof(AutoMapperConfigurationException).ShouldBeThrownBy(Mapper.AssertConfigurationIsValid);
+			}
+		}
     }
 
 }


### PR DESCRIPTION
This happens when source contains void Test() and destination Test { get; set; }.
CreateMap fails with a type coersion exception.
