### PR TITLE
Abstract class is mapped with CustomMapper on CreateMapExpression.

### DIFF
--- a/src/AutoMapper/MappingEngine.cs
+++ b/src/AutoMapper/MappingEngine.cs
@@ -309,10 +309,51 @@ namespace AutoMapper
                 }
 
             }
-            var total = Expression.MemberInit(
-                Expression.New(typeOut),
-                bindings.ToArray()
-            );
+            Expression total;
+            if (typeOut.IsAbstract)
+            {
+                if (typeMap.CustomMapper == null)
+                    throw new AutoMapperMappingException(
+                        String.Format("Abstract type {0} can not be mapped without custom mapper (tip: use ConvertUsing)", typeOut.Name));
+                // We are going to return roughly following expression
+                // typeOut (typeIn)x => (typeOut)(typeMap.CustomMapper.Invoke(new ResolutionContext(typeMap, x, typeIn, typeOut, options)))
+
+                // This expression generates a new ResolutionContext
+                // for the custom mapper (ResolveCore)
+                var context = Expression.MemberInit(
+                    Expression.New(
+                        typeof(ResolutionContext).GetConstructor(BindingFlags.Instance | BindingFlags.Public, null,
+                                                                  new Type[]
+                                                                      {
+                                                                          typeof (TypeMap), typeof (object),
+                                                                          typeof (Type),
+                                                                          typeof (Type),
+                                                                          typeof (MappingOperationOptions)
+                                                                      },
+                                                                  null),
+                        new List<Expression>
+                            {
+                                Expression.Constant(typeMap),
+                                instanceParameter, // Using the original parameter
+                                Expression.Constant(typeIn),
+                                Expression.Constant(typeOut),
+                                Expression.Constant(new MappingOperationOptions())
+                            })
+                    );
+                // This expression gets the CustomMapper from the typeMap
+                Expression<Func<TypeMap, Func<ResolutionContext, object>>> method = x => x.CustomMapper;
+                var customMapper = Expression.Invoke(method, Expression.Constant(typeMap));
+                // This expression calls the Invoke method from the CustomMapper func
+                var invoke = Expression.Call(customMapper, 
+                                typeof (Func<ResolutionContext, object>).GetMethod("Invoke"), context);
+                // We have to convert the object from Invoke to typeOut
+                total = Expression.Convert(invoke, typeOut);
+            }
+            else
+                total = Expression.MemberInit(
+                    Expression.New(typeOut),
+                    bindings.ToArray()
+                );
 
             return Expression.Lambda(total, instanceParameter);
         }


### PR DESCRIPTION
I needed to map abstract classes (using ConvertUsing) on queries. The following code does just that. Maybe it could be developed further to support the ConvertUsing even on non-abstract classes. I didn't want to break any existing functionality though.

<!---
@huboard:{"order":67.0}
-->
