### PR TITLE
Property setters not used in destination maps.

### DIFF
--- a/src/AutoMapper/TypeInfo.cs
+++ b/src/AutoMapper/TypeInfo.cs
@@ -8,7 +8,7 @@ namespace AutoMapper
     public class TypeInfo
     {
         private readonly MemberInfo[] _publicGetters;
-        private readonly MemberInfo[] _publicAccessors;
+        private readonly MemberInfo[] _publicSetters;
         private readonly MethodInfo[] _publicGetMethods;
         private readonly ConstructorInfo[] _constructors;
 
@@ -17,9 +17,9 @@ namespace AutoMapper
         public TypeInfo(Type type)
         {
             Type = type;
-        	var publicReadableMembers = GetAllPublicReadableMembers();
-			_publicGetters = BuildPublicReadAccessors(publicReadableMembers);
-			_publicAccessors = BuildPublicAccessors(publicReadableMembers);
+            var publicMembers = GetAllPublicReadableMembers();
+            _publicGetters = BuildPublicReadAccessors(publicMembers);
+            _publicSetters = BuildPublicWriteAccessors(publicMembers);
             _publicGetMethods = BuildPublicNoArgMethods();
             _constructors = type.GetConstructors(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
         }
@@ -34,9 +34,9 @@ namespace AutoMapper
             return _publicGetters;
         }
 
-		public IEnumerable<MemberInfo> GetPublicWriteAccessors()
+        public IEnumerable<MemberInfo> GetPublicWriteAccessors()
         {
-            return _publicAccessors;
+            return _publicSetters;
         }
 
         public IEnumerable<MethodInfo> GetPublicNoArgMethods()
@@ -46,55 +46,60 @@ namespace AutoMapper
 
         private MemberInfo[] BuildPublicReadAccessors(IEnumerable<MemberInfo> allMembers)
         {
-			// Multiple types may define the same property (e.g. the class and multiple interfaces) - filter this to one of those properties
-            var filteredMembers = allMembers
-                .OfType<PropertyInfo>()
-                .GroupBy(x => x.Name) // group properties of the same name together
-                .Select(x => x.First())
-                .OfType<MemberInfo>() // cast back to MemberInfo so we can add back FieldInfo objects
-                .Concat(allMembers.Where(x => x is FieldInfo));  // add FieldInfo objects back
-
-            return filteredMembers.ToArray();
-        }
-
-        private MemberInfo[] BuildPublicAccessors(IEnumerable<MemberInfo> allMembers)
-        {
-        	// Multiple types may define the same property (e.g. the class and multiple interfaces) - filter this to one of those properties
+            // Multiple types may define the same property (e.g. the class and multiple interfaces) - filter this to one of those properties
             var filteredMembers = allMembers
                 .OfType<PropertyInfo>()
                 .GroupBy(x => x.Name) // group properties of the same name together
                 .Select(x =>
                     x.Any(y => y.CanWrite && y.CanRead) ? // favor the first property that can both read & write - otherwise pick the first one
-						x.Where(y => y.CanWrite && y.CanRead).First() :
+                        x.Where(y => y.CanWrite && y.CanRead).First() :
                         x.First())
-				.Where(pi => pi.CanWrite || pi.PropertyType.IsListOrDictionaryType())
+                .Where(pi => pi.CanRead || pi.PropertyType.IsListOrDictionaryType())
                 .OfType<MemberInfo>() // cast back to MemberInfo so we can add back FieldInfo objects
                 .Concat(allMembers.Where(x => x is FieldInfo));  // add FieldInfo objects back
 
             return filteredMembers.ToArray();
         }
 
-    	private IEnumerable<MemberInfo> GetAllPublicReadableMembers()
-    	{
-			// Collect that target type, its base type, and all implemented/inherited interface types
+        private MemberInfo[] BuildPublicWriteAccessors(IEnumerable<MemberInfo> allMembers)
+        {
+            // Multiple types may define the same property (e.g. the class and multiple interfaces) - filter this to one of those properties
+            var filteredMembers = allMembers
+                .OfType<PropertyInfo>()
+                .GroupBy(x => x.Name) // group properties of the same name together
+                .Select(x =>
+                    x.Any(y => y.CanWrite && y.CanRead) ? // favor the first property that can both read & write - otherwise pick the first one
+                        x.Where(y => y.CanWrite && y.CanRead).First() :
+                        x.First())
+                .Where(pi => pi.CanWrite || pi.PropertyType.IsListOrDictionaryType())
+                .OfType<MemberInfo>() // cast back to MemberInfo so we can add back FieldInfo objects
+                .Concat(allMembers.Where(x => x is FieldInfo));  // add FieldInfo objects back
+
+            return filteredMembers.ToArray();
+        }
+
+        private IEnumerable<MemberInfo> GetAllPublicReadableMembers()
+        {
+            // Collect that target type, its base type, and all implemented/inherited interface types
             var typesToScan = new List<Type>();
             for (var t = Type; t != null; t = t.BaseType)
                 typesToScan.Add(t);
 
-    		if (Type.IsInterface)
-    			typesToScan.AddRange(Type.GetInterfaces());
+            if (Type.IsInterface)
+                typesToScan.AddRange(Type.GetInterfaces());
 
-    		// Scan all types for public properties and fields
-    		return typesToScan
-    			.Where(x => x != null) // filter out null types (e.g. type.BaseType == null)
-    			.SelectMany(x => x.FindMembers(MemberTypes.Property | MemberTypes.Field,
-    			                               BindingFlags.Instance | BindingFlags.Public,
-    			                               (m, f) =>
-    			                               m is FieldInfo ||
-    			                               (m is PropertyInfo && ((PropertyInfo)m).CanRead && !((PropertyInfo)m).GetIndexParameters().Any()), null));
-    	}
+            // Scan all types for public properties and fields
+            return typesToScan
+                .Where(x => x != null) // filter out null types (e.g. type.BaseType == null)
+                .SelectMany(x => x.FindMembers(MemberTypes.Property | MemberTypes.Field,
+                                               BindingFlags.Instance | BindingFlags.Public,
+                                               (m, f) =>
+                                               m is FieldInfo ||
+                                               (m is PropertyInfo && !((PropertyInfo)m).GetIndexParameters().Any()),
+                                               null));
+        }
 
-    	private MethodInfo[] BuildPublicNoArgMethods()
+        private MethodInfo[] BuildPublicNoArgMethods()
         {
             return Type.GetMethods(BindingFlags.Public | BindingFlags.Instance)
                 .Where(m => (m.ReturnType != null) && (m.GetParameters().Length == 0) && (m.MemberType == MemberTypes.Method))

--- a/src/UnitTests/Bug/ExistingInterfaceDestinationBug.cs
+++ b/src/UnitTests/Bug/ExistingInterfaceDestinationBug.cs
@@ -1,0 +1,48 @@
+﻿using NUnit.Framework;
+using Should;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    namespace ExistingInterfaceDestinationBug
+    {
+        public class DataSource : IHaveData
+        {
+            public string SomeData { get; set; }
+        }
+
+        public class DataDestination : INeedData
+        {
+            public string SomeData { get; set; }
+        }
+
+        public interface IHaveData
+        {
+            string SomeData { get; }
+        }
+
+        public interface INeedData
+        {
+            string SomeData { set; }
+        }
+
+        [TestFixture]
+        public class ExistingInterfaceDestinationBug : AutoMapperSpecBase
+        {
+            [Test]
+            public void Should_map_to_existing_object()
+            {
+                Mapper.CreateMap<IHaveData, INeedData>();
+                Mapper.AssertConfigurationIsValid();
+
+                var source = new DataSource();
+                source.SomeData = "Foo";
+
+                var destination = new DataDestination();
+
+                Mapper.Map<IHaveData, INeedData>(source, destination);
+
+                destination.SomeData.ShouldEqual(source.SomeData);
+            }
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Bug\DuplicateValuesBug.cs" />
     <Compile Include="Bug\EnumConditionsBug.cs" />
     <Compile Include="Bug\EnumMatchingOnValue.cs" />
+    <Compile Include="Bug\ExistingInterfaceDestinationBug.cs" />
     <Compile Include="Bug\IgnoreAll.cs" />
     <Compile Include="Bug\InheritanceIssue.cs" />
     <Compile Include="Bug\MultipleInterfaceInheritance.cs" />


### PR DESCRIPTION
I was having an issue mapping to an interface that only had a property defined as a setter.

https://groups.google.com/d/topic/automapper-users/ewcFgIXKWCY/discussion

The type mapper was not recognizing public properties that had a setter only, it was only recognizing ones that had a setter and a getter.

<!---
@huboard:{"order":245.0}
-->
