### PR TITLE
Support for yielding records from DataReaderMapper rather than using a list

### DIFF
--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -97,7 +97,12 @@ namespace AutoMapper
 	        get { return GetProfile(DefaultProfileName).ConstructorMappingEnabled; }
 	    }
 
-		public Assembly[] SourceExtensionMethodSearch
+	    public bool DataReaderMapperYieldReturnEnabled
+	    {
+            get { return GetProfile(DefaultProfileName).DataReaderMapperYieldReturnEnabled; }
+	    }
+
+	    public Assembly[] SourceExtensionMethodSearch
 		{
 			get { return GetProfile(DefaultProfileName).SourceExtensionMethodSearch; }
 			set { GetProfile(DefaultProfileName).SourceExtensionMethodSearch = value; }
@@ -153,7 +158,12 @@ namespace AutoMapper
 	        GetProfile(DefaultProfileName).ConstructorMappingEnabled = false;
 	    }
 
-		public void Seal()
+	    public void EnableYieldReturnForDataReaderMapper()
+	    {
+	        GetProfile(DefaultProfileName).DataReaderMapperYieldReturnEnabled = true;
+	    }
+
+	    public void Seal()
 		{
 			_typeMaps.Each(typeMap => typeMap.Seal());
 		}

--- a/src/AutoMapper/IFormatterExpression.cs
+++ b/src/AutoMapper/IFormatterExpression.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Reflection;
 
 namespace AutoMapper
 {
@@ -49,5 +48,6 @@ namespace AutoMapper
 		void ConstructServicesUsing(Func<Type, object> constructor);
 	    void DisableConstructorMapping();
 		void Seal();
+	    void EnableYieldReturnForDataReaderMapper();
 	}
 }

--- a/src/AutoMapper/INamingConvention.cs
+++ b/src/AutoMapper/INamingConvention.cs
@@ -20,7 +20,8 @@ namespace AutoMapper
 	    IEnumerable<string> DestinationPostfixes { get; }
 	    IEnumerable<AliasedMember> Aliases { get; }
 	    bool ConstructorMappingEnabled { get; }
-		Assembly[] SourceExtensionMethodSearch { get; set; }
+	    bool DataReaderMapperYieldReturnEnabled { get; }
+	    Assembly[] SourceExtensionMethodSearch { get; set; }
 	}
 
 	public class PascalCaseNamingConvention : INamingConvention

--- a/src/AutoMapper/Internal/FormatterExpression.cs
+++ b/src/AutoMapper/Internal/FormatterExpression.cs
@@ -37,7 +37,8 @@ namespace AutoMapper
         public IEnumerable<string> DestinationPostfixes { get { return _destinationPostfixes; } }
         public IEnumerable<AliasedMember> Aliases { get { return _aliases; } }
         public bool ConstructorMappingEnabled { get; set; }
-		public Assembly[] SourceExtensionMethodSearch { get; set; }
+        public bool DataReaderMapperYieldReturnEnabled { get; set; }
+        public Assembly[] SourceExtensionMethodSearch { get; set; }
 
         public IFormatterCtorExpression<TValueFormatter> AddFormatter<TValueFormatter>() where TValueFormatter : IValueFormatter
 		{

--- a/src/AutoMapper/Profile.cs
+++ b/src/AutoMapper/Profile.cs
@@ -74,7 +74,12 @@ namespace AutoMapper
 	        get { return _configurator.ConstructorMappingEnabled; }
 	    }
 
-		public Assembly[] SourceExtensionMethodSearch
+	    public bool DataReaderMapperYieldReturnEnabled
+	    {
+            get { return _configurator.DataReaderMapperYieldReturnEnabled; }
+	    }
+
+	    public Assembly[] SourceExtensionMethodSearch
 		{
 			get { return GetProfile().SourceExtensionMethodSearch; }
 			set { GetProfile().SourceExtensionMethodSearch = value; }

--- a/src/UnitTests/DataReaderMapping.cs
+++ b/src/UnitTests/DataReaderMapping.cs
@@ -18,7 +18,8 @@ namespace AutoMapper.UnitTests
                     .ForMember(dest => dest.Else, options => options.MapFrom(src => src.GetDateTime(10)));
 
                 _dataReader = new DataBuilder().BuildDataReader();
-                _result = Mapper.Map<IDataReader, IEnumerable<DTOObject>>(_dataReader).FirstOrDefault();
+                _results = Mapper.Map<IDataReader, IEnumerable<DTOObject>>(_dataReader); 
+                _result = _results.FirstOrDefault();
             }
 
             [Test]
@@ -87,8 +88,8 @@ namespace AutoMapper.UnitTests
                 Assert.That(_result.Else, Is.EqualTo(_dataReader.GetDateTime(10)));
             }
 
-
             protected DTOObject _result;
+            protected IEnumerable<DTOObject> _results;
             protected IDataReader _dataReader;
         }
 
@@ -102,7 +103,32 @@ namespace AutoMapper.UnitTests
                 base.Establish_context();
 
                 _dataReader = new DataBuilder().BuildDataReader();
-                _result = Mapper.Map<IDataReader, IEnumerable<DTOObject>>(_dataReader).FirstOrDefault();
+                _results = Mapper.Map<IDataReader, IEnumerable<DTOObject>>(_dataReader);
+                _result = _results.FirstOrDefault();
+            }
+        }
+
+        public class When_mapping_a_data_reader_using_the_default_coniguration : When_mapping_a_data_reader_to_a_dto
+        {
+            [Test]
+            public void Then_the_enumerable_should_be_a_list()
+            {
+                Assert.That(_results, Is.InstanceOfType(typeof(IList<DTOObject>)));
+            }
+        }
+
+        public class When_mapping_a_data_reader_using_the_yield_return_option : When_mapping_a_data_reader_to_a_dto
+        {
+            protected override void Establish_context()
+            {
+                Mapper.Configuration.EnableYieldReturnForDataReaderMapper();
+                base.Establish_context();
+            }
+
+            [Test]
+            public void Then_the_enumerable_should_not_be_a_list()
+            {
+                Assert.That(_results, Is.Not.InstanceOfType(typeof(IList<DTOObject>)));
             }
         }
 

--- a/src/UnitTests/Tests/TypeMapFactorySpecs.cs
+++ b/src/UnitTests/Tests/TypeMapFactorySpecs.cs
@@ -1,11 +1,10 @@
-using System;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
-using Should;
-using NUnit.Framework;
 using System.Linq;
-using Rhino.Mocks;
 using System.Reflection;
+using System.Text.RegularExpressions;
+using NUnit.Framework;
+using Rhino.Mocks;
+using Should;
 
 namespace AutoMapper.UnitTests.Tests
 {
@@ -69,7 +68,12 @@ namespace AutoMapper.UnitTests.Tests
             get { return true; }
         }
 
-		public Assembly[] SourceExtensionMethodSearch
+        public bool DataReaderMapperYieldReturnEnabled
+        {
+            get { return false; }
+        }
+
+        public Assembly[] SourceExtensionMethodSearch
 		{
 			get { return _sourceExtensionMethodSearch; }
 			set { _sourceExtensionMethodSearch = value; }


### PR DESCRIPTION
For the most part, the DataReaderMapper has always worked well for me.  The use of a List rather than yielding records was never that big of a deal for the majority of my typical scenarios.  However, I finally have a legitimate need for yielding the records due to some rather large result sets.  

You might decide against merging this, but I wanted to offer it since others have asked for this ability.  All of the existing unit tests pass and I also tested the changes in my own projects.  Depending on how AutoMapper is being applied to data readers, there are some scenarios that could be problematic due to deferred execution.  

For example, code written such as this would now fail because the reader will already be closed when iteration of the enumerable begins.  The reader will not actually be processed until deferred execution is triggered.

``` c#
public IEnumerable<Person> GetAllPersonRecords()
{
   using (var connection = CreateConnection())
   using (var command = CreateCommand())
   using (var reader = command.ExecuteReader())
      return Mapper.Map<IDataReader, IEnumerable<Person>>(reader);
}
```

Instead, the code would have to be changed to something like this:

``` c#
public IEnumerable<Person> GetAllPersonRecords()
{
   var connection = CreateConnection();
   var command = CreateCommand();
   var reader = command.ExecuteReader(CommandBehavior.CloseConnection);
   return DisposeAfterLoading<Person>(reader);
}

private IEnumerable<Item> DisposeAfterLoading<Item>(IDataReader reader)
{
   foreach (var item in Mapper.Map<IDataReader, IEnumerable<Item>>(reader))
      yield return item;

   reader.Dispose();
}

```

At any rate, I wanted to point this out as a potential issue so you can make the best decision about whether to merge the changes.  Either way, I will definitely be putting it to use for my projects, but it would be nice to not maintain my own version of AutoMapper.  /nudge  :)
