### PR TITLE
Mapping fails with null enum property

### DIFF
--- a/src/UnitTests/Enumerations.cs
+++ b/src/UnitTests/Enumerations.cs
@@ -141,6 +141,26 @@ namespace AutoMapper.Tests
 		}
 
 		[Test]
+		public void ShouldMapNullableEnumToNullWhenSourceEnumIsNullAndDestinationWasNotNull() 
+		{
+			Mapper.CreateMap<OrderWithNullableStatus, OrderDtoWithOwnNullableStatus>();
+
+			var dto = new OrderWithNullableStatus
+			{
+				Status = Status.Complete
+			};
+
+			var order = new OrderWithNullableStatus
+			{
+				Status = null
+			};
+
+			Mapper.Map(order, dto);
+
+			dto.Status.ShouldBeNull();
+		}
+
+		[Test]
 		public void ShouldMapNullableEnumToNullWhenSourceEnumIsNull() 
 		{
 			Mapper.CreateMap<OrderWithNullableStatus, OrderDtoWithOwnNullableStatus>();


### PR DESCRIPTION
If a destination object has a nullable enum property set to a value, then the source object, with a null property value, is mapped to the destination, the destination property is not set to null.
