### PR TITLE
Proposed new overloads to AssertConfigurationIsValid to solve issue #187

### DIFF
--- a/src/AutoMapper/IConfigurationProvider.cs
+++ b/src/AutoMapper/IConfigurationProvider.cs
@@ -19,9 +19,17 @@ namespace AutoMapper
 		TypeMap FindTypeMapFor(Type sourceType, Type destinationType);
 		TypeMap FindTypeMapFor(ResolutionResult resolutionResult, Type destinationType);
 		IFormatterConfiguration GetProfileConfiguration(string profileName);
+
+        [Obsolete]
 		void AssertConfigurationIsValid();
+        [Obsolete]
 		void AssertConfigurationIsValid(TypeMap typeMap);
-		void AssertConfigurationIsValid(string profileName);
+        [Obsolete]
+        void AssertConfigurationIsValid(string profileName);
+
+        void AssertConfigurationIsValid(bool onlyCheckPubliclySettableProperties);
+        void AssertConfigurationIsValid(bool onlyCheckPubliclySettableProperties, TypeMap typeMap);
+        void AssertConfigurationIsValid(bool onlyCheckPubliclySettableProperties, string profileName);
 		IObjectMapper[] GetMappers();
 		TypeMap CreateTypeMap(Type sourceType, Type destinationType);
 

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -186,20 +186,38 @@ namespace AutoMapper
 			return ConfigurationProvider.GetAllTypeMaps();
 		}
 
+        [Obsolete]
 		public static void AssertConfigurationIsValid()
 		{
 			ConfigurationProvider.AssertConfigurationIsValid();
 		}
 
+        [Obsolete]
 		public static void AssertConfigurationIsValid(TypeMap tm)
 		{
 			ConfigurationProvider.AssertConfigurationIsValid(tm);
 		}
 
+        [Obsolete]
 		public static void AssertConfigurationIsValid(string profileName)
 		{
 			ConfigurationProvider.AssertConfigurationIsValid(profileName);
-		}
+        }
+
+        public static void AssertConfigurationIsValid(bool onlyCheckPubliclySettableProperties)
+        {
+            ConfigurationProvider.AssertConfigurationIsValid(onlyCheckPubliclySettableProperties);
+        }
+
+        public static void AssertConfigurationIsValid(bool onlyCheckPubliclySettableProperties, TypeMap tm)
+        {
+            ConfigurationProvider.AssertConfigurationIsValid(onlyCheckPubliclySettableProperties, tm);
+        }
+
+        public static void AssertConfigurationIsValid(bool onlyCheckPubliclySettableProperties, string profileName)
+        {
+            ConfigurationProvider.AssertConfigurationIsValid(onlyCheckPubliclySettableProperties, profileName);
+        }
 
 		public static void Reset()
 		{

--- a/src/UnitTests/AutoMapperSpecBase.cs
+++ b/src/UnitTests/AutoMapperSpecBase.cs
@@ -11,7 +11,7 @@ namespace AutoMapper.UnitTests
         [Test]
         public void Should_have_valid_configuration()
         {
-            Mapper.AssertConfigurationIsValid();
+            Mapper.AssertConfigurationIsValid(false);
         }
     }
 

--- a/src/UnitTests/BidirectionalRelationships.cs
+++ b/src/UnitTests/BidirectionalRelationships.cs
@@ -22,7 +22,7 @@ namespace AutoMapper.UnitTests
                     .BeforeMap((src, dest) => _beforeMapCount++)
                     .AfterMap((src, dest) => _afterMapCount++);
                 Mapper.CreateMap<ChildModel, ChildDto>();
-                Mapper.AssertConfigurationIsValid();
+                Mapper.AssertConfigurationIsValid(false);
             }
 
             protected override void Because_of()
@@ -119,7 +119,7 @@ namespace AutoMapper.UnitTests
 					.ForMember(dest => dest.Children, opt => opt.MapFrom(src => src.ID));
 				Mapper.CreateMap<ChildModel, ChildDto>();
 
-				Mapper.AssertConfigurationIsValid();
+				Mapper.AssertConfigurationIsValid(false);
 			}
 
 			protected override void Because_of()
@@ -221,7 +221,7 @@ namespace AutoMapper.UnitTests
 					.ForMember(dest => dest.Children, opt => opt.MapFrom(src => src.ID));
 				Mapper.CreateMap<ChildModel, ChildDto>();
 
-				Mapper.AssertConfigurationIsValid();
+				Mapper.AssertConfigurationIsValid(false);
 			}
 
 			protected override void Because_of()
@@ -303,7 +303,7 @@ namespace AutoMapper.UnitTests
 			{
 				Mapper.CreateMap<Foo, FooDto>();
 				Mapper.CreateMap<Bar, BarDto>();
-				Mapper.AssertConfigurationIsValid();
+				Mapper.AssertConfigurationIsValid(false);
 			}
 
 			protected override void Because_of()
@@ -359,7 +359,7 @@ namespace AutoMapper.UnitTests
 				Mapper.CreateMap<FooModel, FooContainerModel>()
 					.ForMember(dest => dest.Input, opt => opt.MapFrom(src => src))
 					.ForMember(dest => dest.Screen, opt => opt.MapFrom(src => src));
-				Mapper.AssertConfigurationIsValid();
+				Mapper.AssertConfigurationIsValid(false);
 			}
 
 			protected override void Because_of()

--- a/src/UnitTests/Bug/AddingConfigurationForNonMatchingDestinationMemberBug.cs
+++ b/src/UnitTests/Bug/AddingConfigurationForNonMatchingDestinationMemberBug.cs
@@ -30,7 +30,7 @@ namespace AutoMapper.UnitTests.Bug
             [Test]
             public void Should_show_configuration_error()
             {
-                typeof (AutoMapperConfigurationException).ShouldBeThrownBy(Mapper.AssertConfigurationIsValid);
+                typeof (AutoMapperConfigurationException).ShouldBeThrownBy(() => Mapper.AssertConfigurationIsValid(false));
             }
         }
     }

--- a/src/UnitTests/Bug/AssignableCollectionBug.cs
+++ b/src/UnitTests/Bug/AssignableCollectionBug.cs
@@ -65,7 +65,7 @@ namespace AutoMapper.UnitTests.Bug
 				Mapper.CreateMap<PersonOne, PersonTwo>();
 				Mapper.CreateMap<AddressOne, AddressTwo>();
 				Mapper.CreateMap<AddressOne, IAddress>().ConvertUsing(Mapper.Map<AddressOne, AddressTwo>);
-				Mapper.AssertConfigurationIsValid();
+				Mapper.AssertConfigurationIsValid(false);
 				var result = Mapper.Map<PersonOne, PersonTwo>(source);
 
 				// These are ok.

--- a/src/UnitTests/Bug/CannotConvertEnumToNullable.cs
+++ b/src/UnitTests/Bug/CannotConvertEnumToNullable.cs
@@ -25,7 +25,7 @@ namespace AutoMapper.UnitTests.Bug
         public void Should_map_enum_to_nullable()
         {
             Mapper.CreateMap<DummySource, DummyDestination>();
-            Mapper.AssertConfigurationIsValid();
+            Mapper.AssertConfigurationIsValid(false);
             DummySource src = new DummySource() { Dummy = DummyTypes.Bar };
 
             var destination = Mapper.Map<DummySource, DummyDestination>(src);

--- a/src/UnitTests/Bug/CollectionMapperMapsISetIncorrectly.cs
+++ b/src/UnitTests/Bug/CollectionMapperMapsISetIncorrectly.cs
@@ -31,7 +31,7 @@ namespace AutoMapper.UnitTests.Bug
             config.CreateMap<SourceWithIEnumerable, TargetWithISet>()
                   .ForMember(dest => dest.Stuff, opt => opt.MapFrom(src => src.Stuff.Select(s => s.Value)));
 
-            config.AssertConfigurationIsValid();
+            config.AssertConfigurationIsValid(false);
 
             var engine = new MappingEngine(config);
 

--- a/src/UnitTests/Bug/CustomIEnumerableBug.cs
+++ b/src/UnitTests/Bug/CustomIEnumerableBug.cs
@@ -46,7 +46,7 @@ namespace AutoMapper.UnitTests.Bug
 
 			config.CreateMap<IEnumerable<string>, IEnumerable<Item>>().ConvertUsing<StringToItemConverter>();
 
-			config.AssertConfigurationIsValid();
+			config.AssertConfigurationIsValid(false);
 
 			var engine = new MappingEngine(config);
 			var one = new One

--- a/src/UnitTests/Bug/DeepInheritanceIssue.cs
+++ b/src/UnitTests/Bug/DeepInheritanceIssue.cs
@@ -31,7 +31,7 @@ namespace AutoMapper.UnitTests.Bug
             var actualContCDest = Mapper.Map<ContainsASrc, ContainsADest>(expectedContCSrc);
             var actualContBDest = Mapper.Map<ContainsASrc, ContainsADest>(expectedContBSrc); // THROWS
 
-            Mapper.AssertConfigurationIsValid();
+            Mapper.AssertConfigurationIsValid(false);
             Assert.IsNotNull(actualContBDest);
             Assert.IsNotNull(actualContCDest);
         }

--- a/src/UnitTests/Bug/DuplicateValuesBug.cs
+++ b/src/UnitTests/Bug/DuplicateValuesBug.cs
@@ -47,7 +47,7 @@ namespace AutoMapper.UnitTests.Bug
 				var destList = new List<DestObject>();
 
 				Mapper.CreateMap<SourceObject, DestObject>();
-				Mapper.AssertConfigurationIsValid();
+				Mapper.AssertConfigurationIsValid(false);
 
 				var source1 = new SourceObject
 				{

--- a/src/UnitTests/Bug/IgnoreAll.cs
+++ b/src/UnitTests/Bug/IgnoreAll.cs
@@ -29,7 +29,7 @@ namespace AutoMapper.UnitTests.Bug
         {
             Mapper.CreateMap<ModelObjectNotMatching, ModelDto>()
                 .ForAllMembers(opt => opt.Ignore());
-            Mapper.AssertConfigurationIsValid();
+            Mapper.AssertConfigurationIsValid(false);
         }
     }
 }

--- a/src/UnitTests/Bug/InheritanceIssue.cs
+++ b/src/UnitTests/Bug/InheritanceIssue.cs
@@ -176,7 +176,7 @@ namespace AutoMapper.UnitTests.Bug
                 Mapper.CreateMap<Health, HealthDTO>();
                 Mapper.CreateMap<PhysicalLocation, PhysicalLocationDTO>();
 
-                Mapper.AssertConfigurationIsValid();
+                Mapper.AssertConfigurationIsValid(false);
 
                 EntityDTO targetEntity = Mapper.Map<Entity, EntityDTO>(entity);
 

--- a/src/UnitTests/Bug/MultipleTypeConverterInterfaces.cs
+++ b/src/UnitTests/Bug/MultipleTypeConverterInterfaces.cs
@@ -70,7 +70,7 @@ namespace AutoMapper.UnitTests.Bug
 			[Test]
 			public void Should_pass_configuration_validation()
 			{
-				Mapper.AssertConfigurationIsValid();
+				Mapper.AssertConfigurationIsValid(false);
 			}
 		}
 }

--- a/src/UnitTests/ConfigurationValidation.cs
+++ b/src/UnitTests/ConfigurationValidation.cs
@@ -67,7 +67,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_fail_a_configuration_check()
             {
-                typeof(AutoMapperConfigurationException).ShouldBeThrownBy(Mapper.AssertConfigurationIsValid);
+                typeof(AutoMapperConfigurationException).ShouldBeThrownBy(() => Mapper.AssertConfigurationIsValid(false));
             }
         }
 
@@ -95,7 +95,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_pass_an_inspection_of_missing_mappings()
             {
-                Mapper.AssertConfigurationIsValid();
+                Mapper.AssertConfigurationIsValid(false);
             }
         }
 
@@ -119,7 +119,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_fail_a_configuration_check()
             {
-                typeof(AutoMapperConfigurationException).ShouldBeThrownBy(Mapper.AssertConfigurationIsValid);
+                typeof(AutoMapperConfigurationException).ShouldBeThrownBy(() => Mapper.AssertConfigurationIsValid(false));
             }
         }
 
@@ -159,7 +159,7 @@ namespace AutoMapper.UnitTests
             {
                 try
                 {
-                    Mapper.AssertConfigurationIsValid();
+                    Mapper.AssertConfigurationIsValid(false);
                 }
                 catch (AutoMapperConfigurationException ex)
                 {
@@ -200,7 +200,7 @@ namespace AutoMapper.UnitTests
             {
                 try
                 {
-                    Mapper.AssertConfigurationIsValid();
+                    Mapper.AssertConfigurationIsValid(false);
                 }
                 catch (AutoMapperConfigurationException ex)
                 {
@@ -245,7 +245,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_fail_a_configuration_check()
             {
-                typeof(AutoMapperConfigurationException).ShouldBeThrownBy(Mapper.AssertConfigurationIsValid);
+                typeof(AutoMapperConfigurationException).ShouldBeThrownBy(() => Mapper.AssertConfigurationIsValid(false));
             }
         }
 
@@ -279,7 +279,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_fail_a_configuration_check()
             {
-                typeof(AutoMapperConfigurationException).ShouldBeThrownBy(Mapper.AssertConfigurationIsValid);
+                typeof(AutoMapperConfigurationException).ShouldBeThrownBy(() => Mapper.AssertConfigurationIsValid(false));
             }
         }
 
@@ -310,7 +310,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_be_valid()
             {
-                typeof(AutoMapperConfigurationException).ShouldNotBeThrownBy(Mapper.AssertConfigurationIsValid);
+                typeof(AutoMapperConfigurationException).ShouldNotBeThrownBy(() => Mapper.AssertConfigurationIsValid(false));
             }
         }
 
@@ -349,7 +349,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_ignore_bad_dtos_in_other_profiles()
             {
-                typeof(AutoMapperConfigurationException).ShouldNotBeThrownBy(() => Mapper.AssertConfigurationIsValid("Good"));
+                typeof(AutoMapperConfigurationException).ShouldNotBeThrownBy(() => Mapper.AssertConfigurationIsValid(false, "Good"));
             }
         }
 
@@ -380,7 +380,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_fail_a_configuration_check()
             {
-                typeof(AutoMapperConfigurationException).ShouldBeThrownBy(Mapper.AssertConfigurationIsValid);
+                typeof(AutoMapperConfigurationException).ShouldBeThrownBy(() => Mapper.AssertConfigurationIsValid(false));
             }
         }
 
@@ -405,7 +405,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_validate_successfully()
             {
-                typeof(AutoMapperConfigurationException).ShouldNotBeThrownBy(Mapper.AssertConfigurationIsValid);
+                typeof(AutoMapperConfigurationException).ShouldNotBeThrownBy(() => Mapper.AssertConfigurationIsValid(false));
             }
         }
 		
@@ -429,7 +429,7 @@ namespace AutoMapper.UnitTests
 			[Test]
 			public void Should_fail_a_configuration_check()
 			{
-				typeof(AutoMapperConfigurationException).ShouldBeThrownBy(Mapper.AssertConfigurationIsValid);
+				typeof(AutoMapperConfigurationException).ShouldBeThrownBy(() => Mapper.AssertConfigurationIsValid(false));
 			}
 		}
 
@@ -455,9 +455,40 @@ namespace AutoMapper.UnitTests
 			[Test]
 			public void Should_fail_a_configuration_check()
 			{
-				typeof(AutoMapperConfigurationException).ShouldBeThrownBy(Mapper.AssertConfigurationIsValid);
+				typeof(AutoMapperConfigurationException).ShouldBeThrownBy(() => Mapper.AssertConfigurationIsValid(false));
 			}
 		}
+
+        public class When_testing_a_dto_with_non_publicly_settable_properties : NonValidatingSpecBase
+        {
+            public class Source
+            {
+                public int Id { get; set; }
+            }
+
+            public class Destination
+            {
+                public int Id { get; set; }
+                public string Name { get; protected set; }
+                public int Age { get; private set; }
+            }
+
+            protected override void Establish_context()
+            {
+                Mapper.CreateMap<Source, Destination>();
+            }
+
+            protected override void Because_of()
+            {
+                Mapper.Map<Source, Destination>(new Source { Id = 5 });
+            }
+
+            [Test]
+            public void Should_be_valid()
+            {
+                typeof(AutoMapperConfigurationException).ShouldNotBeThrownBy(() => Mapper.AssertConfigurationIsValid(true));
+            }
+        }
     }
 
 }

--- a/src/UnitTests/CustomMapping.cs
+++ b/src/UnitTests/CustomMapping.cs
@@ -599,7 +599,7 @@ namespace AutoMapper.UnitTests
 				Exception thrown = null;
 				try
 				{
-					Mapper.AssertConfigurationIsValid();
+					Mapper.AssertConfigurationIsValid(false);
 
 				}
 				catch (Exception ex)

--- a/src/UnitTests/IgnoreAllTests.cs
+++ b/src/UnitTests/IgnoreAllTests.cs
@@ -31,7 +31,7 @@ namespace AutoMapper.UnitTests
 			});
             
             Mapper.Map<Source, Destination>(new Source{ShouldBeMapped = "true"});
-            Mapper.AssertConfigurationIsValid();
+            Mapper.AssertConfigurationIsValid(false);
         }
 
         [Test]
@@ -85,7 +85,7 @@ namespace AutoMapper.UnitTests
 		public void Ignore_On_Source_Field()
 		{
 			Mapper.CreateMap<Source, Destination>();
-			Mapper.AssertConfigurationIsValid();
+			Mapper.AssertConfigurationIsValid(false);
 
 			Source source = new Source
 			{

--- a/src/UnitTests/Indexers.cs
+++ b/src/UnitTests/Indexers.cs
@@ -43,7 +43,7 @@ namespace AutoMapper.UnitTests
 				Exception thrown = null;
 				try
 				{
-					Mapper.AssertConfigurationIsValid();
+					Mapper.AssertConfigurationIsValid(false);
 				}
 				catch (Exception ex)
 				{

--- a/src/UnitTests/InterfaceMapping.cs
+++ b/src/UnitTests/InterfaceMapping.cs
@@ -58,7 +58,7 @@ namespace AutoMapper.UnitTests
 
                 Mapper.CreateMap<SubChildModelObject, SubDtoChildObject>();
 
-                Mapper.AssertConfigurationIsValid();
+                Mapper.AssertConfigurationIsValid(false);
 
                 _result = Mapper.Map<ModelObject, DtoObject>(model);
             }
@@ -243,7 +243,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_pass_configuration_testing()
             {
-                Mapper.AssertConfigurationIsValid();
+                Mapper.AssertConfigurationIsValid(false);
             }
         }
 
@@ -313,7 +313,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_pass_configuration_testing()
             {
-                Mapper.AssertConfigurationIsValid();
+                Mapper.AssertConfigurationIsValid(false);
             }
         }
 
@@ -356,7 +356,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_ignore_interface_members_for_validation()
             {
-                Mapper.AssertConfigurationIsValid();
+                Mapper.AssertConfigurationIsValid(false);
             }
         }
 

--- a/src/UnitTests/MappingInheritance/IgnoreShouldBeInheritedIfConventionCannotMap.cs
+++ b/src/UnitTests/MappingInheritance/IgnoreShouldBeInheritedIfConventionCannotMap.cs
@@ -48,7 +48,7 @@ namespace AutoMapper.UnitTests.Bug
 
             Mapper.CreateMap<MoreSpecificDomain, Dto>();
 
-            Mapper.AssertConfigurationIsValid();
+            Mapper.AssertConfigurationIsValid(false);
         }
     }
 }

--- a/src/UnitTests/MappingInheritance/IncludedMappingShouldInheritBaseMappings.cs
+++ b/src/UnitTests/MappingInheritance/IncludedMappingShouldInheritBaseMappings.cs
@@ -44,7 +44,7 @@ namespace AutoMapper.UnitTests.Bug
                 .Include<ModelSubObject, DtoSubObject>();
             Mapper.CreateMap<ModelSubObject, DtoSubObject>();
 
-            Mapper.AssertConfigurationIsValid();
+            Mapper.AssertConfigurationIsValid(false);
         }
 
         [Test]
@@ -55,7 +55,7 @@ namespace AutoMapper.UnitTests.Bug
                 .Include<ModelSubObject, DtoSubObject>();
             Mapper.CreateMap<ModelSubObject, DtoSubObject>();
 
-            Mapper.AssertConfigurationIsValid();
+            Mapper.AssertConfigurationIsValid(false);
         }
 
         [Test]
@@ -67,7 +67,7 @@ namespace AutoMapper.UnitTests.Bug
             Mapper.CreateMap<ModelSubObject, DtoSubObject>()
                 .ForMember(d=>d.BaseString, m=>m.MapFrom(s=>s.DifferentBaseString));
 
-            Mapper.AssertConfigurationIsValid();
+            Mapper.AssertConfigurationIsValid(false);
         }
 
         [Test]
@@ -117,7 +117,7 @@ namespace AutoMapper.UnitTests.Bug
             Mapper.CreateMap<ModelSubObject, DtoSubObject>()
                 .ForMember(d => d.BaseString, m => m.UseValue("789"));
 
-            Mapper.AssertConfigurationIsValid();
+            Mapper.AssertConfigurationIsValid(false);
         }
         [Test]
         public void more_specific_map_should_override_base_mapping_with_one_parameter()
@@ -202,7 +202,7 @@ namespace AutoMapper.UnitTests.Bug
 
             Mapper.CreateMap<ModelSubObject, OtherDto>();
 
-            Mapper.AssertConfigurationIsValid();
+            Mapper.AssertConfigurationIsValid(false);
         }
         [Test]
         public void include_should_allow_automapper_to_select_more_specific_included_type_with_one_parameter()

--- a/src/UnitTests/MappingInheritance/InheritedIgnoreShouldBeOverridenByConventionMapping.cs
+++ b/src/UnitTests/MappingInheritance/InheritedIgnoreShouldBeOverridenByConventionMapping.cs
@@ -29,7 +29,7 @@ namespace AutoMapper.UnitTests.Bug
 
             Mapper.CreateMap<SpecificDomain, Dto>();
 
-            Mapper.AssertConfigurationIsValid();
+            Mapper.AssertConfigurationIsValid(false);
         }
 
         [Test]

--- a/src/UnitTests/MappingInheritance/MultipleInheritedBaseMappingsOfSameTypeFails.cs
+++ b/src/UnitTests/MappingInheritance/MultipleInheritedBaseMappingsOfSameTypeFails.cs
@@ -34,7 +34,7 @@ namespace AutoMapper.UnitTests.Bug
 
             Mapper.CreateMap<InformationClass, InformationDto>();
 
-            Mapper.AssertConfigurationIsValid();
+            Mapper.AssertConfigurationIsValid(false);
         }
     }
 }

--- a/src/UnitTests/MappingInheritance/PropertyOnMappingShouldResolveMostSpecificType.cs
+++ b/src/UnitTests/MappingInheritance/PropertyOnMappingShouldResolveMostSpecificType.cs
@@ -152,7 +152,7 @@ namespace AutoMapper.UnitTests.Bug
             Mapper.CreateMap<DifferentItem, DifferentDescriptionDto>();
             Mapper.CreateMap<DifferentItem2, DifferentDescriptionDto2>();
 
-            Mapper.AssertConfigurationIsValid();
+            Mapper.AssertConfigurationIsValid(false);
 
             var dto = Mapper.Map<ItemBase, ItemDto>(new DifferentItem());
 
@@ -181,7 +181,7 @@ namespace AutoMapper.UnitTests.Bug
             Mapper.CreateMap<DifferentItem, DifferentDescriptionDto>();
             Mapper.CreateMap<DifferentItem2, DifferentDescriptionDto2>();
 
-            Mapper.AssertConfigurationIsValid();
+            Mapper.AssertConfigurationIsValid(false);
 
             var dto = Mapper.Map<ItemDto>(new DifferentItem());
 

--- a/src/UnitTests/MemberResolution.cs
+++ b/src/UnitTests/MemberResolution.cs
@@ -564,7 +564,7 @@ namespace AutoMapper.UnitTests
 			[Test]
 			public void Should_succeed_configration_check()
 			{
-				Mapper.AssertConfigurationIsValid();
+				Mapper.AssertConfigurationIsValid(false);
 			}
 
 			protected override void Establish_context()
@@ -1126,7 +1126,7 @@ namespace AutoMapper.UnitTests
 			[Test]
 			public void Should_pass_configuration_check()
 			{
-				Mapper.AssertConfigurationIsValid();
+				Mapper.AssertConfigurationIsValid(false);
 			}
 		}
 
@@ -1179,7 +1179,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_pass_configuration_check()
             {
-                Mapper.AssertConfigurationIsValid();
+                Mapper.AssertConfigurationIsValid(false);
             }
 
             [Test]

--- a/src/UnitTests/Regression.cs
+++ b/src/UnitTests/Regression.cs
@@ -45,7 +45,7 @@ namespace AutoMapper.UnitTests
 				Mapper.CreateMap<ITestDomainItem, TestDtoItem>()
 					.ForMember(d => d.Id, s => s.MapFrom(x => x.ItemId));
 
-				Mapper.AssertConfigurationIsValid();
+				Mapper.AssertConfigurationIsValid(false);
 
 				var dtos = Mapper.Map<IEnumerable<ITestDomainItem>, TestDtoItem[]>(domainItems);
 

--- a/src/UnitTests/ReverseMapping.cs
+++ b/src/UnitTests/ReverseMapping.cs
@@ -75,7 +75,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_not_throw_any_configuration_validation_errors()
             {
-                typeof(AutoMapperConfigurationException).ShouldNotBeThrownBy(Mapper.AssertConfigurationIsValid);
+                typeof(AutoMapperConfigurationException).ShouldNotBeThrownBy(() => Mapper.AssertConfigurationIsValid(false));
             }
         }
 
@@ -102,7 +102,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_throw_a_configuration_validation_error()
             {
-                typeof(AutoMapperConfigurationException).ShouldBeThrownBy(Mapper.AssertConfigurationIsValid);
+                typeof(AutoMapperConfigurationException).ShouldBeThrownBy(() => Mapper.AssertConfigurationIsValid(false));
             }
         }
 
@@ -131,7 +131,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_not_throw_a_configuration_validation_error()
             {
-                typeof(AutoMapperConfigurationException).ShouldNotBeThrownBy(Mapper.AssertConfigurationIsValid);
+                typeof(AutoMapperConfigurationException).ShouldNotBeThrownBy(() => Mapper.AssertConfigurationIsValid(false));
             }
         }
 
@@ -161,7 +161,7 @@ namespace AutoMapper.UnitTests
             [Test]
             public void Should_not_throw_a_configuration_validation_error()
             {
-                typeof(AutoMapperConfigurationException).ShouldNotBeThrownBy(Mapper.AssertConfigurationIsValid);
+                typeof(AutoMapperConfigurationException).ShouldNotBeThrownBy(() => Mapper.AssertConfigurationIsValid(false));
             }
         }
 

--- a/src/UnitTests/TypeConverters.cs
+++ b/src/UnitTests/TypeConverters.cs
@@ -230,7 +230,7 @@ namespace AutoMapper.UnitTests
 			[Test]
 			public void Should_pass_configuration_validation()
 			{
-				Mapper.AssertConfigurationIsValid();
+				Mapper.AssertConfigurationIsValid(false);
 			}
 		}
 
@@ -278,7 +278,7 @@ namespace AutoMapper.UnitTests
 			[Test]
 			public void Should_pass_configuration_validation()
 			{
-				Mapper.AssertConfigurationIsValid();
+				Mapper.AssertConfigurationIsValid(false);
 			}
 		}
 


### PR DESCRIPTION
- This commit resolves the following issue:
  https://github.com/AutoMapper/AutoMapper/issues/187
- Added new overloads of AssertConfigurationIsValid with parameter `bool onlyCheckPubliclySettableProperties`. This parameter allows
  properties with private or protected setters to be bypassed during
  validation.
- Maintained the original overloads but marked them obsolete.
- Updated all unit tests to use the new overloads.
- Added the following unit test:
  When_testing_a_dto_with_non_publicly_settable_properties
- All tests pass.
