### PR TITLE
Added name mappings support

### DIFF
--- a/src/AutoMapper/IConfigurationProvider.cs
+++ b/src/AutoMapper/IConfigurationProvider.cs
@@ -16,9 +16,11 @@ namespace AutoMapper
 	{
 		TypeMap[] GetAllTypeMaps();
 		TypeMap FindTypeMapFor(object source, Type sourceType, Type destinationType);
-		TypeMap FindTypeMapFor(Type sourceType, Type destinationType);
+        TypeMap FindTypeMapFor(object source, Type sourceType, Type destinationType, string profileName);
+        TypeMap FindTypeMapFor(Type sourceType, Type destinationType);
 		TypeMap FindTypeMapFor(ResolutionResult resolutionResult, Type destinationType);
-		IFormatterConfiguration GetProfileConfiguration(string profileName);
+        TypeMap FindTypeMapFor(ResolutionResult resolutionResult, Type destinationType, string profileName);
+        IFormatterConfiguration GetProfileConfiguration(string profileName);
 		void AssertConfigurationIsValid();
 		void AssertConfigurationIsValid(TypeMap typeMap);
 		void AssertConfigurationIsValid(string profileName);

--- a/src/AutoMapper/IFormatterExpression.cs
+++ b/src/AutoMapper/IFormatterExpression.cs
@@ -29,6 +29,7 @@ namespace AutoMapper
 	public interface IProfileExpression : IFormatterExpression, IMappingOptions
 	{
 		IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>();
+        IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>(string profileName);
         IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>(MemberList source);
         IMappingExpression CreateMap(Type sourceType, Type destinationType);
         IMappingExpression CreateMap(Type sourceType, Type destinationType, MemberList source);

--- a/src/AutoMapper/IMappingEngine.cs
+++ b/src/AutoMapper/IMappingEngine.cs
@@ -8,6 +8,7 @@ namespace AutoMapper
         TDestination Map<TDestination>(object source);
         TDestination Map<TDestination>(object source, Action<IMappingOperationOptions> opts);
         TDestination Map<TSource, TDestination>(TSource source);
+        TDestination Map<TSource, TDestination>(TSource source, string profileName);
         TDestination Map<TSource, TDestination>(TSource source, Action<IMappingOperationOptions> opts);
         TDestination Map<TSource, TDestination>(TSource source, TDestination destination);
         TDestination Map<TSource, TDestination>(TSource source, TDestination destination, Action<IMappingOperationOptions> opts);

--- a/src/AutoMapper/Internal/TypePair.cs
+++ b/src/AutoMapper/Internal/TypePair.cs
@@ -10,11 +10,19 @@ namespace AutoMapper.Impl
         {
             _sourceType = sourceType;
             _destinationType = destinationType;
+            _profileName = string.Empty;
             _hashcode = unchecked((_sourceType.GetHashCode() * 397) ^ _destinationType.GetHashCode());
+        }
+
+        public TypePair(Type sourceType, Type destinationType, string profileName)
+            : this(sourceType, destinationType)
+        {
+            _profileName = profileName;
         }
 
         private readonly Type _destinationType;
         private readonly int _hashcode;
+        private readonly string _profileName;
         private readonly Type _sourceType;
 
         public Type SourceType
@@ -29,7 +37,7 @@ namespace AutoMapper.Impl
 
         public bool Equals(TypePair other)
         {
-            return Equals(other._sourceType, _sourceType) && Equals(other._destinationType, _destinationType);
+            return Equals(other._sourceType, _sourceType) && Equals(other._destinationType, _destinationType) && Equals(other._profileName, _profileName);
         }
 
         public override bool Equals(object obj)

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -42,6 +42,11 @@ namespace AutoMapper
 			return Engine.Map(source, destination);
 		}
 
+        public static TDestination Map<TSource, TDestination>(TSource source, string profileName)
+        {
+            return Engine.Map<TSource, TDestination>(source, profileName);
+        }
+
         public static TDestination Map<TSource, TDestination>(TSource source, TDestination destination, Action<IMappingOperationOptions> opts)
         {
             return Engine.Map(source, destination, opts);
@@ -145,6 +150,11 @@ namespace AutoMapper
 		{
 			return Configuration.CreateMap<TSource, TDestination>();
 		}
+
+        public static IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>(string profileName)
+        {
+            return Configuration.CreateMap<TSource, TDestination>(profileName);
+        }
 
 		public static IMappingExpression CreateMap(Type sourceType, Type destinationType)
 		{

--- a/src/AutoMapper/MappingEngine.cs
+++ b/src/AutoMapper/MappingEngine.cs
@@ -80,7 +80,15 @@ namespace AutoMapper
 			return (TDestination)Map(source, modelType, destinationType, opts => {});
 		}
 
-        public TDestination Map<TSource, TDestination>(TSource source, Action<IMappingOperationOptions> opts)
+	    public TDestination Map<TSource, TDestination>(TSource source, string profileName)
+	    {
+            Type modelType = typeof(TSource);
+            Type destinationType = typeof(TDestination);
+
+            return (TDestination)Map(source, modelType, destinationType, profileName);
+        }
+
+	    public TDestination Map<TSource, TDestination>(TSource source, Action<IMappingOperationOptions> opts)
         {
             Type modelType = typeof (TSource);
             Type destinationType = typeof (TDestination);
@@ -204,6 +212,15 @@ namespace AutoMapper
             TypeMap typeMap = ConfigurationProvider.FindTypeMapFor(source, sourceType, destinationType);
             var context = parentContext.CreateTypeContext(typeMap, source, sourceType, destinationType);
             return (TDestination)((IMappingEngineRunner)this).Map(context);
+        }
+
+        public object Map(object source, Type sourceType, Type destinationType, string profileName)
+        {
+            TypeMap typeMap = ConfigurationProvider.FindTypeMapFor(source, sourceType, destinationType, profileName);
+
+            var context = new ResolutionContext(typeMap, source, sourceType, destinationType, new MappingOperationOptions());
+
+            return ((IMappingEngineRunner)this).Map(context);
         }
 
         private LambdaExpression CreateMapExpression(
@@ -439,7 +456,7 @@ namespace AutoMapper
 		{
 		    IObjectMapper existing;
 
-		    _objectMapperCache.TryRemove(new TypePair(e.TypeMap.SourceType, e.TypeMap.DestinationType), out existing);
+		    _objectMapperCache.TryRemove(new TypePair(e.TypeMap.SourceType, e.TypeMap.DestinationType, e.TypeMap.Profile), out existing);
 		}
 
         /// <summary>

--- a/src/AutoMapper/Profile.cs
+++ b/src/AutoMapper/Profile.cs
@@ -115,7 +115,12 @@ namespace AutoMapper
 		    return CreateMap<TSource, TDestination>(MemberList.Destination);
 		}
 
-		public IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>(MemberList memberList)
+	    public IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>(string profileName)
+	    {
+	        return CreateMap<TSource, TDestination>(profileName);
+	    }
+
+	    public IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>(MemberList memberList)
 		{
 			var map = _configurator.CreateMap<TSource, TDestination>(ProfileName, memberList);
 

--- a/src/UnitTests/NamedMappings.cs
+++ b/src/UnitTests/NamedMappings.cs
@@ -1,0 +1,59 @@
+﻿using Should;
+using NUnit.Framework;
+
+namespace AutoMapper.UnitTests
+{
+    namespace NamedMappings
+    {
+        public class When_configuring_multiple_mappings_with_same_type_to_type_mapping_using_a_mapping_name : AutoMapperSpecBase
+        {
+            private Destination _result;
+            private Destination _result2;
+            
+            public class Source
+            {
+                public int Value { get; set; }
+                public int Value2 { get; set; }
+            }
+
+            public class Destination
+            {
+                public int Value { get; set; }
+                public int Value2 { get; set; }
+            }
+
+            protected override void Establish_context()
+            {
+                Mapper.Initialize(cfg =>
+                {
+                    // Create default mapping
+                    cfg.CreateMap<Source, Destination>();
+
+                    // Create named mapping ignoring property Value2
+                    cfg.CreateMap<Source, Destination>("namedMapping")
+                        .ForMember(dest => dest.Value2, opt => opt.Ignore());
+                });
+            }
+
+            protected override void Because_of()
+            {
+                _result = Mapper.Map<Source, Destination>(new Source { Value = 5, Value2 = 3 });
+                _result2 = Mapper.Map<Source, Destination>(new Source { Value = 5, Value2 = 3 }, "namedMapping");
+            }
+
+            [Test]
+            public void Should_use_default_mapping()
+            {
+                _result.Value.ShouldEqual(5);
+                _result.Value2.ShouldEqual(3);
+            }
+
+            [Test]
+            public void Should_use_named_mapping()
+            {
+                _result2.Value.ShouldEqual(5);
+                _result2.Value2.ShouldEqual(default(int));
+            }
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -173,6 +173,7 @@
     <Compile Include="MappingOrder.cs" />
     <Compile Include="MaxDepthTests.cs" />
     <Compile Include="MemberResolution.cs" />
+    <Compile Include="NamedMappings.cs" />
     <Compile Include="NestedContainers.cs" />
     <Compile Include="NullBehavior.cs" />
     <Compile Include="Profiles.cs" />


### PR DESCRIPTION
Resolves issue #277

This extension allows:
Mapper.CreateMap<Source, Destination>("mapping1")...;
Mapper.CreateMap<Source, Destination>("mapping2")...;

and resolve them:
Mapper.Map<Source, Destination>("mapping1");