### PR TITLE
Improvements to ReadOnlyCollection support.

### DIFF
--- a/src/AutoMapper/AutoMapper.csproj
+++ b/src/AutoMapper/AutoMapper.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AutoMapper</RootNamespace>
     <AssemblyName>AutoMapper</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>AutoMapper.snk</AssemblyOriginatorKeyFile>
@@ -33,7 +33,8 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/AutoMapper/Mappers/ReadOnlyCollectionMapper.cs
+++ b/src/AutoMapper/Mappers/ReadOnlyCollectionMapper.cs
@@ -16,16 +16,23 @@ namespace AutoMapper.Mappers
 
             var objectMapper = (IObjectMapper)Activator.CreateInstance(enumerableMapper);
 
-            return objectMapper.Map(context, mapper);
+            var nullDestinationValueSoTheReadOnlyCollectionMapperWorks = context.CreateMemberContext(context.TypeMap, context.SourceValue, null, context.SourceType, context.PropertyMap);
+
+            return objectMapper.Map(nullDestinationValueSoTheReadOnlyCollectionMapperWorks, mapper);
         }
 
         public bool IsMatch(ResolutionContext context)
         {
-            var isMatch = context.SourceType.IsEnumerableType() &&
-                          context.DestinationType.IsGenericType &&
-                          context.DestinationType.GetGenericTypeDefinition() == typeof (ReadOnlyCollection<>);
+			  if(!(context.SourceType.IsEnumerableType() && context.DestinationType.IsGenericType))
+              return false;
 
-            return isMatch;
+			  var genericType= context.DestinationType.GetGenericTypeDefinition();
+			  if (genericType == typeof(ReadOnlyCollection<>) ||
+				  genericType == typeof(IReadOnlyList<>) ||
+				  genericType == typeof(IReadOnlyCollection<>))
+				  return true;
+
+			  return false;
         }
 
         #region Nested type: EnumerableMapper

--- a/src/AutoMapperSamples/AutoMapperSamples.csproj
+++ b/src/AutoMapperSamples/AutoMapperSamples.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AutoMapperSamples</RootNamespace>
     <AssemblyName>AutoMapperSamples</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>

--- a/src/Benchmark/Benchmark.csproj
+++ b/src/Benchmark/Benchmark.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Benchmark</RootNamespace>
     <AssemblyName>Benchmark</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\AutoMapper.snk</AssemblyOriginatorKeyFile>

--- a/src/Benchmark/app.config
+++ b/src/Benchmark/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/src/UnitTests/App.config
+++ b/src/UnitTests/App.config
@@ -8,4 +8,4 @@
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/src/UnitTests/Mappers/ReadOnlyCollectionMapperTests.cs
+++ b/src/UnitTests/Mappers/ReadOnlyCollectionMapperTests.cs
@@ -1,0 +1,181 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace AutoMapper.UnitTests.Mappers
+{
+	[TestFixture]
+	public class ReadOnlyCollectionMapperTests
+	{
+		SourceAsEnumerable _sourceAsEnumerable;
+		[SetUp]
+		public void SetUp()
+		{
+			_sourceAsEnumerable = new SourceAsEnumerable()
+			{
+				ValueInt = new List<int>() { 1, 2, 3 },
+				ValueString = new List<string>() { "a", "b", "c" },
+				ValueIUser = new List<IUser>() { new UserSource("z", 21) },
+				ValueUser = new List<UserSource>() { new UserSource("y", 20), new UserSource("x", 19) },
+			};
+			Mapper.CreateMap<SourceAsEnumerable, DestinationAsReadOnlyCollectionNull>();
+			Mapper.CreateMap<SourceAsEnumerable, DestinationAsReadOnlyCollectionNotNull>();
+			Mapper.CreateMap<UserSource, UserDestination>();
+		}
+
+		[Test]
+		public void should_map_to_ReadOnlyCollection_when_destination_properties_are_null()
+		{
+			var destination = Mapper.Map<SourceAsEnumerable, DestinationAsReadOnlyCollectionNull>(_sourceAsEnumerable);
+
+			Assert.IsNotNull(destination);
+			Assert.AreNotEqual(0, _sourceAsEnumerable.ValueInt);
+			Assert.AreEqual(_sourceAsEnumerable.ValueInt.Count(), destination.ValueInt.Count());
+			foreach (var item in _sourceAsEnumerable.ValueInt)
+			{
+				Assert.IsTrue(destination.ValueInt.Contains(item));
+			}
+
+			Assert.AreNotEqual(0, _sourceAsEnumerable.ValueString);
+			Assert.AreEqual(_sourceAsEnumerable.ValueString.Count(), destination.ValueString.Count());
+			foreach (var item in _sourceAsEnumerable.ValueString)
+			{
+				Assert.IsTrue(destination.ValueString.Contains(item));
+			}
+
+			Assert.AreNotEqual(0, _sourceAsEnumerable.ValueUser);
+			Assert.AreEqual(_sourceAsEnumerable.ValueUser.Count(), destination.ValueUser.Count());
+			for (int i = 0; i < _sourceAsEnumerable.ValueUser.Count(); i++)
+			{
+				Assert.AreEqual(_sourceAsEnumerable.ValueUser.ElementAt(i).Name, destination.ValueUser.ElementAt(i).Name);
+			}
+
+			Assert.AreNotEqual(0, _sourceAsEnumerable.ValueIUser);
+			Assert.AreEqual(_sourceAsEnumerable.ValueIUser.Count(), destination.ValueIUser.Count());
+			for (int i = 0; i < _sourceAsEnumerable.ValueIUser.Count(); i++)
+			{
+				Assert.AreEqual(_sourceAsEnumerable.ValueIUser.ElementAt(i).Name, destination.ValueIUser.ElementAt(i).Name);
+				Assert.AreEqual(_sourceAsEnumerable.ValueIUser.ElementAt(i).Age, destination.ValueIUser.ElementAt(i).Age);
+			}
+
+		}
+
+		[Test]
+		public void should_replace_ReadOnlyCollection_when_destination_properties_are_not_null()
+		{
+			var destination = Mapper.Map<SourceAsEnumerable, DestinationAsReadOnlyCollectionNotNull>(_sourceAsEnumerable);
+
+			Assert.IsNotNull(destination);
+			Assert.AreNotEqual(0, _sourceAsEnumerable.ValueInt);
+			Assert.AreEqual(_sourceAsEnumerable.ValueInt.Count(), destination.ValueInt.Count());
+			foreach (var item in _sourceAsEnumerable.ValueInt)
+			{
+				Assert.IsTrue(destination.ValueInt.Contains(item));
+			}
+
+			Assert.AreNotEqual(0, _sourceAsEnumerable.ValueString);
+			Assert.AreEqual(_sourceAsEnumerable.ValueString.Count(), destination.ValueString.Count());
+			foreach (var item in _sourceAsEnumerable.ValueString)
+			{
+				Assert.IsTrue(destination.ValueString.Contains(item));
+			}
+
+			Assert.AreNotEqual(0, _sourceAsEnumerable.ValueUser);
+			Assert.AreEqual(_sourceAsEnumerable.ValueUser.Count(), destination.ValueUser.Count());
+			for (int i = 0; i < _sourceAsEnumerable.ValueUser.Count(); i++)
+			{
+				Assert.AreEqual(_sourceAsEnumerable.ValueUser.ElementAt(i).Name, destination.ValueUser.ElementAt(i).Name);
+			}
+
+			Assert.AreNotEqual(0, _sourceAsEnumerable.ValueIUser);
+			Assert.AreEqual(_sourceAsEnumerable.ValueIUser.Count(), destination.ValueIUser.Count());
+			for (int i = 0; i < _sourceAsEnumerable.ValueIUser.Count(); i++)
+			{
+				Assert.AreEqual(_sourceAsEnumerable.ValueIUser.ElementAt(i).Name, destination.ValueIUser.ElementAt(i).Name);
+				Assert.AreEqual(_sourceAsEnumerable.ValueIUser.ElementAt(i).Age, destination.ValueIUser.ElementAt(i).Age);
+			}
+		}
+
+		[Test]
+		public void should_set_ReadOnlyCollection_underlying_all_IReadOnlyList()
+		{
+			var destination = Mapper.Map<SourceAsEnumerable, DestinationAsReadOnlyCollectionNull>(_sourceAsEnumerable);
+
+			Assert.IsNotNull(destination);
+			Assert.IsInstanceOfType(typeof(ReadOnlyCollection<IUser>), destination.ValueIUser);
+		}
+
+		[Test]
+		public void should_set_ReadOnlyCollection_underlying_all_IReadOnlyCollection()
+		{
+			var destination = Mapper.Map<SourceAsEnumerable, DestinationAsReadOnlyCollectionNull>(_sourceAsEnumerable);
+
+			Assert.IsNotNull(destination);
+			Assert.IsInstanceOfType(typeof(ReadOnlyCollection<UserDestination>), destination.ValueUser);
+		}
+
+
+		private class SourceAsEnumerable
+		{
+			public IEnumerable<int> ValueInt { get; set; }
+			public IEnumerable<string> ValueString { get; set; }
+			public IEnumerable<UserSource> ValueUser { get; set; }
+			public IEnumerable<IUser> ValueIUser { get; set; }
+		}
+
+		private class DestinationAsReadOnlyCollectionNull
+		{
+			public ReadOnlyCollection<int> ValueInt { get; set; }
+			public ReadOnlyCollection<string> ValueString { get; set; }
+			public IReadOnlyCollection<UserDestination> ValueUser { get; set; }
+			public IReadOnlyList<IUser> ValueIUser { get; set; }
+		}
+		private class DestinationAsReadOnlyCollectionNotNull
+		{
+			public DestinationAsReadOnlyCollectionNotNull()
+			{
+				ValueInt = new ReadOnlyCollection<int>(new List<int>());
+				ValueString = new ReadOnlyCollection<string>(new List<string>());
+				ValueUser = new ReadOnlyCollection<UserDestination>(new List<UserDestination>());
+				ValueIUser = new ReadOnlyCollection<IUser>(new List<IUser>());
+			}
+
+			public ReadOnlyCollection<int> ValueInt { get; set; }
+			public ReadOnlyCollection<string> ValueString { get; set; }
+			public ReadOnlyCollection<UserDestination> ValueUser { get; set; }
+			public ReadOnlyCollection<IUser> ValueIUser { get; set; }
+		}
+
+		private interface IUser
+		{
+			string Name { get; set; }
+			int Age { get; set; }
+		}
+
+		private class UserSource : IUser
+		{
+			public UserSource()
+			{
+
+			}
+
+			public UserSource(string name, int age)
+			{
+				Name = name;
+				((IUser)this).Age = age;
+			}
+
+			public string Name { get; set; }
+			int IUser.Age { get; set; }
+		}
+
+		private class UserDestination : IUser
+		{
+			public string Name { get; set; }
+			int IUser.Age { get; set; }
+		}
+	}
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AutoMapper.UnitTests</RootNamespace>
     <AssemblyName>AutoMapper.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>AutoMapper.snk</AssemblyOriginatorKeyFile>
@@ -157,6 +157,7 @@
     <Compile Include="Internationalization.cs" />
     <Compile Include="Bug\LazyCollectionMapping.cs" />
     <Compile Include="Mappers\NameValueCollectionMapperTests.cs" />
+    <Compile Include="Mappers\ReadOnlyCollectionMapperTests.cs" />
     <Compile Include="Mappers\TypeHelperTests.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
https://github.com/AutoMapper/AutoMapper/issues/288

Upgraded to 4.5 to add support for IReadOnlyCollection and IReadOnlyList.
Set the destinationValue to null on the mapping context so the ReadOnlyCollection is recreated.
Added mapping tests to assert the behavior.
