### PR TITLE
Option AllowDuplicateCallsPerMapping

### DIFF
--- a/src/AutoMapper/AutoMapper.csproj
+++ b/src/AutoMapper/AutoMapper.csproj
@@ -92,6 +92,7 @@
     <Compile Include="..\CommonAssemblyInfo.cs">
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="DuplicateCallsPerMappingException.cs" />
     <Compile Include="Internal\AliasedMember.cs" />
     <Compile Include="Mappers\ExplicitConversionOperatorMapper.cs" />
     <Compile Include="Mappers\ImplicitConversionOperatorMapper.cs" />

--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -34,6 +34,7 @@ namespace AutoMapper
 		    _typeMapFactory = typeMapFactory;
 		    _mappers = mappers;
             _globalIgnore = new List<string>();
+            AllowDuplicateCallsPerMapping = true;
 		}
 
 	    public event EventHandler<TypeMapCreatedEventArgs> TypeMapCreated;
@@ -42,6 +43,8 @@ namespace AutoMapper
 	    {
 	        get { return _serviceCtor; }
 	    }
+
+        public bool AllowDuplicateCallsPerMapping { get; set; }
 
 	    public bool AllowNullDestinationValues
 		{
@@ -241,7 +244,12 @@ namespace AutoMapper
 		public TypeMap CreateTypeMap(Type source, Type destination, string profileName, MemberList memberList)
 		{
 			TypeMap typeMap = FindExplicitlyDefinedTypeMap(source, destination);
-				
+
+            var profileConfiguration2 = GetProfile(profileName);
+			if (this.AllowDuplicateCallsPerMapping == false)
+                if (typeMap != null)
+                    throw new DuplicateCallsPerMappingException(string.Format("Mapping was already define before! Mapping from {0} to {1}, profile {2}", 
+                        source.FullName, destination.FullName, profileName));
 			if (typeMap == null)
 			{
 			    var profileConfiguration = GetProfile(profileName);

--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -15,6 +15,7 @@ using AutoMapper.Mappers;
 
 namespace AutoMapper
 {
+
 	public class ConfigurationStore : IConfigurationProvider, IConfiguration
 	{
 	    private readonly ITypeMapFactory _typeMapFactory;
@@ -26,6 +27,12 @@ namespace AutoMapper
         private readonly ConcurrentDictionary<TypePair, TypeMap> _typeMapCache = new ConcurrentDictionary<TypePair, TypeMap>();
         private readonly ConcurrentDictionary<string, FormatterExpression> _formatterProfiles = new ConcurrentDictionary<string, FormatterExpression>();
 		private Func<Type, object> _serviceCtor = ObjectCreator.CreateObject;
+        /// <summary>
+        /// Stores stack traces where a type map where registered. This is in use only when AllowDuplicateCallsPerMapping
+        /// setting is set to true. This will output previous typeMap registration location, plus current one (which 
+        /// will be evident from exceptions stack trace)
+        /// </summary>
+        private readonly  ConcurrentDictionary<TypeMap, string> _typeMapRegistrationLocations = new ConcurrentDictionary<TypeMap, string>();
 
 	    private readonly List<string> _globalIgnore;
 
@@ -245,11 +252,11 @@ namespace AutoMapper
 		{
 			TypeMap typeMap = FindExplicitlyDefinedTypeMap(source, destination);
 
-            var profileConfiguration2 = GetProfile(profileName);
 			if (this.AllowDuplicateCallsPerMapping == false)
                 if (typeMap != null)
-                    throw new DuplicateCallsPerMappingException(string.Format("Mapping was already define before! Mapping from {0} to {1}, profile {2}", 
-                        source.FullName, destination.FullName, profileName));
+                    throw new DuplicateCallsPerMappingException(string.Format("Mapping was already define before! Mapping from type '{0}' to '{1}'. " +
+                                                                              "Original type map was registered here {2}", 
+                        source.FullName, destination.FullName, _typeMapRegistrationLocations[typeMap]));
 			if (typeMap == null)
 			{
 			    var profileConfiguration = GetProfile(profileName);
@@ -258,6 +265,7 @@ namespace AutoMapper
 
                 typeMap.Profile = profileName;
 			    typeMap.IgnorePropertiesStartingWith = _globalIgnore;
+                
 
 			    IncludeBaseMappings(source, destination, typeMap);
 
@@ -266,13 +274,22 @@ namespace AutoMapper
 			    var typePair = new TypePair(source, destination);
 			    _typeMapCache.AddOrUpdate(typePair, typeMap, (tp, tm) => typeMap);
 
+                if (this.AllowDuplicateCallsPerMapping == false)
+                    UpdateRegistrationLocations(typeMap);
+
 				OnTypeMapCreated(typeMap);
 			}
 
 			return typeMap;
 		}
 
-        private void IncludeBaseMappings(Type source, Type destination, TypeMap typeMap)
+	    private void UpdateRegistrationLocations(TypeMap typeMap)
+	    {
+	        var stackTrace = Environment.StackTrace;
+	        this._typeMapRegistrationLocations.AddOrUpdate(typeMap, stackTrace, (old, n) => stackTrace);
+	    }
+
+	    private void IncludeBaseMappings(Type source, Type destination, TypeMap typeMap)
         {
             foreach (var inheritedTypeMap in _typeMaps.Where(t => t.TypeHasBeenIncluded(source, destination)))
             {

--- a/src/AutoMapper/DuplicateCallsPerMappingException.cs
+++ b/src/AutoMapper/DuplicateCallsPerMappingException.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace AutoMapper
+{
+    public class DuplicateCallsPerMappingException : Exception
+    {
+        public DuplicateCallsPerMappingException(string message)
+            : base(message)
+        {
+        }
+
+        protected DuplicateCallsPerMappingException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+
+    }
+}

--- a/src/AutoMapper/IFormatterExpression.cs
+++ b/src/AutoMapper/IFormatterExpression.cs
@@ -49,5 +49,6 @@ namespace AutoMapper
 	    void DisableConstructorMapping();
 		void Seal();
 	    void EnableYieldReturnForDataReaderMapper();
+        bool AllowDuplicateCallsPerMapping { get; set; }
 	}
 }

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -22,6 +22,12 @@ namespace AutoMapper
 			set { Configuration.AllowNullDestinationValues = value; }
 		}
 
+        public static bool AllowDuplicateCallsPerMapping
+        {
+            get { return Configuration.AllowDuplicateCallsPerMapping; }
+            set { Configuration.AllowDuplicateCallsPerMapping = value; }
+        }
+
         public static TDestination Map<TDestination>(object source)
         {
             return Engine.Map<TDestination>(source);

--- a/src/UnitTests/Bug/AllowDuplicateCallsPerMapping.cs
+++ b/src/UnitTests/Bug/AllowDuplicateCallsPerMapping.cs
@@ -1,0 +1,68 @@
+using NUnit.Framework;
+using Should;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    namespace AllowDuplicateCallsPerMapping
+    {
+        [TestFixture]
+        public class When_setting_AllowDuplicateCallsPerMapping_Should_Honour_Rule : AutoMapperSpecBase
+        {
+            public class Source
+            {
+            }
+
+            public class Destination
+            {
+            }
+
+            protected override void Establish_context()
+            {
+            }
+
+            protected override void Because_of()
+            {
+            }
+
+            [Test, ExpectedException(typeof(DuplicateCallsPerMappingException))]
+            public void Should_Dissallow_Double_Configuration()
+            {
+                Mapper.Initialize(config =>
+                {
+                    config.AllowDuplicateCallsPerMapping = false;
+                    config.CreateMap<Source, Destination>();
+                    config.CreateMap<Source, Destination>();
+                });
+            }
+
+            [Test]
+            public void Should_Allow_Double_Configuration()
+            {
+                Mapper.Initialize(config =>
+                {
+                    config.AllowDuplicateCallsPerMapping = true;
+                    config.CreateMap<Source, Destination>();
+                    config.CreateMap<Source, Destination>();
+                });
+            }
+
+            [Test]
+            public void Default_Intiailize_Should_Be_Allow()
+            {
+                Mapper.Initialize(config =>
+                {
+                    config.CreateMap<Source, Destination>();
+                    config.CreateMap<Source, Destination>();
+                });
+            }
+
+            [Test]
+            public void Default_Should_Be_Allow()
+            {
+                Mapper.CreateMap<Source, Destination>();
+                Mapper.CreateMap<Source, Destination>();
+            }
+        }
+    }
+}
+

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Bug\CannotConvertEnumToNullable.cs" />
     <Compile Include="Bug\ConditionBug.cs" />
     <Compile Include="Bug\ContextValuesIncorrect.cs" />
+    <Compile Include="Bug\AllowDuplicateCallsPerMapping.cs" />
     <Compile Include="Bug\DestinationValueInitializedByCtorBug.cs" />
     <Compile Include="Bug\CreateMapExpressionWithIgnoredPropertyBug.cs" />
     <Compile Include="Bug\CollectionMapperMapsISetIncorrectly.cs" />


### PR DESCRIPTION
New option AllowDuplicateCallsPerMapping to track whether a typemap pair has already been registered or not. 
