### PR TITLE
Test conflict between member mapping and constructor in destination clas...

### DIFF
--- a/src/UnitTests/CustomMapping.cs
+++ b/src/UnitTests/CustomMapping.cs
@@ -1081,7 +1081,47 @@ namespace AutoMapper.UnitTests
                 _e.ShouldNotBeNull();
             }
         }
-
-
 	}
+
+    public class When_mapping_from_one_type_to_another : AutoMapperSpecBase
+    {
+        private Dest _dest;
+
+        public class Source
+        {
+            public string Value { get; set; }
+        }
+
+        public class Dest
+        {
+            // AutoMapper tries to map Source.Value to this constructor's parameter,
+            // but does not take its member configuration into account
+            public Dest(int value)
+            {
+                Value = value;
+            }
+            public Dest()
+            {
+            }
+
+            public int Value { get; set; }
+        }
+
+        protected override void Establish_context()
+        {
+            Mapper.CreateMap<Source, Dest>()
+                .ForMember(dest => dest.Value, opt => opt.MapFrom(s => ParseValue(s.Value)));
+        }
+
+        protected override void Because_of()
+        {
+            var source = new Source { Value = "a1" };
+            _dest = Mapper.Map<Source, Dest>(source);
+        }
+
+        private static int ParseValue(string value)
+        {
+            return int.Parse(value.Substring(1));
+        }
+    }
 }


### PR DESCRIPTION
I've found that if a destination class has a non-default constructor, it'll take precedence over any member mapping in said class. This leads to mysterious errors, if you depend on member mapping in order to be able to translate source properties, which can be really hard to pin down. It took me several hours of debugging AutoMapper to figure out what was going on.

I'm not sure how to fix the issue so all this branch does is add a test to detect it.
