### PR TITLE
Sharing base type mappings between derived types

### DIFF
--- a/src/UnitTests/Bug/MappingInheritance.cs
+++ b/src/UnitTests/Bug/MappingInheritance.cs
@@ -1,0 +1,78 @@
+﻿using NUnit.Framework;
+
+namespace AutoMapper.UnitTests.Bug
+{
+	[TestFixture]
+	class MappingInheritance
+	{
+		private Entity testEntity;
+		private EditModel testModel;
+
+		[SetUp]
+		public void Prepare_common_staff()
+		{
+			Mapper.Reset();
+
+			testEntity = new Entity
+			{
+				Value1 = 1,
+				Value2 = 2,
+			};
+		}
+
+		[Test]
+		public void AutoMapper_should_map_derived_types_properly()
+		{
+			Mapper.CreateMap<Entity, BaseModel>()
+				.ForMember(model => model.Value1, mce => mce.MapFrom(entity => entity.Value2))
+				.ForMember(model => model.Value2, mce => mce.MapFrom(entity => entity.Value1))
+				.Include<Entity, EditModel>();
+			Mapper.CreateMap<Entity, EditModel>()
+				.ForMember(model => model.Value3, mce => mce.MapFrom(entity => entity.Value1 + entity.Value2));
+
+			testModel = Mapper.Map<Entity, EditModel>(testEntity);
+		}
+
+		[Test]
+		public void AutoMapper_should_map_derived_types_properly_2()
+		{
+			Mapper.CreateMap<Entity, BaseModel>()
+				.ForMember(model => model.Value1, mce => mce.MapFrom(entity => entity.Value2))
+				.ForMember(model => model.Value2, mce => mce.MapFrom(entity => entity.Value1))
+				.Include<Entity, EditModel>()
+				.Include<Entity, ViewModel>();
+			Mapper.CreateMap<Entity, EditModel>()
+				.ForMember(model => model.Value3, mce => mce.MapFrom(entity => entity.Value1 + entity.Value2));
+			Mapper.CreateMap<Entity, ViewModel>();
+
+			testModel = Mapper.Map<Entity, EditModel>(testEntity);
+		}
+
+		[TearDown]
+		public void Verify_mapping_results()
+		{
+			Assert.AreEqual(testEntity.Value1, testModel.Value2);
+			Assert.AreEqual(testEntity.Value2, testModel.Value1);
+			Assert.AreEqual(testEntity.Value1 + testEntity.Value2, testModel.Value3);
+		}
+	}
+
+	class Entity
+	{
+		public int Value1 { get; set; }
+		public int Value2 { get; set; }
+	}
+
+	class BaseModel
+	{
+		public int Value1 { get; set; }
+		public int Value2 { get; set; }
+	}
+
+	class EditModel : BaseModel
+	{
+		public int Value3 { get; set; }
+	}
+
+	class ViewModel : BaseModel { }
+}

--- a/src/UnitTests/UnitTests.csproj
+++ b/src/UnitTests/UnitTests.csproj
@@ -124,6 +124,7 @@
     <Compile Include="Bug\IgnoreAll.cs" />
     <Compile Include="Bug\InheritanceIssue.cs" />
     <Compile Include="Bug\InterfaceSelfMappingBug.cs" />
+    <Compile Include="Bug\MappingInheritance.cs" />
     <Compile Include="Bug\MemberNamedTypeBug.cs" />
     <Compile Include="Bug\MultipleInterfaceInheritance.cs" />
     <Compile Include="Bug\MultipleTypeConverterInterfaces.cs" />


### PR DESCRIPTION
Hello,

I've recently found out that it's impossible to share base type mappings of 1 entity between multiple derived types. The case is that I have an entity which is mapped to view & edit models (they are almost the same - that's why base model is extracted).
It would be great if you explain how your .Include<> functionality works and I will be able to extend it, or maybe was I just searching not hard enough and the in-box solution already exists in AutoMapper project?
Thanks hor your help, Artyom

Short commit history:
- Implement a test as a proof that mapping derived types using base type
  rules is working not properly for multiple derived types
