### PR TITLE
fixing broken link for 'wiki'

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ AutoMapper is a simple little library built to solve a deceptively complex probl
 
 How do I get started?
 --------------------------------
-Check out the [getting started guide](https://github.com/AutoMapper/AutoMapper/wiki/Getting-started). When you're done there, the [wiki](/AutoMapper/AutoMapper/wiki/Getting-started) goes in to the nitty-gritty details. Finally, check out the [dnrTV episode](http://www.dnrtv.com/default.aspx?showNum=155) for a full walkthrough. If you have questions, you can post them to the [Mailing List](http://groups.google.com/group/automapper-users).
+Check out the [getting started guide](https://github.com/AutoMapper/AutoMapper/wiki/Getting-started). When you're done there, the [wiki](https://github.com/AutoMapper/AutoMapper/wiki) goes in to the nitty-gritty details. Finally, check out the [dnrTV episode](http://www.dnrtv.com/default.aspx?showNum=155) for a full walkthrough. If you have questions, you can post them to the [Mailing List](http://groups.google.com/group/automapper-users).
 
 Where can I get it?
 --------------------------------


### PR DESCRIPTION
Not sure if this is By Design for github, but the current url for the 'wiki' link, which seems like it should be resolved relative to the current url authority (https://github.com/ as I view it), is instead prefixed with the blob path for the default branch (in this case, /AutoMapper/AutoMapper/blob/develop/) - the resulting html sent to the client includes this:

```
When you're done there, the <a href="/AutoMapper/AutoMapper/blob/develop/AutoMapper/AutoMapper/wiki/Getting-started">wiki</a> goes in to the nitty-gritty details
```

Since the Getting-started page was linked in the previous sentence, I'm guessing this particular link was meant to be to its parent so a user could see a listing of the pages available.
