### PR TITLE
UseDestinationValue not regarded

### DIFF
--- a/src/AutoMapper/IMappingExpression.cs
+++ b/src/AutoMapper/IMappingExpression.cs
@@ -307,11 +307,16 @@ namespace AutoMapper
         void UseDestinationValue();
 
         /// <summary>
+        /// Use the destination value instead of mapping from the source value or creating a new instance
+        /// </summary>        
+		void UseDestinationValue(bool value);
+        
+        /// <summary>
         /// Use a custom value
         /// </summary>
         /// <typeparam name="TValue">Value type</typeparam>
         /// <param name="value">Value to use</param>
-        void UseValue<TValue>(TValue value);
+		 void UseValue<TValue>(TValue value);
 
         /// <summary>
         /// Use a custom value

--- a/src/AutoMapper/Internal/MappingExpression.cs
+++ b/src/AutoMapper/Internal/MappingExpression.cs
@@ -337,6 +337,11 @@ namespace AutoMapper
             _propertyMap.UseDestinationValue = true;
         }
 
+        public void UseDestinationValue(bool value)
+        {
+            _propertyMap.UseDestinationValue = value;
+        }
+
         public void SetMappingOrder(int mappingOrder)
         {
             _propertyMap.SetMappingOrder(mappingOrder);

--- a/src/AutoMapper/Mappers/TypeMapObjectMapperRegistry.cs
+++ b/src/AutoMapper/Mappers/TypeMapObjectMapperRegistry.cs
@@ -152,7 +152,7 @@ namespace AutoMapper.Mappers
 
 			protected virtual void AssignValue(PropertyMap propertyMap, object mappedObject, object propertyValueToAssign)
 			{
-				if (!propertyMap.UseDestinationValue && propertyMap.CanBeSet)
+				if (propertyMap.CanBeSet)
 					propertyMap.DestinationProperty.SetValue(mappedObject, propertyValueToAssign);
 			}
 

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -26,6 +26,7 @@ namespace AutoMapper
 
         public PropertyMap(IMemberAccessor destinationProperty)
         {
+            UseDestinationValue = true; 
             DestinationProperty = destinationProperty;
         }
 
@@ -243,7 +244,9 @@ namespace AutoMapper
 
         public object GetDestinationValue(object mappedObject)
         {
-            return DestinationProperty.GetValue(mappedObject);
+		     return UseDestinationValue
+                ? DestinationProperty.GetValue(mappedObject)
+                : null;
         }
 
         public ExpressionResolutionResult ResolveExpression(Type currentType, Expression instanceParameter)


### PR DESCRIPTION
Regarding Issue #356 - I am also interested in solving this.

We found that the flag PropertyMap.UseDestinationValue is currently not used. By default is regarded to be on. 
We made three changes: 
- set the initial value of the UseDestinationValue to true (to reflect the current state and dont break anything)
- regard its value in PropertyMap.GetDestinationValue (return null if false)
- added a function in IMappingExpression to disable it
  That way we preserve the current behaviour but introduce a way to go back to the old behaviour.

(The change in TypeMapObjectMapperRegistry, seemed a nessesary fix to a hidden bug, revealed by our change. UseDestinationValue does not need to be regarded when setting the value).

Please consider this fix. 
Regards,
Jonas
