### PR TITLE
Added possibility to disable constructor mapping for a profile

### DIFF
--- a/src/AutoMapper/Profile.cs
+++ b/src/AutoMapper/Profile.cs
@@ -23,6 +23,11 @@ namespace AutoMapper
 
 	    public virtual string ProfileName { get; private set; }
 
+        protected void DisableConstructorMapping()
+        {
+            GetProfile().ConstructorMappingEnabled = false;
+        }
+
 	    public bool AllowNullDestinationValues
 		{
 			get { return GetProfile().AllowNullDestinationValues; }

--- a/src/UnitTests/Profiles.cs
+++ b/src/UnitTests/Profiles.cs
@@ -1,3 +1,4 @@
+using System;
 using Should;
 using Xunit;
 
@@ -120,6 +121,58 @@ namespace AutoMapper.UnitTests
 				_result.Value.ShouldEqual("5 Custom");
 			}
 		}
+
+
+        public class When_disabling_constructor_mapping_with_profiles : AutoMapperSpecBase
+        {
+            private B _b;
+
+            public class AProfile : Profile
+            {
+                protected override void Configure()
+                {
+                    DisableConstructorMapping();
+                    CreateMap<A, B>();
+                }
+            }
+
+            public class A
+            {
+                public string Value { get; set; }
+            }
+
+            public class B
+            {
+
+                public B()
+                {
+                }
+
+                public B(string value)
+                {
+                    throw new Exception();
+                }
+
+                public string Value { get; set; }
+            }
+
+            protected override void Establish_context()
+            {
+                Mapper.AddProfile<AProfile>();
+            }
+
+            protected override void Because_of()
+            {
+                _b = Mapper.Map<B>(new A { Value = "BLUEZ" });
+            }
+
+            [Fact]
+            public void When_using_profile_and_no_constructor_mapping()
+            {
+                Assert.Equal("BLUEZ", _b.Value);
+            }
+        }
+
 
 	}
 }


### PR DESCRIPTION
We are using profiles, and I wanted to be able to disable constructor mapping, but there didn't seem to be any way to configure this in a profile, so I added it.

It would actually been enough for me if I could turn off constructor mapping globally for all profiles in some way, but it doesn't seem like the global configuration is propagated down to the different profiles. I don't know if that is a bug or not, but this small addition to Profile.cs would solve it for us.
