### PR TITLE
Update MappingExpression.cs

### DIFF
--- a/src/AutoMapper/Internal/MappingExpression.cs
+++ b/src/AutoMapper/Internal/MappingExpression.cs
@@ -76,6 +76,7 @@ namespace AutoMapper
         private void ForDestinationMember(IMemberAccessor destinationProperty, Action<IMemberConfigurationExpression> memberOptions)
         {
             _propertyMap = _typeMap.FindOrCreatePropertyMapFor(destinationProperty);
+            _typeMap.AddPropertyMap(_propertyMap);
 
             memberOptions(this);
         }


### PR DESCRIPTION
When using Mapper.Map(sourceInstance, destinationInstance), the property maps set through the .ForMember(T, T.MapFrom) were not considered until this addition.
