### PR TITLE
Fixed a NullReferenceException thrown by QueryableExtensions with Inherited Explicit Mapping

### DIFF
--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -276,7 +276,10 @@ namespace AutoMapper
                                          m.DestinationProperty.Name == inheritedMappedProperty.DestinationProperty.Name);
 
                     if (conventionPropertyMap != null && inheritedMappedProperty.HasCustomValueResolver)
+                    {
                         conventionPropertyMap.AssignCustomValueResolver(inheritedMappedProperty.GetSourceValueResolvers().First());
+                        conventionPropertyMap.AssignCustomExpression(inheritedMappedProperty.CustomExpression);
+                    }
                     else if (conventionPropertyMap == null)
                     {
                         var propertyMap = new PropertyMap(inheritedMappedProperty);

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -45,6 +45,7 @@ namespace AutoMapper
             ApplyCondition(inheritedMappedProperty._condition);
             SetNullSubstitute(inheritedMappedProperty._nullSubstitute);
             SetMappingOrder(inheritedMappedProperty._mappingOrder);
+            CustomExpression = inheritedMappedProperty.CustomExpression;
         }
 
         public IMemberAccessor DestinationProperty { get; private set; }
@@ -154,7 +155,12 @@ namespace AutoMapper
         {
             return _valueFormatters.ToArray();
         }
-
+        
+        public void AssignCustomExpression(LambdaExpression customExpression)
+        {
+            CustomExpression = customExpression;
+        }
+        
         public void AssignCustomValueResolver(IValueResolver valueResolver)
         {
             _ignored = false;


### PR DESCRIPTION
Resolves issue #443.

Fixes NullReferenceException in PropertyMap.ResolveExpression method (used by QueryableExtensions ) when Explicit Mapping is inherited.
