### PR TITLE
Possible fix for #474

### DIFF
--- a/src/AutoMapper.targets
+++ b/src/AutoMapper.targets
@@ -13,7 +13,7 @@
     <Message Importance="low" Text="AutoMapper Platform Extension Assembly: %(_AutoMapperReference.FullPath)"/>
 
     <ItemGroup>
-      <Content Include="%(_AutoMapperReference.FullPath)" Condition="'%(_AutoMapperReference.FullPath)' != ''">
+      <Content Include="$([MSBuild]::MakeRelative($(MSBuildProjectDirectory), %(_AutoMapperReference.FullPath)))" Condition="'%(_AutoMapperReference.FullPath)' != ''">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>
     </ItemGroup>


### PR DESCRIPTION
One way to fix #474 is to have `AutoMapper.targets` only include relative paths in `@(Content)` via `MakeRelative` [property function](http://msdn.microsoft.com/en-us/library/dd633440.aspx#BKMK_MakeRelative), however they were introduced in .NET 4 and unavailable to older versions of .NET/MSBuild and I can't tell if `[MSBuild]` static class is present in other builder engines, i.e. Mono, WP8/Android, etc.
