### PR TITLE
MemberNameReplacers

### DIFF
--- a/src/AutoMapper/AutoMapper.csproj
+++ b/src/AutoMapper/AutoMapper.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Internal\AliasedMember.cs" />
     <Compile Include="Internal\IAdapterResolver.cs" />
     <Compile Include="Internal\ManualNullableConverterFactory.cs" />
+    <Compile Include="Internal\MemberNameReplacer.cs" />
     <Compile Include="Internal\NoOpReaderWriterLockFactory.cs" />
     <Compile Include="Internal\NotSupportedEnumNameValueMappingFactory.cs" />
     <Compile Include="Internal\NotSupportedProxyGeneratorFactory.cs" />

--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -87,6 +87,11 @@ namespace AutoMapper
             get { return GetProfile(DefaultProfileName).DestinationPostfixes; }
 	    }
 
+	    public IEnumerable<MemberNameReplacer> MemberNameReplacers
+        {
+            get { return GetProfile(DefaultProfileName).MemberNameReplacers; }
+        }
+
 	    public IEnumerable<AliasedMember> Aliases
 	    {
 	        get { return GetProfile(DefaultProfileName).Aliases; }
@@ -223,6 +228,11 @@ namespace AutoMapper
 		{
 			GetProfile(DefaultProfileName).RecognizeAlias(original, alias);
 		}
+
+        public void RecognizePartialAlias(string original, string alias)
+        {
+            GetProfile(DefaultProfileName).RecognizePartialAlias(original, alias);
+        }
 
         public void RecognizeDestinationPrefixes(params string[] prefixes)
         {

--- a/src/AutoMapper/INamingConvention.cs
+++ b/src/AutoMapper/INamingConvention.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using AutoMapper.Internal;
 
 namespace AutoMapper
 {
@@ -51,6 +52,11 @@ namespace AutoMapper
         /// Destination member naem prefixes to ignore/drop
         /// </summary>
 	    IEnumerable<string> DestinationPostfixes { get; }
+
+        /// <summary>
+        /// Source/destination member name replacers
+        /// </summary>
+        IEnumerable<MemberNameReplacer> MemberNameReplacers { get; }
 
         /// <summary>
         /// Source/destination member aliases

--- a/src/AutoMapper/Internal/FormatterExpression.cs
+++ b/src/AutoMapper/Internal/FormatterExpression.cs
@@ -19,6 +19,7 @@ namespace AutoMapper
         private readonly ISet<string> _destinationPrefixes = new HashSet<string>();
         private readonly ISet<string> _destinationPostfixes = new HashSet<string>();
         private readonly ISet<AliasedMember> _aliases = new HashSet<AliasedMember>();
+        private readonly ISet<MemberNameReplacer> _memberNameReplacers = new HashSet<MemberNameReplacer>();
         private readonly List<MethodInfo> _sourceExtensionMethods = new List<MethodInfo>();
 
 	    public FormatterExpression(Func<Type, IValueFormatter> formatterCtor)
@@ -40,6 +41,7 @@ namespace AutoMapper
         public IEnumerable<string> Postfixes { get { return _postfixes; } }
         public IEnumerable<string> DestinationPrefixes { get { return _destinationPrefixes; } }
         public IEnumerable<string> DestinationPostfixes { get { return _destinationPostfixes; } }
+        public IEnumerable<MemberNameReplacer> MemberNameReplacers { get { return _memberNameReplacers; } }
         public IEnumerable<AliasedMember> Aliases { get { return _aliases; } }
         public bool ConstructorMappingEnabled { get; set; }
         public bool DataReaderMapperYieldReturnEnabled { get; set; }
@@ -195,6 +197,11 @@ namespace AutoMapper
 		{
 		    _aliases.Add(new AliasedMember(original, alias));
 		}
+
+        public void RecognizePartialAlias(string original, string alias)
+        {
+            _memberNameReplacers.Add(new MemberNameReplacer(original, alias));
+        }
 
 		public void RecognizeDestinationPrefixes(params string[] prefixes)
 		{

--- a/src/AutoMapper/Internal/MemberNameReplacer.cs
+++ b/src/AutoMapper/Internal/MemberNameReplacer.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace AutoMapper.Internal
+{
+    public class MemberNameReplacer
+    {
+        public MemberNameReplacer(string originalValue, string alias)
+        {
+            OrginalValue = originalValue;
+            Alias = alias;
+        }
+
+        public string OrginalValue { get; private set; }
+        public string Alias { get; private set; }
+    }
+}

--- a/src/AutoMapper/Internal/TypeMapFactory.cs
+++ b/src/AutoMapper/Internal/TypeMapFactory.cs
@@ -157,10 +157,11 @@ namespace AutoMapper
 
         private static bool NameMatches(string memberName, string nameToMatch, IMappingOptions mappingOptions)
         {
-            var possibleSourceNames = PossibleNames(memberName, mappingOptions.Aliases, mappingOptions.Prefixes,
-                                                          mappingOptions.Postfixes);
-            var possibleDestNames = PossibleNames(nameToMatch, mappingOptions.Aliases, mappingOptions.DestinationPrefixes,
-                                                          mappingOptions.DestinationPostfixes);
+            var possibleSourceNames = PossibleNames(memberName, mappingOptions.Aliases, mappingOptions.MemberNameReplacers,
+                mappingOptions.Prefixes, mappingOptions.Postfixes);
+
+            var possibleDestNames = PossibleNames(nameToMatch, mappingOptions.Aliases, mappingOptions.MemberNameReplacers,
+                mappingOptions.DestinationPrefixes, mappingOptions.DestinationPostfixes);
 
             var all =
                 from sourceName in possibleSourceNames
@@ -170,7 +171,8 @@ namespace AutoMapper
             return all.Any(pair => String.Compare(pair.sourceName, pair.destName, StringComparison.OrdinalIgnoreCase) == 0);
         }
 
-        private static IEnumerable<string> PossibleNames(string memberName, IEnumerable<AliasedMember> aliases, IEnumerable<string> prefixes, IEnumerable<string> postfixes)
+        private static IEnumerable<string> PossibleNames(string memberName, IEnumerable<AliasedMember> aliases, 
+            IEnumerable<MemberNameReplacer> memberNameReplacers, IEnumerable<string> prefixes, IEnumerable<string> postfixes)
         {
             if (string.IsNullOrEmpty(memberName))
                 yield break;
@@ -180,6 +182,18 @@ namespace AutoMapper
             foreach (var alias in aliases.Where(alias => String.Equals(memberName, alias.Member, StringComparison.Ordinal)))
             {
                 yield return alias.Alias;
+            }
+
+            if (memberNameReplacers.Any())
+            {
+                string aliasName = memberName;
+
+                foreach (var nameReplacer in memberNameReplacers)
+                {
+                    aliasName = aliasName.Replace(nameReplacer.OrginalValue, nameReplacer.Alias);
+                }
+
+                yield return aliasName;
             }
 
             foreach (var prefix in prefixes.Where(prefix => memberName.StartsWith(prefix, StringComparison.Ordinal)))

--- a/src/AutoMapper/Profile.cs
+++ b/src/AutoMapper/Profile.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using AutoMapper.Internal;
 
 namespace AutoMapper
 {
@@ -77,7 +78,12 @@ namespace AutoMapper
 	        get { return GetProfile().DestinationPostfixes; }
 	    }
 
-	    public IEnumerable<AliasedMember> Aliases
+        public IEnumerable<MemberNameReplacer> MemberNameReplacers
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public IEnumerable<AliasedMember> Aliases
 	    {
 	        get { throw new NotImplementedException(); }
 	    }

--- a/src/UnitTests/Tests/TypeMapFactorySpecs.cs
+++ b/src/UnitTests/Tests/TypeMapFactorySpecs.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using AutoMapper.Internal;
 using Xunit;
 using Should;
 
@@ -30,6 +31,8 @@ namespace AutoMapper.UnitTests.Tests
         private IEnumerable<string> _destinationPostfixes = new List<string>();
 
         private IEnumerable<AliasedMember> _aliases = new List<AliasedMember>();
+
+        private HashSet<MemberNameReplacer> _memberNameReplacers = new HashSet<MemberNameReplacer>();
 
         private IEnumerable<Assembly> _sourceExtensionMethodSearch = null;
         private IEnumerable<MethodInfo> _sourceExtensionMethods = new List<MethodInfo>();
@@ -66,6 +69,11 @@ namespace AutoMapper.UnitTests.Tests
             get { return _destinationPostfixes; }
         }
 
+        public IEnumerable<MemberNameReplacer> MemberNameReplacers
+        {
+            get { return _memberNameReplacers; }
+        }
+
         public IEnumerable<AliasedMember> Aliases
         {
             get { return _aliases; }
@@ -84,6 +92,11 @@ namespace AutoMapper.UnitTests.Tests
         public IEnumerable<MethodInfo> SourceExtensionMethods
         {
             get { return _sourceExtensionMethods; }
+        }
+
+        public void RecognizePartialAlias(string original, string alias)
+        {
+            _memberNameReplacers.Add(new MemberNameReplacer(original, alias));
         }
     }
 
@@ -213,6 +226,45 @@ namespace AutoMapper.UnitTests.Tests
         public void Should_split_using_naming_convention_rules()
         {
             _map.GetPropertyMaps().Count().ShouldEqual(1);
+        }
+    }
+
+    public class When_using_a_source_member_name_replacer : SpecBase
+    {
+        private TypeMapFactory _factory;
+
+        public class Source
+        {
+            public int Value { get; set; }
+            public int Ävíator { get; set; }
+            public int SubAirlinaFlight { get; set; }
+        }
+
+        public class Destination
+        {
+            public int Value { get; set; }
+            public int Aviator { get; set; }
+            public int SubAirlineFlight { get; set; }
+        }
+
+        protected override void Establish_context()
+        {
+            _factory = new TypeMapFactory();
+        }
+
+        [Fact]
+        public void Should_map_properties_with_same_name()
+        {
+            var mappingOptions = new StubMappingOptions();
+            mappingOptions.RecognizePartialAlias("Ä", "A");
+            mappingOptions.RecognizePartialAlias("í", "i");
+            mappingOptions.RecognizePartialAlias("Airlina", "Airline");
+            
+            var typeMap = _factory.CreateTypeMap(typeof(Source), typeof(Destination), mappingOptions, MemberList.Destination);
+
+            var propertyMaps = typeMap.GetPropertyMaps();
+
+            propertyMaps.Count().ShouldEqual(3);
         }
     }
 }


### PR DESCRIPTION
Match member names with replaced member names.

Issue: #471

//Mapping from:
class DemoLegacyModel
public int Äviator { get; set: }

//to:
class DemoViewModel
public int Aviator { get; set: }
