### PR TITLE
Issue #473. Static DynamicMap and CreateMap APIs should be thread-safe

### DIFF
--- a/src/AutoMapper/Mappers/MapperRegistry.cs
+++ b/src/AutoMapper/Mappers/MapperRegistry.cs
@@ -25,12 +25,17 @@ namespace AutoMapper.Mappers
             new ExplicitConversionOperatorMapper()
         };
 
-        private static readonly List<IObjectMapper> _mappers = new List<IObjectMapper>(_initialMappers);
+        private static readonly ThreadSafeList<IObjectMapper> _mappers = new ThreadSafeList<IObjectMapper>();
+
+        static MapperRegistry()
+        {
+            Reset();
+        }
 
         /// <summary>
         /// Extension point for modifying list of object mappers
         /// </summary>
-        public static IList<IObjectMapper> Mappers
+        public static ThreadSafeList<IObjectMapper> Mappers
         {
             get { return _mappers; }
         }
@@ -41,7 +46,11 @@ namespace AutoMapper.Mappers
         public static void Reset()
         {
             _mappers.Clear();
-            _mappers.AddRange(_initialMappers);
+            _mappers.SyncChange(list =>
+            {
+                foreach (var val in _initialMappers)
+                    list.Add(val);
+            });
         }
     }
 }

--- a/src/AutoMapper/Mappers/PlatformSpecificMapperRegistryOverride.cs
+++ b/src/AutoMapper/Mappers/PlatformSpecificMapperRegistryOverride.cs
@@ -26,9 +26,12 @@ namespace AutoMapper.Mappers
         private void InsertBefore<TObjectMapper>(IObjectMapper mapper)
             where TObjectMapper : IObjectMapper
         {
-            var targetMapper = MapperRegistry.Mappers.FirstOrDefault(om => om is TObjectMapper);
-            var index = targetMapper == null ? 0 : MapperRegistry.Mappers.IndexOf(targetMapper);
-            MapperRegistry.Mappers.Insert(index, mapper);
+            MapperRegistry.Mappers.SyncChange(list =>
+            {
+                var targetMapper = list.FirstOrDefault(om => om is TObjectMapper);
+                var index = targetMapper == null ? 0 : list.IndexOf(targetMapper);
+                list.Insert(index, mapper);
+            });
         }
     }
 }


### PR DESCRIPTION
It's variant of changes. Mostly idea, because of strong types are used and not all platforms were tested.
