### PR TITLE
Missing feature of handling enum to string mappings in queryable projections

### DIFF
--- a/src/UnitTests/Projection/ProjectEnumTest.cs
+++ b/src/UnitTests/Projection/ProjectEnumTest.cs
@@ -1,0 +1,63 @@
+﻿namespace AutoMapper.UnitTests.Projection
+{
+    using AutoMapper.QueryableExtensions;
+    using Should;
+    using System.Linq;
+    using Xunit;
+
+    public class ProjectEnumTest
+    {
+        public ProjectEnumTest()
+        {
+            Mapper.CreateMap<Customer, CustomerDto>();
+            Mapper.CreateMap<CustomerType, string>().ConvertUsing(ct => ct.ToString().ToUpper());
+        }
+
+        [Fact]
+        public void RegularMappingWorks()
+        {
+            var customers = new[] { new Customer() { FirstName = "Bill", LastName = "White", CustomerType = CustomerType.Vip } }.AsQueryable();
+
+            var projected = Mapper.Map<CustomerDto[]>(customers);
+
+            projected.ShouldNotBeNull();
+            Assert.Equal(customers.Single().CustomerType.ToString().ToUpper(), projected.Single().CustomerType);
+        }
+
+        [Fact]
+        public void ProjectingEnumToString()
+        {
+            var customers = new[] { new Customer() { FirstName = "Bill", LastName = "White", CustomerType = CustomerType.Vip } }.AsQueryable();
+
+            Mapper.Map<CustomerDto[]>(customers);
+
+            var projected = customers.Project().To<CustomerDto>();
+            projected.ShouldNotBeNull();
+            Assert.Equal(customers.Single().CustomerType.ToString().ToUpper(), projected.Single().CustomerType);
+        }
+
+        public class Customer
+        {
+            public string FirstName { get; set; }
+
+            public string LastName { get; set; }
+
+            public CustomerType CustomerType { get; set; }
+        }
+
+        public class CustomerDto
+        {
+            public string FirstName { get; set; }
+
+            public string LastName { get; set; }
+
+            public string CustomerType { get; set; }
+        }
+
+        public enum CustomerType
+        {
+            Regular,
+            Vip,
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -180,6 +180,7 @@
     <Compile Include="Projection\ProjectCollectionEnumerableTest.cs" />
     <Compile Include="Projection\ProjectCollectionListTest.cs" />
     <Compile Include="Projection\ProjectEnumerableToArrayTest.cs" />
+    <Compile Include="Projection\ProjectEnumTest.cs" />
     <Compile Include="Projection\ProjectTest.cs" />
     <Compile Include="PropertyMapContexts.cs" />
     <Compile Include="Regression.cs" />


### PR DESCRIPTION
I believe it should be possible in Automapper to handle mapping enums in queryable projections. I believe that supporting ConvertUsing will not be possible in all cases, but for the simple and common case of mapping enums it should work.
