### PR TITLE
Added Functionality to Support Web Api expands on Projections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ AppPackages/
 packages
 *.orig
 *.DotSettings
+src/UpgradeLog.htm

--- a/src/AutoMapper/IMappingExpression.cs
+++ b/src/AutoMapper/IMappingExpression.cs
@@ -323,6 +323,17 @@ namespace AutoMapper
         void MapFrom<TMember>(Expression<Func<TSource, TMember>> sourceMember);
 
         /// <summary>
+        /// Specify the source member to map from. Can only reference a member on the <typeparamref name="TSource"/> type
+        /// This method can be used in mapping to LINQ query projections, while ResolveUsing cannot.
+        /// Any null reference exceptions in this expression will be ignored (similar to flattening behavior).
+        /// And the specified member will be ignored unless explicitly expanded.
+        /// </summary>
+        /// <typeparam name="TMember">Member type of the source member to use</typeparam>
+        /// <param name="sourceMember">Expression referencing the source member to map against</param>
+        /// <param name="ignoreProjectionUnlessExpanded">Specify if the mapped type should be ignored unless explicity expanded on Projections</param>
+        void MapFrom<TMember>(Expression<Func<TSource, TMember>> sourceMember, bool ignoreProjectionUnlessExpanded);
+
+        /// <summary>
         /// Ignore this member for configuration validation and skip during mapping
         /// </summary>
         void Ignore();

--- a/src/AutoMapper/Internal/MappingExpression.cs
+++ b/src/AutoMapper/Internal/MappingExpression.cs
@@ -288,6 +288,12 @@ namespace AutoMapper
             _propertyMap.SetCustomValueResolverExpression(sourceMember);
         }
 
+        public void MapFrom<TMember>(Expression<Func<TSource, TMember>> sourceMember, bool ignoreProjectionUnlessExpanded)
+        {
+            _propertyMap.IgnoreProjectionUnlessExpanded = ignoreProjectionUnlessExpanded;
+            MapFrom(sourceMember);
+        }
+
         public void UseValue<TValue>(TValue value)
         {
             MapFrom(src => value);

--- a/src/AutoMapper/Internal/TypePair.cs
+++ b/src/AutoMapper/Internal/TypePair.cs
@@ -1,47 +1,64 @@
-using System;
+    using System;
 
-namespace AutoMapper.Impl
-{
-    public struct TypePair : IEquatable<TypePair>
+    namespace AutoMapper.Impl
     {
-
-        public TypePair(Type sourceType, Type destinationType)
-            : this()
+        public struct TypePair : IEquatable<TypePair>
         {
-            _sourceType = sourceType;
-            _destinationType = destinationType;
-            _hashcode = unchecked((_sourceType.GetHashCode() * 397) ^ _destinationType.GetHashCode());
-        }
 
-        private readonly Type _destinationType;
-        private readonly int _hashcode;
-        private readonly Type _sourceType;
+            public TypePair(Type sourceType, Type destinationType)
+                : this()
+            {
+                _sourceType = sourceType;
+                _destinationType = destinationType;
+                _hashcode = unchecked((_sourceType.GetHashCode() * 397) ^ _destinationType.GetHashCode());
+                _projectionExpandMembers = null;
+            }
 
-        public Type SourceType
-        {
-            get { return _sourceType; }
-        }
+            public TypePair(Type sourceType, Type destinationType, string projectionExpandMembers)
+                : this()
+            {
+                _sourceType = sourceType;
+                _destinationType = destinationType;
+                _hashcode = unchecked((_sourceType.GetHashCode() * 397) ^ _destinationType.GetHashCode());
+                _projectionExpandMembers = projectionExpandMembers;
+            }
 
-        public Type DestinationType
-        {
-            get { return _destinationType; }
-        }
+            private readonly Type _destinationType;
+            private readonly int _hashcode;
+            private readonly Type _sourceType;
+            private readonly string _projectionExpandMembers;
 
-        public bool Equals(TypePair other)
-        {
-            return Equals(other._sourceType, _sourceType) && Equals(other._destinationType, _destinationType);
-        }
+            public Type SourceType
+            {
+                get { return _sourceType; }
+            }
 
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj)) return false;
-            if (obj.GetType() != typeof(TypePair)) return false;
-            return Equals((TypePair)obj);
-        }
+            public Type DestinationType
+            {
+                get { return _destinationType; }
+            }
 
-        public override int GetHashCode()
-        {
-            return _hashcode;
+            public string ProjectionExpandMembers
+            {
+                get { return _projectionExpandMembers; }
+
+            }
+
+            public bool Equals(TypePair other)
+            {
+                return Equals(other._sourceType, _sourceType) && Equals(other._destinationType, _destinationType) && Equals(other.ProjectionExpandMembers, _projectionExpandMembers);
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (obj.GetType() != typeof(TypePair)) return false;
+                return Equals((TypePair)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return _hashcode;
+            }
         }
     }
-}

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -23,6 +23,7 @@ namespace AutoMapper
         private IValueResolver[] _cachedResolvers;
         private Func<ResolutionContext, bool> _condition;
         private MemberInfo _sourceMember;
+        private bool _ignoreProjectionUnlessExpanded;
 
         public PropertyMap(IMemberAccessor destinationProperty)
         {
@@ -50,6 +51,12 @@ namespace AutoMapper
         public IMemberAccessor DestinationProperty { get; private set; }
         public Type DestinationPropertyType { get { return DestinationProperty.MemberType; } }
         public LambdaExpression CustomExpression { get; private set; }
+
+        public bool IgnoreProjectionUnlessExpanded
+        {
+            get { return _ignoreProjectionUnlessExpanded; }
+            set { _ignoreProjectionUnlessExpanded = value; }
+        }
 
         public MemberInfo SourceMember
         {


### PR DESCRIPTION
Added functionality to support web api expands on Projections as previously Automapper was expanding all members.

Specifically modified QueryableExtensions.cs to enable a string of expandable fields to
include in the projection only.  Additionally added new constructor on
MapFrom whereby the mapping can be specified to be ignored by default
unless explicitly expanded in the projection.  This resolves issue
whereby all members where being expanded by default.  Supporting files
modified are TypePair.cs and PropertyMap.cs.  Changes to TypePair add a
string member ProjectionExpandMembers which stores the expanded fields
for the mapping.  This ensures that the existing mapping cache in
QueryableExtensions.cs remains intact and enables different versions of
the mapping expression can be cached.  Finally the changes to PropertyMap.cs support
the above mentioned functionality whereby individual member mappings can
be ignored by default in projections.

Related to issue: https://github.com/AutoMapper/AutoMapper/issues/486
