### PR TITLE
Add NullSubstitution support to QueryExtentions

### DIFF
--- a/src/AutoMapper/Internal/NullReplacementMethod.cs
+++ b/src/AutoMapper/Internal/NullReplacementMethod.cs
@@ -3,6 +3,7 @@ namespace AutoMapper
 	public class NullReplacementMethod : IValueResolver
 	{
 		private readonly object _nullSubstitute;
+        public object NullSubstitute {get { return _nullSubstitute; }}
 
 		public NullReplacementMethod(object nullSubstitute)
 		{

--- a/src/AutoMapper/QueryableExtensions.cs
+++ b/src/AutoMapper/QueryableExtensions.cs
@@ -280,83 +280,25 @@ namespace AutoMapper.QueryableExtensions
                 selectExpression);
         }
 
+        private static readonly IList<IExpressionResultConverter> ExpressionResultConverters =
+            new IExpressionResultConverter[]
+            {
+                new MemberGetterExpressionResultConverter(),
+                new MemberResolverExpressionResultConverter(),
+                new NullSubstitutionExpressionResultConverter(), 
+            };
+
         private static ExpressionResolutionResult ResolveExpression(PropertyMap propertyMap, Type currentType, Expression instanceParameter)
         {
-            Expression currentChild = instanceParameter;
-            Type currentChildType = currentType;
+            var result = new ExpressionResolutionResult(instanceParameter, currentType);
             foreach (var resolver in propertyMap.GetSourceValueResolvers())
             {
-                var getter = resolver as IMemberGetter;
-                if (getter != null)
-                {
-                    var memberInfo = getter.MemberInfo;
-
-                    var propertyInfo = memberInfo as PropertyInfo;
-                    if (propertyInfo != null)
-                    {
-                        currentChild = Expression.Property(currentChild, propertyInfo);
-                        currentChildType = propertyInfo.PropertyType;
-                    }
-                    else
-                        currentChildType = currentChild.Type;
-                }
-                else
-                {
-                    var oldParameter = propertyMap.CustomExpression.Parameters.Single();
-                    var newParameter = instanceParameter;
-                    var converter = new ConversionVisitor(newParameter, oldParameter);
-
-                    currentChild = converter.Visit(propertyMap.CustomExpression.Body);
-                    currentChildType = currentChild.Type;
-                }
+                var matchingExpressionConverter = ExpressionResultConverters.FirstOrDefault(c => c.CanGetExpressionResolutionResult(result, resolver));
+                if(matchingExpressionConverter == null)
+                    throw new Exception("Can't resolve this to Queryable Expression");
+                result = matchingExpressionConverter.GetExpressionResolutionResult(result, propertyMap, resolver);
             }
-
-            return new ExpressionResolutionResult(currentChild, currentChildType);
-        }
-
-        /// <summary>
-        /// This expression visitor will replace an input parameter by another one
-        /// 
-        /// see http://stackoverflow.com/questions/4601844/expression-tree-copy-or-convert
-        /// </summary>
-        private class ConversionVisitor : ExpressionVisitor
-        {
-            private readonly Expression newParameter;
-            private readonly ParameterExpression oldParameter;
-
-            public ConversionVisitor(Expression newParameter, ParameterExpression oldParameter)
-            {
-                this.newParameter = newParameter;
-                this.oldParameter = oldParameter;
-            }
-
-            protected override Expression VisitParameter(ParameterExpression node)
-            {
-                // replace all old param references with new ones
-                return node.Type == oldParameter.Type ? newParameter : node;
-            }
-
-            protected override Expression VisitMember(MemberExpression node)
-            {
-                if (node.Expression != oldParameter) // if instance is not old parameter - do nothing
-                    return base.VisitMember(node);
-
-                var newObj = Visit(node.Expression);
-                var newMember = newParameter.Type.GetMember(node.Member.Name).First();
-                return Expression.MakeMemberAccess(newObj, newMember);
-            }
-        }
-
-        private class ExpressionResolutionResult
-        {
-            public Expression ResolutionExpression { get; private set; }
-            public Type Type { get; private set; }
-
-            public ExpressionResolutionResult(Expression resolutionExpression, Type type)
-            {
-                ResolutionExpression = resolutionExpression;
-                Type = type;
-            }
+            return result;
         }
 
         private class ExpressionRequest : IEquatable<ExpressionRequest>
@@ -412,7 +354,153 @@ namespace AutoMapper.QueryableExtensions
                 return !Equals(left, right);
             }
         }
+    }
 
+    internal interface IExpressionResultConverter
+    {
+        ExpressionResolutionResult GetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult, PropertyMap propertyMap, IValueResolver valueResolver);
+        bool CanGetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult, IValueResolver valueResolver);
+    }
+
+    internal class MemberGetterExpressionResultConverter : IExpressionResultConverter
+    {
+        public ExpressionResolutionResult GetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult, PropertyMap propertyMap, IValueResolver valueResolver)
+        {
+            Expression currentChild = expressionResolutionResult.ResolutionExpression;
+            Type currentChildType = expressionResolutionResult.Type;
+            var getter = valueResolver as IMemberGetter;
+            var memberInfo = getter.MemberInfo;
+
+            var propertyInfo = memberInfo as PropertyInfo;
+            if (propertyInfo != null)
+            {
+                currentChild = Expression.Property(currentChild, propertyInfo);
+                currentChildType = propertyInfo.PropertyType;
+            }
+            else
+                currentChildType = currentChild.Type;
+
+            return new ExpressionResolutionResult(currentChild, currentChildType);
+        }
+
+        public bool CanGetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult, IValueResolver valueResolver)
+        {
+            return valueResolver is IMemberGetter;
+        }
+    }
+
+    internal class NullSubstitutionExpressionResultConverter : IExpressionResultConverter
+    {
+        public ExpressionResolutionResult GetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult, PropertyMap propertyMap, IValueResolver valueResolver)
+        {
+            Expression currentChild = expressionResolutionResult.ResolutionExpression;
+            Type currentChildType = expressionResolutionResult.Type;
+            var nullSubstitute = (valueResolver as NullReplacementMethod).NullSubstitute;
+
+            var newParameter = expressionResolutionResult.ResolutionExpression;
+            var converter = new NullSubstitutionConversionVisitor(newParameter, nullSubstitute);
+
+            currentChild = converter.Visit(currentChild);
+            currentChildType = currentChildType.GetTypeOfNullable();
+
+            return new ExpressionResolutionResult(currentChild, currentChildType);
+        }
+
+        public bool CanGetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult, IValueResolver valueResolver)
+        {
+            return valueResolver is NullReplacementMethod && expressionResolutionResult.Type.IsNullableType();
+        }
+    }
+
+    internal class NullSubstitutionConversionVisitor : ExpressionVisitor
+    {
+        private readonly Expression newParameter;
+        private readonly object _nullSubstitute;
+
+        public NullSubstitutionConversionVisitor(Expression newParameter, object nullSubstitute)
+        {
+            this.newParameter = newParameter;
+            _nullSubstitute = nullSubstitute;
+        }
+
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            if (node == newParameter)
+            {
+                var equalsNull = Expression.Property(newParameter, "HasValue");
+                var nullConst = Expression.Condition(equalsNull, Expression.Property(newParameter, "Value"), Expression.Constant(_nullSubstitute),node.Type.GetTypeOfNullable());
+                return nullConst;
+            }
+            return node;
+        }
+    }
+
+    internal class MemberResolverExpressionResultConverter : IExpressionResultConverter
+    {
+        public ExpressionResolutionResult GetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult, PropertyMap propertyMap, IValueResolver valueResolver)
+        {
+            Expression currentChild = expressionResolutionResult.ResolutionExpression;
+            Type currentChildType = expressionResolutionResult.Type;
+
+            var oldParameter = propertyMap.CustomExpression.Parameters.Single();
+            var newParameter = expressionResolutionResult.ResolutionExpression;
+            var converter = new PrameterConversionVisitor(newParameter, oldParameter);
+
+            currentChild = converter.Visit(propertyMap.CustomExpression.Body);
+            currentChildType = currentChild.Type;
+
+            return new ExpressionResolutionResult(currentChild, currentChildType);
+        }
+
+        public bool CanGetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult, IValueResolver valueResolver)
+        {
+            return valueResolver is IMemberResolver;
+        }
+    }
+
+    /// <summary>
+    /// This expression visitor will replace an input parameter by another one
+    /// 
+    /// see http://stackoverflow.com/questions/4601844/expression-tree-copy-or-convert
+    /// </summary>
+    internal class PrameterConversionVisitor : ExpressionVisitor
+    {
+        private readonly Expression newParameter;
+        private readonly ParameterExpression oldParameter;
+
+        public PrameterConversionVisitor(Expression newParameter, ParameterExpression oldParameter)
+        {
+            this.newParameter = newParameter;
+            this.oldParameter = oldParameter;
+        }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            // replace all old param references with new ones
+            return node.Type == oldParameter.Type ? newParameter : node;
+        }
+
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            if (node.Expression != oldParameter) // if instance is not old parameter - do nothing
+                return base.VisitMember(node);
+
+            var newObj = Visit(node.Expression);
+            var newMember = newParameter.Type.GetMember(node.Member.Name).First();
+            return Expression.MakeMemberAccess(newObj, newMember);
+        }
+    }
+
+    internal class ExpressionResolutionResult
+    {
+        public Expression ResolutionExpression { get; private set; }
+        public Type Type { get; private set; }
+
+        public ExpressionResolutionResult(Expression resolutionExpression, Type type)
+        {
+            ResolutionExpression = resolutionExpression;
+            Type = type;
+        }
     }
 
     /// <summary>

--- a/src/IntegrationTests.Net4/IntegrationTests.Net4.csproj
+++ b/src/IntegrationTests.Net4/IntegrationTests.Net4.csproj
@@ -60,6 +60,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ChildClassTests.cs" />
+    <Compile Include="ProjectTests.cs" />
     <Compile Include="CustomMapFromTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/IntegrationTests.Net4/ProjectTests.cs
+++ b/src/IntegrationTests.Net4/ProjectTests.cs
@@ -1,0 +1,40 @@
+﻿using System.Linq;
+using AutoMapper.QueryableExtensions;
+using Xunit;
+using Should;
+
+namespace AutoMapper.IntegrationTests.Net4
+{
+    namespace ProjectTests
+    {
+        public class Source
+        {
+            public int? Value { get; set; }
+        }
+
+        public class Dest
+        {
+            public int? Value { get; set; }
+        }
+
+        public class UnitTest
+        {
+            public UnitTest()
+            {
+                Mapper.Reset();
+            }
+
+            [Fact]
+            public void NullSubstitution()
+            {
+                Mapper.CreateMap<Source, Dest>()
+                    .ForMember(dest => dest.Value, opt => opt.NullSubstitute(3));
+
+                var sources = new[] {new Source()}.AsQueryable();
+                var dests = sources.Project().To<Dest>().ToList();
+                dests[0].Value.ShouldEqual(3);
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
Solution for Issue #506

Changed ResolvedExpression to go through a list of classes that could possibly resolve it.
Took normal 2 conditions and made own class and added one for null substitution.

If no issues happen throws exception saying can't convert query mapper.
