### PR TITLE
Work around xunit issue which drops everything after dashes.

### DIFF
--- a/src/AutoMapper/AutoMapperConfigurationException.cs
+++ b/src/AutoMapper/AutoMapperConfigurationException.cs
@@ -78,7 +78,8 @@ namespace AutoMapper
                         message.AppendLine(error.TypeMap.SourceType.FullName + " -> " +
                                            error.TypeMap.DestinationType.FullName + " (" + 
                                            error.TypeMap.ConfiguredMemberList + " member list)");
-                        message.AppendLine(new string('-', len));
+                        message.AppendLine();
+                        message.AppendLine("Unmapped properties:");
                         foreach (var name in error.UnmappedPropertyNames)
                         {
                             message.AppendLine(name);


### PR DESCRIPTION
xunit has a problem with rendering exception messages that inclued lines
of dashes in the message. It silently drops everything after the dashes.
This is documented at https://github.com/xunit/xunit/issues/149

This commit adds a slightly more verbose wording to the message
and updates the dashes to a blank line.
