### PR TITLE
Addressing issues with ExpressionMapper logic.

### DIFF
--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -12,14 +12,13 @@
             var destDelegateType = context.DestinationType.GetGenericArguments()[0];
             var expression = (LambdaExpression) context.SourceValue;
 
-            if (sourceDelegateType.GetGenericArguments().Length != destDelegateType.GetGenericArguments().Length)
-                throw new AutoMapperMappingException(
-                    "Source and destination expressions must have same number of generic arguments.");
+            if (sourceDelegateType.GetGenericTypeDefinition() != destDelegateType.GetGenericTypeDefinition())
+                throw new AutoMapperMappingException("Source and destination expressions must be of the same type.");
 
             var parameters = expression.Parameters.ToArray();
             var body = expression.Body;
 
-            for (int i = 0; i < sourceDelegateType.GetGenericArguments().Length; i++)
+            for (int i = 0; i < expression.Parameters.Count; i++)
             {
                 var sourceParamType = sourceDelegateType.GetGenericArguments()[i];
                 var destParamType = destDelegateType.GetGenericArguments()[i];

--- a/src/UnitTests/ExpressionConversion.cs
+++ b/src/UnitTests/ExpressionConversion.cs
@@ -1,4 +1,6 @@
-﻿namespace AutoMapper.UnitTests
+﻿using Xunit.Sdk;
+
+namespace AutoMapper.UnitTests
 {
     using System;
     using System.Linq;
@@ -82,6 +84,35 @@
             };
 
             items.AsQueryable().Where(mapped).Count().ShouldEqual(2);
+        }
+
+        [Fact]
+        public void Throw_AutoMapperMappingException_if_expression_types_dont_match()
+        {
+            Mapper.Initialize(cfg => cfg.CreateMap<Source, Dest>());
+
+            Expression<Func<Dest, bool>> expr = d => d.Bar == 10;
+
+            Assert.Throws<AutoMapperMappingException>(() => Mapper.Map<Expression<Func<Dest, bool>>, Expression<Action<Source, bool>>>(expr));
+        }
+
+        [Fact]
+        public void Can_map_with_different_destination_types()
+        {
+            Mapper.Initialize(cfg => cfg.CreateMap<Source, Dest>().ForMember(d => d.Bar, opt => opt.MapFrom(src => src.Foo)));
+
+            Expression<Func<Dest, Dest>> expr = d => d;
+
+            var mapped = Mapper.Map<Expression<Func<Dest, Dest>>, Expression<Func<Source, Source>>>(expr);
+
+            var items = new[]
+            {
+                new Source {Foo = 10},
+                new Source {Foo = 10},
+                new Source {Foo = 15}
+            };
+
+            var items2 = items.AsQueryable().Select(mapped).ToList();
         }
     }
 }


### PR DESCRIPTION
There are some possible scenarios with solution #294 that would cause weird exceptions to occur.

Things not accounted for were if you were mapping expressions of  functions to expressions of actions with the same amount of variables would get casting exception trying to convert a function to an action.
What this change does is account for it in the same line as the generic parameter count is accounted for so it's now looking at the generic type as a whole instead of the individual parameters.

Also with Func, the last generic variable is return type so there is no parameter for it.  If the last type was different then would get index out of array exception, so I changed to only parameters go through.  Don't think you can change return type at all, just hope there return types match up based on the expression you are going for.

These issues probably won't come up, at least for a good while, but if they do come up the exceptions are going to be very confusing.

On another note my pull request for issue #528 has a mapper that does this same type of thing.  It will need to be removed before before it can be pushed over.
