### PR TITLE
AddGlobalIgnore does not work when the property name exists on both source and destination, but types are not compatible.

### DIFF
--- a/src/UnitTests/IgnoreAllTests.cs
+++ b/src/UnitTests/IgnoreAllTests.cs
@@ -19,6 +19,11 @@ namespace AutoMapper.UnitTests
             public string AnotherString_ShouldBeNullAfterwards { get; set; }
         }
 
+        public class DestinationWrongType
+        {
+            public Destination ShouldBeMapped { get; set; }
+        }
+
         [Fact]
         public void GlobalIgnore_ignores_all_properties_beginning_with_string()
         {
@@ -30,6 +35,19 @@ namespace AutoMapper.UnitTests
 			});
             
             Mapper.Map<Source, Destination>(new Source{ShouldBeMapped = "true"});
+            Mapper.AssertConfigurationIsValid();
+        }
+
+        [Fact]
+        public void GlobalIgnore_ignores_properties_with_names_matching_but_different_types()
+        {
+            Mapper.Initialize(cfg =>
+            {
+                cfg.AddGlobalIgnore("ShouldBeMapped");
+                cfg.CreateMap<Source, DestinationWrongType>();
+            });
+
+            Mapper.Map<Source, Destination>(new Source { ShouldBeMapped = "true" });
             Mapper.AssertConfigurationIsValid();
         }
 


### PR DESCRIPTION
Ran into this issue with AddGlobalIgnore. We have a property name that is in the GlobalIgnore but exists on both the source and destination. The problem is that the types are not compatible, and AddGlobalIgnore does not actually ignore them. It appears from a code review that AddGlobalIgnore is ONLY to satisfy the "AssertConfigurationIsValid" function, it does not appear to actually cause the property to be ignored...
