### PR TITLE
Include with conditions on source type

### DIFF
--- a/src/AutoMapper/AutoMapper.csproj
+++ b/src/AutoMapper/AutoMapper.csproj
@@ -47,7 +47,7 @@
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <DocumentationFile>bin\Debug\AutoMapper.xml</DocumentationFile>
     <NoWarn>1591,0618</NoWarn>
-    <TargetFrameworkProfile>Profile328</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile3</TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -365,7 +365,7 @@ namespace AutoMapper
             {
                 var potentialSourceType = source.GetType();
                 //Try and get the most specific type map possible
-                var potentialTypes = _typeMaps
+                var potentialTypes = _typeMaps.Where(IsTypeMapOrIncludedDerivedType(typeMap))
                     .Where(t => ((destination == null && destinationType.IsAssignableFrom(t.DestinationType))
                                  || (destination != null && t.DestinationType.IsInstanceOfType(destination))) &&
                                 t.SourceType.IsInstanceOfType(source));
@@ -402,7 +402,12 @@ namespace AutoMapper
 		    return typeMap;
 		}
 
-        private static int GetInheritanceDepth(Type type)
+	    private static Func<TypeMap, bool> IsTypeMapOrIncludedDerivedType(TypeMap typeMap)
+	    {
+	        return tm => tm == typeMap || typeMap.IncludedDerivedTypes.Any(itm => itm.SourceType == tm.SourceType && itm.DestinationType == tm.DestinationType);
+	    }
+
+	    private static int GetInheritanceDepth(Type type)
         {
             if (type == null)
                 throw new ArgumentNullException("type");

--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -359,7 +359,7 @@ namespace AutoMapper
                 return FindTypeMapFor(source, destination, sourceType, typeMap.DestinationTypeOverride);
             }
             // Check for runtime derived types
-		    var shouldCheckDerivedType = (typeMap != null) && (typeMap.HasDerivedTypesToInclude()) && (source != null) && (source.GetType() != sourceType);
+		    var shouldCheckDerivedType = (typeMap != null) && (typeMap.HasDerivedTypesToInclude()) && (source != null);
 		    
             if (shouldCheckDerivedType)
             {

--- a/src/AutoMapper/IMappingExpression.cs
+++ b/src/AutoMapper/IMappingExpression.cs
@@ -105,6 +105,15 @@ namespace AutoMapper
             where TOtherDestination : TDestination;
 
         /// <summary>
+        /// Include this configuration in derived types' maps under condition being applied
+        /// </summary>
+        /// <typeparam name="TOtherDestination">Derived destination type</typeparam>
+        /// <returns>Itself</returns>
+        IMappingExpression<TSource, TDestination> IncludeOnSourceType<TOtherDestination>(Func<TSource, bool> condition)
+            where TOtherDestination : TDestination;
+        
+
+        /// <summary>
         /// Include the base type map's configuration in this map
         /// </summary>
         /// <typeparam name="TSourceBase">Base source type</typeparam>

--- a/src/AutoMapper/Internal/MappingExpression.cs
+++ b/src/AutoMapper/Internal/MappingExpression.cs
@@ -231,6 +231,14 @@ namespace AutoMapper
             return setMethod == null || setMethod.IsPrivate || setMethod.IsFamily;
         }
 
+        public static Func<TypePair, ObjectPair, bool> TypesInheritFromBase(Type destinationType)
+        {
+            return (tp, op) =>
+                ((op.Destination == null && destinationType.IsAssignableFrom(tp.DestinationType))
+                 || (op.Destination != null && tp.DestinationType.IsInstanceOfType(op.Destination))) &&
+                tp.SourceType.IsInstanceOfType(op.Source);
+        }
+
         public IMappingExpression<TSource, TDestination> Include<TOtherSource, TOtherDestination>()
             where TOtherSource : TSource
             where TOtherDestination : TDestination
@@ -240,7 +248,7 @@ namespace AutoMapper
 
         public IMappingExpression<TSource, TDestination> Include(Type otherSourceType, Type otherDestinationType)
         {
-            TypeMap.IncludeDerivedTypes(otherSourceType, otherDestinationType);
+            TypeMap.IncludeDerivedTypeUnderCondition(otherSourceType, otherDestinationType, TypesInheritFromBase(typeof(TDestination)));
 
             return this;
         }
@@ -248,7 +256,7 @@ namespace AutoMapper
         public IMappingExpression<TSource, TDestination> IncludeBase<TSourceBase, TDestinationBase>()
         {
             TypeMap baseTypeMap = _configurationContainer.CreateMap<TSourceBase, TDestinationBase>().TypeMap;
-            baseTypeMap.IncludeDerivedTypes(typeof(TSource), typeof(TDestination));
+            baseTypeMap.IncludeDerivedTypeUnderCondition(typeof(TSource), typeof(TDestination), TypesInheritFromBase(typeof(TDestinationBase)));
             TypeMap.ApplyInheritedMap(baseTypeMap);
 
             return this;
@@ -396,7 +404,7 @@ namespace AutoMapper
                 mappingExpression.ForSourceMember(destProperty.DestinationProperty.Name, opt => opt.Ignore());
             }
 
-            foreach (var includedDerivedType in TypeMap.IncludedDerivedTypes)
+            foreach (var includedDerivedType in TypeMap.IncludedDerivedTypes.Select(kp => kp.Key))
             {
                 mappingExpression.Include(includedDerivedType.DestinationType, includedDerivedType.SourceType);
             }

--- a/src/AutoMapper/Internal/MappingExpression.cs
+++ b/src/AutoMapper/Internal/MappingExpression.cs
@@ -249,7 +249,7 @@ namespace AutoMapper
         public IMappingExpression<TSource, TDestination> IncludeOnSourceType<TOtherDestination>(Func<TSource, bool> condition)
             where TOtherDestination : TDestination
         {
-            return IncludeOnCondition(typeof(TSource), typeof(TOtherDestination), (tp, op) => condition((TSource)op.Source));
+            return IncludeOnCondition(typeof(TSource), typeof(TOtherDestination), (tp, op) => condition((TSource)op.Source) && op.Destination == null || op.Destination is TDestination);
         }
 
         public IMappingExpression<TSource, TDestination> Include(Type otherSourceType, Type otherDestinationType)

--- a/src/AutoMapper/Internal/MappingExpression.cs
+++ b/src/AutoMapper/Internal/MappingExpression.cs
@@ -246,9 +246,20 @@ namespace AutoMapper
             return Include(typeof(TOtherSource), typeof(TOtherDestination));
         }
 
+        public IMappingExpression<TSource, TDestination> IncludeOnSourceType<TOtherDestination>(Func<TSource, bool> condition)
+            where TOtherDestination : TDestination
+        {
+            return IncludeOnCondition(typeof(TSource), typeof(TOtherDestination), (tp, op) => condition((TSource)op.Source));
+        }
+
         public IMappingExpression<TSource, TDestination> Include(Type otherSourceType, Type otherDestinationType)
         {
-            TypeMap.IncludeDerivedTypeUnderCondition(otherSourceType, otherDestinationType, TypesInheritFromBase(typeof(TDestination)));
+            return IncludeOnCondition(otherSourceType, otherDestinationType, TypesInheritFromBase(typeof(TDestination)));
+        }
+
+        private IMappingExpression<TSource, TDestination> IncludeOnCondition(Type otherSourceType, Type otherDestinationType, Func<TypePair, ObjectPair, bool> condition)
+        {
+            TypeMap.IncludeDerivedTypeUnderCondition(otherSourceType, otherDestinationType, condition);
 
             return this;
         }

--- a/src/AutoMapper/Internal/TypePair.cs
+++ b/src/AutoMapper/Internal/TypePair.cs
@@ -44,4 +44,46 @@ namespace AutoMapper.Impl
             return _hashcode;
         }
     }
+
+    public struct ObjectPair : IEquatable<ObjectPair>
+    {
+        public ObjectPair(object sourceObject, object destinationObject)
+            : this()
+        {
+            _sourceObject = sourceObject;
+            _destinationObject = destinationObject;
+            _hashcode = unchecked(((_sourceObject == null ? 0 : _sourceObject.GetHashCode()) * 397) ^ (_destinationObject == null ? 0 : destinationObject.GetHashCode()));
+        }
+
+        private readonly object _destinationObject;
+        private readonly int _hashcode;
+        private readonly object _sourceObject;
+
+        public object Source
+        {
+            get { return _sourceObject; }
+        }
+
+        public object Destination
+        {
+            get { return _destinationObject; }
+        }
+
+        public bool Equals(ObjectPair other)
+        {
+            return Equals(other._sourceObject, _sourceObject) && Equals(other._destinationObject, _destinationObject);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (obj.GetType() != typeof(TypePair)) return false;
+            return Equals((TypePair)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return _hashcode;
+        }
+    }
 }

--- a/src/UnitTests/Bug/IncludeWillMapToUnincludedMappings.cs
+++ b/src/UnitTests/Bug/IncludeWillMapToUnincludedMappings.cs
@@ -1,0 +1,48 @@
+﻿using Should;
+using Xunit;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public class When_mapping_multiple_maps_off_a_base_but_not_including_them_all : AutoMapperSpecBase
+    {
+        [Fact]
+        public void Should_ignore_inheritance_from_unincluded_types()
+        {
+            Mapper.CreateMap<A, A1>().Include<B, B1>();
+            Mapper.CreateMap<B, B1>();
+            Mapper.CreateMap<C, C1>();
+
+            Mapper.Map<A, A1>(new C()).ShouldBeType<A1>();
+        }
+
+        public class A
+        {
+            
+        }
+
+        public class B : A
+        {
+            
+        }
+
+        public class C : A
+        {
+            
+        }
+
+        public class A1
+        {
+
+        }
+
+        public class B1 : A1
+        {
+
+        }
+
+        public class C1 : A1
+        {
+
+        }
+    }
+}

--- a/src/UnitTests/InheritanceByCondition.cs
+++ b/src/UnitTests/InheritanceByCondition.cs
@@ -1,0 +1,41 @@
+﻿using Should;
+using Xunit;
+
+namespace AutoMapper.UnitTests
+{
+    public class InheritanceByCondition : AutoMapperSpecBase
+    {
+        [Fact]
+        public void AddConditionInTheIncludeMethod()
+        {
+            Mapper.CreateMap<DTOParty, Party>()
+                .IncludeOnSourceType<SomeParty>(source => source.PartyTypeDiscriminatorValue == 1)
+                .IncludeOnSourceType<SomeOtherParty>(source => source.PartyTypeDiscriminatorValue == 2);
+            Mapper.CreateMap<DTOParty, SomeParty>();
+            Mapper.CreateMap<DTOParty, SomeOtherParty>();
+
+            var party = new DTOParty() { PartyTypeDiscriminatorValue = 2 };
+
+            var result = Mapper.Map<DTOParty, Party>(party);
+            result.ShouldBeType<SomeOtherParty>();
+        }
+
+    }
+
+    public class SomeOtherParty : SomeParty
+    {
+    }
+
+    public class SomeParty : Party
+    {
+    }
+
+    public class Party
+    {
+    }
+
+    public class DTOParty
+    {
+        public int PartyTypeDiscriminatorValue { get; set; }
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -106,6 +106,7 @@
     <Compile Include="Bug\EnumMatchingOnValue.cs" />
     <Compile Include="Bug\ExistingArrays.cs" />
     <Compile Include="Bug\IgnoreAll.cs" />
+    <Compile Include="Bug\IncludeWillMapToUnincludedMappings.cs" />
     <Compile Include="Bug\InheritanceIssue.cs" />
     <Compile Include="Bug\InterfaceSelfMappingBug.cs" />
     <Compile Include="Bug\ListSourceMapperBug.cs" />

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -148,6 +148,7 @@
     <Compile Include="ExpressionConversion.cs" />
     <Compile Include="ExtensionMethods.cs" />
     <Compile Include="IgnoreAllTests.cs" />
+    <Compile Include="InheritanceByCondition.cs" />
     <Compile Include="Internal\DelegateFactoryTests.cs" />
     <Compile Include="Dictionaries.cs" />
     <Compile Include="DynamicMapping.cs" />


### PR DESCRIPTION
Addresses issue #258

Added IncludeOnSourceType function which will map to destination if source condition is met.

Had to do a lot of internal re-factoring in multiple commits to show an underlying problem with how includes were handled, and then add the ability to specify conditions, default before which was did the types inherit, and now condition from the source to determine how to map to the destination.

Before it wasn't using the includedDeriveTypes as part of the possible included mappings, only whether one existed or not.  Ergo it assumed that if there were included types it would include them all.
So now it's going on the condition that type map must match types of included TypePair, as well as meet its condition to say the type map is applicable to be mapped over.

This pull request might need a few changes.  Better name for the new Include function call, internal re-ordering of include functionality, ect...  But this will allow #258 to be possible, along with others to make their own extensions off the Include(type, type, condition) for whatever scenario they might want, not just checking source and destination types.