### PR TITLE
Consistent ResolveUsing and ConvertUsing interfaces

### DIFF
--- a/src/AutoMapper/IMappingExpression.cs
+++ b/src/AutoMapper/IMappingExpression.cs
@@ -140,6 +140,18 @@ namespace AutoMapper
         void ConvertUsing(Func<TSource, TDestination> mappingFunction);
 
         /// <summary>
+        /// Skip member mapping and use a custom function to convert to the destination type
+        /// </summary>
+        /// <param name="mappingFunction">Callback to convert from source type to destination type</param>
+        void ConvertUsing(Func<ResolutionContext, TDestination> mappingFunction);
+
+        /// <summary>
+        /// Skip member mapping and use a custom function to convert to the destination type
+        /// </summary>
+        /// <param name="mappingFunction">Callback to convert from source type to destination type</param>
+        void ConvertUsing(Func<ResolutionContext, TSource, TDestination> mappingFunction);
+
+        /// <summary>
         /// Skip member mapping and use a custom type converter instance to convert to the destination type
         /// </summary>
         /// <param name="converter">Type converter instance</param>
@@ -374,6 +386,14 @@ namespace AutoMapper
         /// </summary>
         /// <param name="resolver">Callback function to resolve against source type</param>
         void ResolveUsing(Func<ResolutionResult, object> resolver);
+
+        /// <summary>
+        /// Resolve destination member using a custom value resolver callback. Used instead of MapFrom when not simply redirecting a source member
+        /// Access both the source object and current resolution context for additional mapping, context items and parent objects
+        /// This method cannot be used in conjunction with LINQ query projection
+        /// </summary>
+        /// <param name="resolver">Callback function to resolve against source type</param>
+        void ResolveUsing(Func<ResolutionResult, TSource, object> resolver);
 
         /// <summary>
         /// Specify the source member to map from. Can only reference a member on the <typeparamref name="TSource"/> type

--- a/src/AutoMapper/Internal/MappingExpression.cs
+++ b/src/AutoMapper/Internal/MappingExpression.cs
@@ -334,6 +334,11 @@ namespace AutoMapper
             _propertyMap.AssignCustomValueResolver(new DelegateBasedResolver<TSource>(resolver));
         }
 
+        public void ResolveUsing(Func<ResolutionResult, TSource, object> resolver)
+        {
+            _propertyMap.AssignCustomValueResolver(new DelegateBasedResolver<TSource>(r => resolver(r, (TSource)r.Value)));
+        }
+
         public void MapFrom<TMember>(Expression<Func<TSource, TMember>> sourceMember)
         {
             _propertyMap.SetCustomValueResolverExpression(sourceMember);

--- a/src/UnitTests/TypeConverters.cs
+++ b/src/UnitTests/TypeConverters.cs
@@ -46,7 +46,7 @@ namespace AutoMapper.UnitTests
 
 			protected override void Establish_context()
 			{
-				Mapper.CreateMap<string, int>().ConvertUsing(arg => Convert.ToInt32(arg));
+				Mapper.CreateMap<string, int>().ConvertUsing((string arg) => Convert.ToInt32(arg));
 				Mapper.CreateMap<string, DateTime>().ConvertUsing(new DateTimeTypeConverter());
 				Mapper.CreateMap<string, Type>().ConvertUsing<TypeTypeConverter>();
 

--- a/src/UnitTests/ValueTypes.cs
+++ b/src/UnitTests/ValueTypes.cs
@@ -61,7 +61,7 @@ namespace AutoMapper.UnitTests
 
             protected override void Establish_context()
             {
-                Mapper.CreateMap<string, int>().ConvertUsing(Convert.ToInt32);
+                Mapper.CreateMap<string, int>().ConvertUsing((string s) => Convert.ToInt32(s));
                 Mapper.CreateMap<Source, Destination>();
             }
 


### PR DESCRIPTION
Commit 8b3bc93 (described in #445) added an option to do `ResolveUsing` with a delegate that accepts `ResolutionResult`. I further extended this with an option of a delegate that accepts `ResolutionResult, Source`. I also added (in fact, just pushed to public) same overloads for `ConvertUsing`.

So, as a result, following methods are now available:

````c#
void ResolveUsing(Func<TSource, object> resolver);
void ResolveUsing(Func<ResolutionResult, object> resolver);
void ResolveUsing(Func<ResolutionResult, TSource, object> resolver);

void ConvertUsing(Func<TSource, TDestination> mappingFunction);
void ConvertUsing(Func<ResolutionContext, TDestination> mappingFunction);
void ConvertUsing(Func<ResolutionContext, TSource, TDestination> mappingFunction);
````

PS All that started because I needed `ConvertUsing(Func<ResolutionContext, TSource, TDestination> mappingFunction)` in my project.
