### PR TITLE
Generic ForMember() and ForSourceMember() do not work when using an inherited interface

### DIFF
--- a/src/AutoMapper/Internal/MappingExpression.cs
+++ b/src/AutoMapper/Internal/MappingExpression.cs
@@ -179,6 +179,7 @@ namespace AutoMapper
                                                                    Action<IMemberConfigurationExpression<TSource>> memberOptions)
         {
             var memberInfo = ReflectionHelper.FindProperty(destinationMember);
+            memberInfo = ReflectionHelper.TryGetImplementedMember(TypeMap.DestinationType, memberInfo);
             IMemberAccessor destProperty = memberInfo.ToMemberAccessor();
             ForDestinationMember(destProperty, memberOptions);
             return new MappingExpression<TSource, TDestination>(TypeMap, _serviceCtor, _configurationContainer);

--- a/src/AutoMapper/Internal/MappingExpression.cs
+++ b/src/AutoMapper/Internal/MappingExpression.cs
@@ -408,6 +408,7 @@ namespace AutoMapper
         public IMappingExpression<TSource, TDestination> ForSourceMember(Expression<Func<TSource, object>> sourceMember, Action<ISourceMemberConfigurationExpression<TSource>> memberOptions)
         {
             var memberInfo = ReflectionHelper.FindProperty(sourceMember);
+            memberInfo = ReflectionHelper.TryGetImplementedMember(TypeMap.SourceType, memberInfo);
 
             var srcConfig = new SourceMappingExpression(TypeMap, memberInfo);
 

--- a/src/AutoMapper/Internal/ReflectionHelper.cs
+++ b/src/AutoMapper/Internal/ReflectionHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Linq;
 
 namespace AutoMapper.Impl
 {
@@ -41,6 +42,35 @@ namespace AutoMapper.Impl
             }
 
             throw new AutoMapperConfigurationException("Custom configuration for members is only supported for top-level individual members on a type.");
+        }
+
+        public static MemberInfo TryGetImplementedMember(Type implementationType, MemberInfo memberInfo)
+        {
+            var isImplementedMember = memberInfo != null &&
+                                      implementationType != memberInfo.DeclaringType &&
+                                      memberInfo.DeclaringType.IsAssignableFrom(implementationType);
+            if (!isImplementedMember)
+            {
+                return memberInfo;
+            }
+
+            var propertyInfo = memberInfo as PropertyInfo;
+            if (propertyInfo != null)
+            {
+                var implementedProperty = implementationType.GetProperties()
+                    .SingleOrDefault(p => p.Name == propertyInfo.Name && p.PropertyType == propertyInfo.PropertyType);
+                return implementedProperty;
+            }
+
+            var fieldInfo = memberInfo as FieldInfo;
+            if (fieldInfo != null)
+            {
+                var implementedField = implementationType.GetFields()
+                    .SingleOrDefault(f => f.Name == fieldInfo.Name && f.FieldType == fieldInfo.FieldType);
+                return implementedField;
+            }
+
+            return memberInfo;
         }
 
         public static Type GetMemberType(this MemberInfo memberInfo)

--- a/src/UnitTests/Bug/ForMemberWrappedInAGenericExtensionMethodBug.cs
+++ b/src/UnitTests/Bug/ForMemberWrappedInAGenericExtensionMethodBug.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+using Should;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public class ForMemberWrappedInAGenericExtensionMethodBug : SpecBase
+    {
+        abstract class DestinationModelBase
+        {
+            // Must have different property names so that auto-mapping doesn't
+            // occur.
+            public virtual int DstId { get; set; }
+            public virtual string DstFirstName { get; set; }
+            public string DstLastName = null;
+        }
+
+        interface IDestinationModel
+        {
+            int DstId { get; }
+            string DstFirstName { get; }
+            string DstLastName { get; }
+        }
+
+        class SourceModel
+        {
+            public int Id { get; set; }
+            public string FirstName { get; set; }
+            public string LastName;
+        }
+
+        class DestinationModelFromAbstract : DestinationModelBase
+        {
+            
+        }
+
+        class DestinationModelFromInterface : IDestinationModel
+        {
+            public int DstId { get; set; }
+            public string DstFirstName { get; set; }
+            public string DstLastName { get; set; }
+        }
+
+        [Fact]
+        public void maps_all_properties_when_destination_properties_are_from_abstract_class()
+        {
+            Mapper.Initialize(mapper =>
+            {
+                var expression = mapper.CreateMap<SourceModel, DestinationModelFromAbstract>();
+                ExtensionForMemberAbstract(expression);
+            });
+            var source = new SourceModel() { Id = 12345, FirstName = "John", LastName = "Doe" };
+
+            var destination = Mapper.Map<DestinationModelFromAbstract>(source);
+
+            destination.DstId.ShouldEqual(12345);
+            destination.DstFirstName.ShouldEqual("John");
+            destination.DstLastName.ShouldEqual("Doe");
+        }
+
+        private static IMappingExpression<SourceModel, TDestination> ExtensionForMemberAbstract<TDestination>(IMappingExpression<SourceModel, TDestination> expression)
+            where TDestination : DestinationModelBase
+        {
+            return expression.ForMember(dst => dst.DstId, cfg => cfg.MapFrom(src => src.Id))
+                             .ForMember(dst => dst.DstFirstName, cfg => cfg.MapFrom(src => src.FirstName))
+                             .ForMember(dst => dst.DstLastName, cfg => cfg.MapFrom(src => src.LastName));
+        }
+
+        [Fact]
+        public void maps_all_properties_when_destination_properties_are_from_interface()
+        {
+            Mapper.Initialize(mapper =>
+            {
+                var expression = mapper.CreateMap<SourceModel, DestinationModelFromInterface>();
+                ExtensionForMemberInterface(expression);
+            });
+            var source = new SourceModel() { Id = 12345, FirstName = "John", LastName = "Doe" };
+
+            var destination = Mapper.Map<DestinationModelFromInterface>(source);
+
+            destination.DstId.ShouldEqual(12345);
+            destination.DstFirstName.ShouldEqual("John");
+            destination.DstLastName.ShouldEqual("Doe");
+        }
+
+        private static IMappingExpression<SourceModel, TDestination> ExtensionForMemberInterface<TDestination>(IMappingExpression<SourceModel, TDestination> expression)
+            where TDestination : IDestinationModel
+        {
+            return expression.ForMember(dst => dst.DstId, cfg => cfg.MapFrom(src => src.Id))
+                             .ForMember(dst => dst.DstFirstName, cfg => cfg.MapFrom(src => src.FirstName))
+                             .ForMember(dst => dst.DstLastName, cfg => cfg.MapFrom(src => src.LastName));
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Bug\EnumConditionsBug.cs" />
     <Compile Include="Bug\EnumMatchingOnValue.cs" />
     <Compile Include="Bug\ExistingArrays.cs" />
+    <Compile Include="Bug\ForMemberWrappedInAGenericExtensionMethodBug.cs" />
     <Compile Include="Bug\IgnoreAll.cs" />
     <Compile Include="Bug\InheritanceIssue.cs" />
     <Compile Include="Bug\InterfaceSelfMappingBug.cs" />

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -105,7 +105,7 @@
     <Compile Include="Bug\EnumConditionsBug.cs" />
     <Compile Include="Bug\EnumMatchingOnValue.cs" />
     <Compile Include="Bug\ExistingArrays.cs" />
-    <Compile Include="Bug\ForMemberWrappedInAGenericExtensionMethodBug.cs" />
+    <Compile Include="Bug\ForMemberAndForSourceMemberGenericsBug.cs" />
     <Compile Include="Bug\IgnoreAll.cs" />
     <Compile Include="Bug\InheritanceIssue.cs" />
     <Compile Include="Bug\InterfaceSelfMappingBug.cs" />


### PR DESCRIPTION
If a destination model implements an interface that is to be re-used on other models, we sometimes wrap it in an extension method for mapping:

```csharp
public static IMappingExpression<TSource, TDestination> MapAsCommonDestination<TSource, TDestination>(this IMappingExpression<TSource, TDestination> expression, Expression<Func<TSource, SomeObject>> objectSelector)
    where TDestination : ICommonDestination
{
    return expression.ForMember(dst => dst.Common1, cfg => cfg.ResolveUsing(src => objectSelector(src).Property1))
                     .ForMember(dst => dst.Common2, cfg => cfg.ResolveUsing(src => objectSelector(src).Property2));
}
```

Which we then use in our mappings:

```csharp
CreateMap<FooBar1, CommonDestinationUse1>()
  .MapAsCommonDestination(src => src.SomeObject1);

CreateMap<FooBar2, CommonDestinationUse2>()
  .MapAsCommonDestination(src => src.SomeObject2);
```

This allows us to group together some `ForMember()` where we have some common mapping to reduce code duplication.

Currently, AutoMapper ignores these properties mapped from the interface because the members from the interface (`Common1` and `Common2` in this example above) [do not have the same `DeclaringType` as the `TypeMap`'s `DestinationType`](https://github.com/AutoMapper/AutoMapper/blob/de2aa09f18738ad37b339ba9bfbba644ab4611a8/src/AutoMapper/Internal/MappingExpression.cs#L181). They get ignored.

If we use the string versions of `ForMember()` or `ForSourceMember()`, everything behaves as expected.

This pull request ensures that the generic versions of `ForMember()` and `ForSourceMember()` behave the same as the string counterparts by checking if the member is declared on the wrong type and then finds the matching member of the `TypeMap`'s `DestinationType`.