### PR TITLE
Fix ExpressionMapper error for sub property expression conversion

### DIFF
--- a/src/AutoMapper/Internal/ReflectionHelper.cs
+++ b/src/AutoMapper/Internal/ReflectionHelper.cs
@@ -83,5 +83,18 @@ namespace AutoMapper.Impl
 
 			return null;
 		}
+
+        public static bool IsStatic(this MemberInfo accessorCandidate)
+        {
+            var fieldInfo = accessorCandidate as FieldInfo;
+            if (fieldInfo != null && fieldInfo.IsStatic)
+                return true;
+
+            var propertyInfo = accessorCandidate as PropertyInfo;
+            if (propertyInfo != null && ((propertyInfo.CanRead && propertyInfo.GetGetMethod().IsStatic) || (propertyInfo.CanWrite && propertyInfo.GetSetMethod().IsStatic)))
+                return true;
+
+            return false;
+        }
 	}
 }

--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -255,6 +255,9 @@ namespace AutoMapper.Mappers
 
             private PropertyMap PropertyMap(MemberExpression node)
             {
+                if (node.Member.IsStatic())
+                    return null;
+
                 var memberAccessor = node.Member.ToMemberAccessor();
                 var propertyMap = _typeMap.GetExistingPropertyMapFor(memberAccessor);
                 return propertyMap;

--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -67,6 +67,8 @@ namespace AutoMapper.Mappers
 
             private MethodCallExpression GetConvertedMethodCall(MethodCallExpression node)
             {
+                if (!node.Method.IsGenericMethod)
+                    return node;
                 var convertedArguments = Visit(node.Arguments);
                 var convertedMethodArgumentTypes = node.Method.GetGenericArguments().Select(t => GetConvertingTypeIfExists(node.Arguments, t, convertedArguments)).ToArray();
                 var convertedMethodCall = node.Method.GetGenericMethodDefinition().MakeGenericMethod(convertedMethodArgumentTypes);

--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -162,7 +162,11 @@ namespace AutoMapper.Mappers
                 var baseExpression = Visit(node.Expression);
                 var propertyMap = FindPropertyMapOfExpression(node.Expression as MemberExpression);
 
-                var typeMap = Mapper.FindTypeMapFor(propertyMap.SourceMember.GetMemberType(), propertyMap.DestinationPropertyType);
+                var sourceType = propertyMap.SourceMember.GetMemberType();
+                var destType = propertyMap.DestinationPropertyType;
+                if (sourceType == destType)
+                    return Expression.MakeMemberAccess(baseExpression, node.Member);
+                var typeMap = Mapper.FindTypeMapFor(sourceType, destType);
                 var memberExpression = new MappingVisitor(typeMap, node.Expression, baseExpression).Visit(node) as MemberExpression;
 
                 return Expression.MakeMemberAccess(baseExpression,memberExpression.Member);

--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -67,7 +67,7 @@ namespace AutoMapper.Mappers
 
             private MethodCallExpression GetConvertedMethodCall(MethodCallExpression node)
             {
-                var convertedArguments = node.Arguments.Select(e => base.Visit(e)).ToList();
+                var convertedArguments = Visit(node.Arguments);
                 var convertedMethodArgumentTypes = node.Method.GetGenericArguments().Select(t => GetConvertingTypeIfExists(node.Arguments, t, convertedArguments)).ToArray();
                 var convertedMethodCall = node.Method.GetGenericMethodDefinition().MakeGenericMethod(convertedMethodArgumentTypes);
                 return Expression.Call(convertedMethodCall, convertedArguments);
@@ -107,7 +107,6 @@ namespace AutoMapper.Mappers
 
             private Expression VisitAllParametersExpression<T>(Expression<T> expression)
             {
-                var parameters = expression.Parameters.ToArray();
                 var visitors = new List<ExpressionVisitor>();
                 for (var i = 0; i < expression.Parameters.Count; i++)
                 {
@@ -128,7 +127,6 @@ namespace AutoMapper.Mappers
 
                     var oldParam = expression.Parameters[i];
                     var newParam = Expression.Parameter(typeMap.SourceType, oldParam.Name);
-                    parameters[i] = newParam;
                     visitors.Add(new MappingVisitor(typeMap, oldParam, newParam));
                 }
                 return visitors.Aggregate(expression as Expression, (e, v) => v.Visit(e));

--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
+using AutoMapper.Internal;
 using AutoMapper.QueryableExtensions.Impl;
 
 namespace AutoMapper.Mappers
@@ -34,23 +35,25 @@ namespace AutoMapper.Mappers
 
         private class MappingVisitor : ExpressionVisitor
         {
-            private IList<Type> _destSubTypes;
+            private IList<Type> _destSubTypes = new Type[0];
 
             private readonly TypeMap _typeMap;
             private readonly Expression _oldParam;
             private readonly Expression _newParam;
+            private readonly MappingVisitor _parentMappingVisitor;
 
             public MappingVisitor(IList<Type> destSubTypes)
-                : this(null, Expression.Parameter(typeof(Nullable)), Expression.Parameter(typeof(Nullable)) )
+                : this(null, Expression.Parameter(typeof(Nullable)), Expression.Parameter(typeof(Nullable)), null)
             {
                 _destSubTypes = destSubTypes;
             }
 
-            private MappingVisitor(TypeMap typeMap, Expression oldParam, Expression newParam)
+            private MappingVisitor(TypeMap typeMap, Expression oldParam, Expression newParam, MappingVisitor parentMappingVisitor)
             {
                 _typeMap = typeMap;
                 _oldParam = oldParam;
                 _newParam = newParam;
+                _parentMappingVisitor = parentMappingVisitor;
             }
 
             protected override Expression VisitParameter(ParameterExpression node)
@@ -93,6 +96,68 @@ namespace AutoMapper.Mappers
                 return arguments[index2].Type.GetGenericArguments()[0];
             }
 
+            protected override Expression VisitBinary(BinaryExpression node)
+            {
+                var newLeft = base.Visit(node.Left);
+                var newRight = base.Visit(node.Right);
+
+                CheckNullableToNonNullableChanges(node.Left, node.Right, ref newLeft, ref newRight);
+                CheckNullableToNonNullableChanges(node.Right, node.Left, ref newRight, ref newLeft);
+                return Expression.MakeBinary(node.NodeType, newLeft, newRight);
+            }
+
+            private static void CheckNullableToNonNullableChanges(Expression left, Expression right, ref Expression newLeft, ref Expression newRight)
+            {
+                if (GoingFromNonNullableToNullable(left, newLeft))
+                    if (BothAreNonNullable(right, newRight))
+                        UpdateToNullableExpression(right, out newRight);
+                    else if (BothAreNullable(right, newRight))
+                        UpdateToNonNullableExpression(right, out newRight);
+
+                if (GoingFromNonNullableToNullable(newLeft, left))
+                    if (BothAreNonNullable(right, newRight))
+                        UpdateToNullableExpression(right, out newRight);
+                    else if (BothAreNullable(right, newRight))
+                        UpdateToNonNullableExpression(right, out newRight);
+            }
+
+            private static void UpdateToNullableExpression(Expression right, out Expression newRight)
+            {
+                if (right is ConstantExpression)
+                    newRight = Expression.Constant((right as ConstantExpression).Value,
+                        typeof (Nullable<>).MakeGenericType(right.Type));
+                else
+                    throw new AutoMapperMappingException(
+                        "Mapping a BinaryExpression where one side is nullable and the other isn't");
+            }
+
+            private static void UpdateToNonNullableExpression(Expression right, out Expression newRight)
+            {
+                if (right is ConstantExpression)
+                    newRight = Expression.Constant((right as ConstantExpression).Value,
+                        typeof(Nullable<>).MakeGenericType(right.Type));
+                else if (right is UnaryExpression)
+                    newRight = (right as UnaryExpression).Operand;
+                else
+                    throw new AutoMapperMappingException(
+                        "Mapping a BinaryExpression where one side is nullable and the other isn't");
+            }
+
+            private static bool GoingFromNonNullableToNullable(Expression node, Expression newLeft)
+            {
+                return !node.Type.IsNullableType() && newLeft.Type.IsNullableType();
+            }
+
+            private static bool BothAreNullable(Expression node, Expression newLeft)
+            {
+                return node.Type.IsNullableType() && newLeft.Type.IsNullableType();
+            }
+
+            private static bool BothAreNonNullable(Expression node, Expression newLeft)
+            {
+                return !node.Type.IsNullableType() && !newLeft.Type.IsNullableType();
+            }
+
             protected override Expression VisitLambda<T>(Expression<T> expression)
             {
                 if (expression.Parameters.Any(b => b.Type == _oldParam.Type))
@@ -113,23 +178,17 @@ namespace AutoMapper.Mappers
                 for (var i = 0; i < expression.Parameters.Count; i++)
                 {
                     var sourceParamType = expression.Parameters[i].Type;
-                    if (_destSubTypes.Count <= i)
-                        continue;
-                    var destParamType = _destSubTypes[i];
-                    if (sourceParamType == destParamType)
-                        continue;
+                    foreach (var destParamType in _destSubTypes.Where(dt => dt != sourceParamType))
+                    {
+                        var typeMap = Mapper.FindTypeMapFor(destParamType, sourceParamType);
 
-                    var typeMap = Mapper.FindTypeMapFor(destParamType, sourceParamType);
+                        if (typeMap == null)
+                            continue;
 
-                    if (typeMap == null)
-                        throw new AutoMapperMappingException(
-                            string.Format(
-                                "Could not find type map from destination type {0} to source type {1}. Use CreateMap to create a map from the source to destination types.",
-                                destParamType, sourceParamType));
-
-                    var oldParam = expression.Parameters[i];
-                    var newParam = Expression.Parameter(typeMap.SourceType, oldParam.Name);
-                    visitors.Add(new MappingVisitor(typeMap, oldParam, newParam));
+                        var oldParam = expression.Parameters[i];
+                        var newParam = Expression.Parameter(typeMap.SourceType, oldParam.Name);
+                        visitors.Add(new MappingVisitor(typeMap, oldParam, newParam, this));
+                    }
                 }
                 return visitors.Aggregate(expression as Expression, (e, v) => v.Visit(e));
             }
@@ -149,14 +208,27 @@ namespace AutoMapper.Mappers
                 SetSorceSubTypes(propertyMap);
 
                 var replacedExpression = Visit(node.Expression);
+                if (replacedExpression == node.Expression)
+                    replacedExpression = _parentMappingVisitor.Visit(node.Expression);
 
                 if (propertyMap.CustomExpression != null)
                     return ConvertCustomExpression(replacedExpression, propertyMap);
-                
+
+                Func<Expression,IMemberGetter,Expression> getExpression = (current, memberGetter) => Expression.MakeMemberAccess(current, memberGetter.MemberInfo);
+
+                //if (propertyMap.SourceMember.ToMemberGetter().MemberType.IsNullableType())
+                //{
+                //    var expression = getExpression;
+                //    getExpression = (current, memberGetter) => Expression.Call(expression.Invoke(current,memberGetter), "GetValueOrDefault", new Type[0], new Expression[0]);
+                //}
+                //else if (propertyMap.DestinationPropertyType.IsNullableType())
+                //{
+
+                //}
+
                 return propertyMap.GetSourceValueResolvers()
                     .OfType<IMemberGetter>()
-                    .Aggregate(replacedExpression,
-                        (current, memberGetter) => Expression.MakeMemberAccess(current, memberGetter.MemberInfo));
+                    .Aggregate(replacedExpression, getExpression);
             }
 
             private Expression GetConvertedSubMemberCall(MemberExpression node)
@@ -169,9 +241,8 @@ namespace AutoMapper.Mappers
                 if (sourceType == destType)
                     return Expression.MakeMemberAccess(baseExpression, node.Member);
                 var typeMap = Mapper.FindTypeMapFor(sourceType, destType);
-                var memberExpression = new MappingVisitor(typeMap, node.Expression, baseExpression).Visit(node) as MemberExpression;
-
-                return Expression.MakeMemberAccess(baseExpression,memberExpression.Member);
+                var newExpression = new MappingVisitor(typeMap, node.Expression, baseExpression, this).Visit(node);
+                return newExpression;
             }
 
             private PropertyMap FindPropertyMapOfExpression(MemberExpression expression)
@@ -192,7 +263,7 @@ namespace AutoMapper.Mappers
             private void SetSorceSubTypes(PropertyMap propertyMap)
             {
                 if (propertyMap.SourceMember is PropertyInfo)
-                    _destSubTypes = (propertyMap.SourceMember as PropertyInfo).PropertyType.GetGenericArguments();
+                    _destSubTypes = (propertyMap.SourceMember as PropertyInfo).PropertyType.GetGenericArguments().Concat(new []{ (propertyMap.SourceMember as PropertyInfo).PropertyType }).ToList();
                 else if (propertyMap.SourceMember is FieldInfo)
                     _destSubTypes = (propertyMap.SourceMember as FieldInfo).FieldType.GetGenericArguments();
             }

--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -1,4 +1,9 @@
-﻿namespace AutoMapper.Mappers
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using AutoMapper.QueryableExtensions.Impl;
+
+namespace AutoMapper.Mappers
 {
     using System.Linq;
     using System.Linq.Expressions;
@@ -15,32 +20,8 @@
             if (sourceDelegateType.GetGenericTypeDefinition() != destDelegateType.GetGenericTypeDefinition())
                 throw new AutoMapperMappingException("Source and destination expressions must be of the same type.");
 
-            var parameters = expression.Parameters.ToArray();
-            var body = expression.Body;
-
-            for (int i = 0; i < expression.Parameters.Count; i++)
-            {
-                var sourceParamType = sourceDelegateType.GetGenericArguments()[i];
-                var destParamType = destDelegateType.GetGenericArguments()[i];
-
-                if (sourceParamType == destParamType)
-                    continue;
-
-                var typeMap = mapper.ConfigurationProvider.FindTypeMapFor(destParamType, sourceParamType);
-
-                if (typeMap == null)
-                    throw new AutoMapperMappingException(
-                        string.Format(
-                            "Could not find type map from destination type {0} to source type {1}. Use CreateMap to create a map from the source to destination types.",
-                            destParamType, sourceParamType));
-
-                var oldParam = expression.Parameters[i];
-                var newParam = Expression.Parameter(typeMap.SourceType, oldParam.Name);
-                parameters[i] = newParam;
-                var visitor = new MappingVisitor(typeMap, oldParam, newParam);
-                body = visitor.Visit(body);
-            }
-            return Expression.Lambda(body, parameters);
+            var mappingVisitor = new MappingVisitor(destDelegateType.GetGenericArguments());
+            return mappingVisitor.Visit(expression);
         }
 
         public bool IsMatch(ResolutionContext context)
@@ -53,11 +34,19 @@
 
         private class MappingVisitor : ExpressionVisitor
         {
-            private readonly TypeMap _typeMap;
-            private readonly ParameterExpression _oldParam;
-            private readonly ParameterExpression _newParam;
+            private IList<Type> _destSubTypes;
 
-            public MappingVisitor(TypeMap typeMap, ParameterExpression oldParam, ParameterExpression newParam)
+            private readonly TypeMap _typeMap;
+            private readonly Expression _oldParam;
+            private readonly Expression _newParam;
+
+            public MappingVisitor(IList<Type> destSubTypes)
+                : this(null, Expression.Parameter(typeof(Nullable)), Expression.Parameter(typeof(Nullable)) )
+            {
+                _destSubTypes = destSubTypes;
+            }
+
+            private MappingVisitor(TypeMap typeMap, Expression oldParam, Expression newParam)
             {
                 _typeMap = typeMap;
                 _oldParam = oldParam;
@@ -71,40 +60,144 @@
                 return node;
             }
 
+            protected override Expression VisitMethodCall(MethodCallExpression node)
+            {
+                return base.VisitMethodCall(GetConvertedMethodCall(node));
+            }
+
+            private MethodCallExpression GetConvertedMethodCall(MethodCallExpression node)
+            {
+                var convertedArguments = node.Arguments.Select(e => base.Visit(e)).ToList();
+                var convertedMethodArgumentTypes = node.Method.GetGenericArguments().Select(t => GetConvertingTypeIfExists(node.Arguments, t, convertedArguments)).ToArray();
+                var convertedMethodCall = node.Method.GetGenericMethodDefinition().MakeGenericMethod(convertedMethodArgumentTypes);
+                return Expression.Call(convertedMethodCall, convertedArguments);
+            }
+
+            private static Type GetConvertingTypeIfExists(IList<Expression> args, Type t, IList<Expression> arguments)
+            {
+                var matchingArgument = args.Where(a => !a.Type.IsGenericType).FirstOrDefault(a => a.Type == t);
+                if (matchingArgument != null)
+                {
+                    var index = args.IndexOf(matchingArgument);
+                    if (index < 0)
+                        return t;
+                    return arguments[index].Type;
+                }
+
+                var matchingEnumerableArgument = args.Where(a => a.Type.IsGenericType).FirstOrDefault(a => a.Type.GetGenericArguments()[0] == t);
+                var index2 = args.IndexOf(matchingEnumerableArgument);
+                if (index2 < 0) 
+                    return t;
+                return arguments[index2].Type.GetGenericArguments()[0];
+            }
+
+            protected override Expression VisitLambda<T>(Expression<T> expression)
+            {
+                if (expression.Parameters.Any(b => b.Type == _oldParam.Type))
+                    return VisitLambdaExpression(expression);
+                return VisitAllParametersExpression(expression);
+            }
+
+            private Expression VisitLambdaExpression<T>(Expression<T> expression)
+            {
+                var convertedBody = base.Visit(expression.Body);
+                var convertedArguments = expression.Parameters.Select(e => base.Visit(e) as ParameterExpression).ToList();
+                return Expression.Lambda(convertedBody, convertedArguments);
+            }
+
+            private Expression VisitAllParametersExpression<T>(Expression<T> expression)
+            {
+                var parameters = expression.Parameters.ToArray();
+                var visitors = new List<ExpressionVisitor>();
+                for (var i = 0; i < expression.Parameters.Count; i++)
+                {
+                    var sourceParamType = expression.Parameters[i].Type;
+                    if (_destSubTypes.Count <= i)
+                        continue;
+                    var destParamType = _destSubTypes[i];
+                    if (sourceParamType == destParamType)
+                        continue;
+
+                    var typeMap = Mapper.FindTypeMapFor(destParamType, sourceParamType);
+
+                    if (typeMap == null)
+                        throw new AutoMapperMappingException(
+                            string.Format(
+                                "Could not find type map from destination type {0} to source type {1}. Use CreateMap to create a map from the source to destination types.",
+                                destParamType, sourceParamType));
+
+                    var oldParam = expression.Parameters[i];
+                    var newParam = Expression.Parameter(typeMap.SourceType, oldParam.Name);
+                    parameters[i] = newParam;
+                    visitors.Add(new MappingVisitor(typeMap, oldParam, newParam));
+                }
+                return visitors.Aggregate(expression as Expression, (e, v) => v.Visit(e));
+            }
+
             protected override Expression VisitMember(MemberExpression node)
             {
-                var memberAccessor = node.Member.ToMemberAccessor();
-                var propertyMap = _typeMap.GetExistingPropertyMapFor(memberAccessor);
+                if (node == _oldParam)
+                    return _newParam;
+                var propertyMap = PropertyMap(node);
 
-
-                if (propertyMap.CustomExpression != null)
+                if (propertyMap == null)
                 {
-                    var replaced = new ParameterReplacementVisitor(_newParam);
-                    var newBody = replaced.Visit(propertyMap.CustomExpression.Body);
-                    return newBody;
+                    if (node.Expression is MemberExpression)
+                        return GetConvertedSubMemberCall(node);
+                    return node;
                 }
+                SetSorceSubTypes(propertyMap);
 
                 var replacedExpression = Visit(node.Expression);
 
+                if (propertyMap.CustomExpression != null)
+                    return ConvertCustomExpression(replacedExpression, propertyMap);
+                
                 return propertyMap.GetSourceValueResolvers()
                     .OfType<IMemberGetter>()
                     .Aggregate(replacedExpression,
                         (current, memberGetter) => Expression.MakeMemberAccess(current, memberGetter.MemberInfo));
             }
-        }
 
-        private class ParameterReplacementVisitor : ExpressionVisitor
-        {
-            private readonly ParameterExpression _newParam;
-
-            public ParameterReplacementVisitor(ParameterExpression newParam)
+            private Expression GetConvertedSubMemberCall(MemberExpression node)
             {
-                _newParam = newParam;
+                var baseExpression = Visit(node.Expression);
+                var propertyMap = FindPropertyMapOfExpression(node.Expression as MemberExpression);
+
+                var typeMap = Mapper.FindTypeMapFor(propertyMap.SourceMember.GetMemberType(), propertyMap.DestinationPropertyType);
+                var memberExpression = new MappingVisitor(typeMap, node.Expression, baseExpression).Visit(node) as MemberExpression;
+
+                return Expression.MakeMemberAccess(baseExpression,memberExpression.Member);
             }
 
-            protected override Expression VisitParameter(ParameterExpression node)
+            private PropertyMap FindPropertyMapOfExpression(MemberExpression expression)
             {
-                return _newParam;
+                var propertyMap = PropertyMap(expression);
+                if (propertyMap == null && expression.Expression is MemberExpression)
+                    return FindPropertyMapOfExpression(expression.Expression as MemberExpression);
+                return propertyMap;
+            }
+
+            private PropertyMap PropertyMap(MemberExpression node)
+            {
+                var memberAccessor = node.Member.ToMemberAccessor();
+                var propertyMap = _typeMap.GetExistingPropertyMapFor(memberAccessor);
+                return propertyMap;
+            }
+
+            private void SetSorceSubTypes(PropertyMap propertyMap)
+            {
+                if (propertyMap.SourceMember is PropertyInfo)
+                    _destSubTypes = (propertyMap.SourceMember as PropertyInfo).PropertyType.GetGenericArguments();
+                else if (propertyMap.SourceMember is FieldInfo)
+                    _destSubTypes = (propertyMap.SourceMember as FieldInfo).FieldType.GetGenericArguments();
+            }
+
+            private Expression ConvertCustomExpression(Expression node, PropertyMap propertyMap)
+            {
+                var replaced = new ParameterReplacementVisitor(node);
+                var newBody = replaced.Visit(propertyMap.CustomExpression.Body);
+                return newBody;
             }
         }
     }

--- a/src/UnitTests/Bug/ExpressionMapping.cs
+++ b/src/UnitTests/Bug/ExpressionMapping.cs
@@ -7,7 +7,25 @@ using Xunit;
 
 namespace AutoMapper.UnitTests.Bug
 {
-    public class ExpressionMapping : AutoMapperSpecBase
+    public static class GenericTestExtensionMethods
+    {
+        public static bool Any<T>(this IEnumerable<T> self, Func<T,int,bool> func)
+        {
+            return self.Where(func).Any();
+        }
+
+        public static bool AnyParamReverse<T>(this IEnumerable<T> self, Func<T, T, bool> func)
+        {
+            return self.Any(t => func(t,t));
+        }
+
+        public static bool Lambda<T>(this T self, Func<T, bool> func)
+        {
+            return func(self);
+        }
+    }
+
+    public class ExpressionMapping : NonValidatingSpecBase
     {
         public class ParentDTO
         {
@@ -19,16 +37,17 @@ namespace AutoMapper.UnitTests.Bug
         public class ChildDTO
         {
             public ParentDTO Parent { get; set; }
-            public int ID2 { get; set; }
             public ChildDTO GrandChild { get; set; }
-            public int IDs { get; set; }
+            public int ID_ { get; set; }
+            public int? IDs { get; set; }
+            public int ID2 { get; set; }
         }
 
         public class Parent
         {
-            private Child _child;
             public ICollection<Child> Children { get; set; }
 
+            private Child _child;
             public Child Child
             {
                 get { return _child; }
@@ -44,7 +63,6 @@ namespace AutoMapper.UnitTests.Bug
         public class Child
         {
             private Parent _parent;
-
             public Parent Parent
             {
                 get { return _parent; }
@@ -59,165 +77,172 @@ namespace AutoMapper.UnitTests.Bug
             public int ID { get; set; }
             public Child GrandChild { get; set; }
             public int IDs { get; set; }
+            public int? ID2 { get; set; }
         }
 
-        [Fact]
-        public void Expression_Mapping_Fails_When_Use_Sub_Enumerable_Mapping()
+        private Expression<Func<ParentDTO, bool>> _predicateExpression;
+        private Parent _valid; 
+
+        protected override void Establish_context()
         {
             Mapper.CreateMap<Parent, ParentDTO>().ReverseMap();
             Mapper.CreateMap<Child, ChildDTO>()
-                .ForMember(d => d.ID2, opt => opt.MapFrom(s => s.ID))
+                .ForMember(d => d.ID_, opt => opt.MapFrom(s => s.ID))
                 .ReverseMap()
-                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID2));
+                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID_));
+        }
 
-            var ids = new[] {4, 5};
-            Expression<Func<ParentDTO, bool>> dtoExpression = p => p.Children.Where((c,i) => c.ID2 > 4).Any(c => ids.Contains(c.ID2));
-            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(dtoExpression);
-            var parents = new[] { new Parent { Children = new[] { new Child { ID = 4 } } }, new Parent { Children = new[] { new Child { ID = 5 } } } }.AsQueryable();
+        public override void MainTeardown()
+        {
+            Should_Validate();
+            base.MainTeardown();
+        }
 
-            parents.Where(expression).Count().ShouldEqual(1);
+        private void Should_Validate()
+        {
+            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(_predicateExpression);
+            var items = new[] {_valid}.AsQueryable();
+            items.Where(expression).ShouldContain(_valid);
         }
 
         [Fact]
-        public void Expression_Mapping_Fails_When_Use_Sub_Mapping()
+        public void When_Use_Outside_Class_Method_Call()
         {
-            Mapper.CreateMap<Parent, ParentDTO>().ReverseMap();
-            Mapper.CreateMap<Child, ChildDTO>()
-                .ForMember(d => d.ID2, opt => opt.MapFrom(s => s.ID))
-                .ReverseMap()
-                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID2));
-
-            Expression<Func<ParentDTO, bool>> dtoExpression = p => p.Child.ID2 > 4;
-            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(dtoExpression);
-            var parents = new[] { new Parent { Child = new Child { ID = 4 } }, new Parent { Child= new Child { ID = 5 } } }.AsQueryable();
-
-            parents.Where(expression).Count().ShouldEqual(1);
+            var ids = new[] { 4, 5 };
+            _predicateExpression = p => p.Children.Where((c, i) => c.ID_ > 4).Any(c => ids.Contains(c.ID_));
+            _valid = new Parent { Children = new[] { new Child { ID = 5 } } };
         }
 
         [Fact]
-        public void Crazy_MultiTiered_Super_Mapping_Test()
+        public void When_Use_Property_From_Child_Property()
         {
-            Mapper.CreateMap<Parent, ParentDTO>().ReverseMap();
-            Mapper.CreateMap<Child, ChildDTO>()
-                .ForMember(d => d.ID2, opt => opt.MapFrom(s => s.ID))
-                .ReverseMap()
-                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID2));
+            _predicateExpression = p => p.Child.ID_ > 4;
+            _valid = new Parent { Child= new Child { ID = 5 } };
+        }
 
-            Expression<Func<ParentDTO, bool>> dtoExpression = p => p.Children.Any(c => c.GrandChild.GrandChild.IDs == 4);
-            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(dtoExpression);
-            var parents =
-                new[]
+        [Fact]
+        public void When_Use_Null_Substitution_Mappings_Against_Constants()
+        {
+            _predicateExpression = p => p.Child.ID_ > 4;
+            _valid = new Parent { Child = new Child { ID = 5 } };
+        }
+
+        [Fact]
+        public void When_Use_Null_Substitution_Mappings_Against_Constants_Reverse_Order()
+        {
+            _predicateExpression = p => 4 < p.Child.ID_;
+            _valid = new Parent { Child = new Child { ID = 5 } };
+        }
+
+        [Fact]
+        public void When_Use_Reverse_Null_Substitution_Mappings_Against_Constants()
+        {
+            _predicateExpression = p => p.Child.ID2 > 4;
+            _valid = new Parent {Child = new Child {ID2 = 5}};
+        }
+
+        [Fact]
+        public void When_Use_Reverse_Null_Substitution_Mappings_Against_Constants_Reverse_Order()
+        {
+            _predicateExpression = p => 4 < p.Child.ID2;
+            _valid = new Parent { Child = new Child { ID2 = 5 } };
+        }
+
+        [Fact]
+        public void When_Use_Sub_Lambda_Statement()
+        {
+            _predicateExpression = p => p.Children.Any(c => c.ID_ > 4);
+            _valid = new Parent { Children = new[] { new Child { ID = 5 } } };
+        }
+
+        [Fact]
+        public void When_Use_Multiple_Parameter_Lambda_Statement()
+        {
+            _predicateExpression = p => p.Children.Any((c, i) => c.ID_ > 4);
+            _valid = new Parent { Children = new[] { new Child { ID = 5 } } };
+        }
+
+        [Fact]
+        public void When_Use_Lambda_Statement_With_TypeMapped_Property_Being_Other_Than_First()
+        {
+            _predicateExpression = p => p.Children.AnyParamReverse((c, c2) => c.ID_ > 4);
+            _valid = new Parent {Children = new[] {new Child {ID = 5}}};
+        }
+
+        [Fact]
+        public void When_Use_Child_TypeMap_In_Sub_Lambda_Statement()
+        {
+            _predicateExpression = p => p.Children.Any(c => c.GrandChild.GrandChild.ID_ == 4);
+            _valid = new Parent
+            {
+                Children = new[]
                 {
-                    new Parent {Children = new[] {new Child {GrandChild = new Child {GrandChild = new Child {IDs = 4}}}}},
-                    new Parent {Children = new[] {new Child {GrandChild = new Child {GrandChild = new Child {IDs = 5}}}}}
-                }.AsQueryable();
-
-            parents.Where(expression).Count().ShouldEqual(1);
+                    new Child {GrandChild = new Child {GrandChild = new Child {ID = 4}}}
+                }
+            };
         }
 
         [Fact]
-        public void Crazy_MultiTiered_Super_Mapping_CustomResolver_Test()
+        public void When_Use_Parent_And_Child_Lambda_Parameters_In_Child_Lambda_Statement()
         {
-            Mapper.CreateMap<Parent, ParentDTO>().ReverseMap();
-            Mapper.CreateMap<Child, ChildDTO>()
-                .ForMember(d => d.ID2, opt => opt.MapFrom(s => s.ID))
-                .ReverseMap()
-                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID2));
-
-            Expression<Func<ParentDTO, bool>> dtoExpression = p => p.Child.Parent.Child.GrandChild.ID2 == 4;
-            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(dtoExpression);
-            var parents =
-                new[]
-                {
-                    new Parent {Child = new Child {GrandChild = new Child {ID = 4}}},
-                    new Parent {Child = new Child {GrandChild = new Child {ID = 5}}}
-                }.AsQueryable();
-
-            parents.Where(expression).Count().ShouldEqual(1);
+            _predicateExpression = p => p.Children.Any(c => c.GrandChild.ID_ == p.Child.ID_);
+            _valid = new Parent
+            {
+                Child = new Child {ID = 4},
+                Children = new[] {new Child {GrandChild = new Child  {ID = 4}}}
+            };
         }
 
         [Fact]
-        public void Crazyier_MultiTiered_Super_Mapping_CustomResolver_Test()
+        public void When_Use_Lambdas_Where_Type_Matches_Parent_Object()
         {
-            Mapper.CreateMap<Parent, ParentDTO>().ReverseMap();
-            Mapper.CreateMap<Child, ChildDTO>()
-                .ForMember(d => d.ID2, opt => opt.MapFrom(s => s.ID))
-                .ReverseMap()
-                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID2));
-
-            Expression<Func<ParentDTO, bool>> dtoExpression = p => p.Child.Parent.Child.GrandChild.GrandChild.IDs == 4;
-            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(dtoExpression);
-            var parents =
-                new[]
-                {
-                    new Parent {Child = new Child {GrandChild = new Child {GrandChild = new Child {IDs = 4}}}},
-                    new Parent {Child = new Child {GrandChild = new Child {GrandChild = new Child {IDs = 5}}}}
-                }.AsQueryable();
-
-            parents.Where(expression).Count().ShouldEqual(1);
+            _predicateExpression = p => p.Child.Lambda(c => c.ID_ == 4);
+            _valid = new Parent {Child = new Child {ID = 4}};
         }
 
         [Fact]
-        public void Why_Why_Why_I_Must_Know_Why_You_Would_Go_This_Far_Up_And_Down_The_Property_Tree()
+        public void When_Reusing_TypeMaps()
         {
-            Mapper.CreateMap<Parent, ParentDTO>().ReverseMap();
-            Mapper.CreateMap<Child, ChildDTO>()
-                .ForMember(d => d.ID2, opt => opt.MapFrom(s => s.ID))
-                .ReverseMap()
-                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID2));
-
-            Expression<Func<ParentDTO, bool>> dtoExpression = p => p.Child.Parent.Child.GrandChild.Parent.Child.GrandChild.GrandChild.IDs == 4 && p.Children.Any(c => c.GrandChild.GrandChild.ID2 == 4);
-            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(dtoExpression);
-            var parents =
-                new[]
-                {
-                    new Parent {Child = new Child {GrandChild = new Child {GrandChild = new Child {IDs = 4}}},Children = new[] {new Child {GrandChild = new Child {GrandChild = new Child {ID = 4}}}}},
-                    new Parent {Child = new Child {GrandChild = new Child {GrandChild = new Child {IDs = 5}}},Children = new[] {new Child {GrandChild = new Child {GrandChild = new Child {ID = 5}}}}}
-                }.AsQueryable();
-
-            parents.Where(expression).Count().ShouldEqual(1);
+            _predicateExpression = p => p.Child.Parent.Child.GrandChild.ID_ == 4;
+            _valid = new Parent {Child = new Child {GrandChild = new Child {ID = 4}}};
         }
 
         [Fact]
-        public void DateTimeExample()
+        public void When_Using_Non_TypeMapped_Class_Property()
         {
-            Mapper.CreateMap<Parent, ParentDTO>().ReverseMap();
-            Mapper.CreateMap<Child, ChildDTO>()
-                .ForMember(d => d.ID2, opt => opt.MapFrom(s => s.ID))
-                .ReverseMap()
-                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID2));
             var year = DateTime.Now.Year;
-            Expression<Func<ParentDTO, bool>> dtoExpression = p => p.DateTime.Year == year;
-            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(dtoExpression);
-            var parents =
-                new[]
-                {
-                    new Parent {DateTime = DateTime.Now},
-                    new Parent {DateTime = DateTime.Now.AddYears(1)}
-                }.AsQueryable();
-
-            parents.Where(expression).Count().ShouldEqual(1);
+            _predicateExpression = p => p.DateTime.Year == year;
+            _valid = new Parent {DateTime = DateTime.Now};
         }
 
         [Fact]
-        public void EqualsDateTimeExample()
+        public void When_Using_Non_TypeMapped_Class_Method()
         {
-            Mapper.CreateMap<Parent, ParentDTO>().ReverseMap();
-            Mapper.CreateMap<Child, ChildDTO>()
-                .ForMember(d => d.ID2, opt => opt.MapFrom(s => s.ID))
-                .ReverseMap()
-                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID2));
             var year = DateTime.Now.Year;
-            Expression<Func<ParentDTO, bool>> dtoExpression = p => p.DateTime.Year.Equals(year);
-            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(dtoExpression);
-            var parents =
-                new[]
-                {
-                    new Parent {DateTime = DateTime.Now},
-                    new Parent {DateTime = DateTime.Now.AddYears(1)}
-                }.AsQueryable();
+            _predicateExpression = p => p.DateTime.Year.Equals(year);
+            _valid = new Parent { DateTime = DateTime.Now };
+        }
 
-            parents.Where(expression).Count().ShouldEqual(1);
+        [Fact]
+        public void When_Using_Non_TypeMapped_Class_Property_Against_Constant()
+        {
+            _predicateExpression = p => p.DateTime.Year.ToString() == "2015";
+            _valid = new Parent { DateTime = DateTime.Now };
+        }
+
+        [Fact]
+        public void When_Using_Non_TypeMapped_Class_Method_Against_Constant()
+        {
+            _predicateExpression = p => p.DateTime.Year.ToString().Equals("2015");
+            _valid = new Parent { DateTime = DateTime.Now };
+        }
+
+        [Fact]
+        public void When_Using_Everything_At_Once()
+        {
+            var year = DateTime.Now.Year;
+            _predicateExpression = p => p.DateTime.Year == year && p.Child.Parent.Child.GrandChild.Parent.Child.GrandChild.GrandChild.ID_ == 4 && p.Children.Any(c => c.GrandChild.GrandChild.ID_ == 4);
+            _valid = new Parent { DateTime = DateTime.Now, Child = new Child { GrandChild = new Child { GrandChild = new Child { ID = 4 } } }, Children = new[] { new Child { GrandChild = new Child { GrandChild = new Child { ID = 4 } } } } };
         }
     }
 

--- a/src/UnitTests/Bug/ExpressionMapping.cs
+++ b/src/UnitTests/Bug/ExpressionMapping.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Should;
+using Xunit;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public class ExpressionMapping : AutoMapperSpecBase
+    {
+        public class ParentDTO
+        {
+            public ICollection<ChildDTO> Children { get; set; }
+            public ChildDTO Child { get; set; }
+        }
+
+        public class ChildDTO
+        {
+            public ParentDTO Parent { get; set; }
+            public int ID2 { get; set; }
+            public ChildDTO GrandChild { get; set; }
+            public int IDs { get; set; }
+        }
+
+        public class Parent
+        {
+            private Child _child;
+            public ICollection<Child> Children { get; set; }
+
+            public Child Child
+            {
+                get { return _child; }
+                set
+                {
+                    _child = value;
+                    _child.Parent = this;
+                }
+            }
+        }
+
+        public class Child
+        {
+            private Parent _parent;
+
+            public Parent Parent
+            {
+                get { return _parent; }
+                set
+                {
+                    _parent = value;
+                    if (GrandChild != null)
+                        GrandChild.Parent = _parent;
+                }
+            }
+
+            public int ID { get; set; }
+            public Child GrandChild { get; set; }
+            public int IDs { get; set; }
+        }
+
+        [Fact]
+        public void Expression_Mapping_Fails_When_Use_Sub_Enumerable_Mapping()
+        {
+            Mapper.CreateMap<Parent, ParentDTO>().ReverseMap();
+            Mapper.CreateMap<Child, ChildDTO>()
+                .ForMember(d => d.ID2, opt => opt.MapFrom(s => s.ID))
+                .ReverseMap()
+                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID2));
+
+            var ids = new[] {4, 5};
+            Expression<Func<ParentDTO, bool>> dtoExpression = p => p.Children.Where((c,i) => c.ID2 > 4).Any(c => ids.Contains(c.ID2));
+            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(dtoExpression);
+            var parents = new[] { new Parent { Children = new[] { new Child { ID = 4 } } }, new Parent { Children = new[] { new Child { ID = 5 } } } }.AsQueryable();
+
+            parents.Where(expression).Count().ShouldEqual(1);
+        }
+
+        [Fact]
+        public void Expression_Mapping_Fails_When_Use_Sub_Mapping()
+        {
+            Mapper.CreateMap<Parent, ParentDTO>().ReverseMap();
+            Mapper.CreateMap<Child, ChildDTO>()
+                .ForMember(d => d.ID2, opt => opt.MapFrom(s => s.ID))
+                .ReverseMap()
+                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID2));
+
+            Expression<Func<ParentDTO, bool>> dtoExpression = p => p.Child.ID2 > 4;
+            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(dtoExpression);
+            var parents = new[] { new Parent { Child = new Child { ID = 4 } }, new Parent { Child= new Child { ID = 5 } } }.AsQueryable();
+
+            parents.Where(expression).Count().ShouldEqual(1);
+        }
+
+        [Fact]
+        public void Crazy_MultiTiered_Super_Mapping_Test()
+        {
+            Mapper.CreateMap<Parent, ParentDTO>().ReverseMap();
+            Mapper.CreateMap<Child, ChildDTO>()
+                .ForMember(d => d.ID2, opt => opt.MapFrom(s => s.ID))
+                .ReverseMap()
+                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID2));
+
+            Expression<Func<ParentDTO, bool>> dtoExpression = p => p.Children.Any(c => c.GrandChild.GrandChild.IDs == 4);
+            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(dtoExpression);
+            var parents =
+                new[]
+                {
+                    new Parent {Children = new[] {new Child {GrandChild = new Child {GrandChild = new Child {IDs = 4}}}}},
+                    new Parent {Children = new[] {new Child {GrandChild = new Child {GrandChild = new Child {IDs = 5}}}}}
+                }.AsQueryable();
+
+            parents.Where(expression).Count().ShouldEqual(1);
+        }
+
+        [Fact]
+        public void Crazy_MultiTiered_Super_Mapping_CustomResolver_Test()
+        {
+            Mapper.CreateMap<Parent, ParentDTO>().ReverseMap();
+            Mapper.CreateMap<Child, ChildDTO>()
+                .ForMember(d => d.ID2, opt => opt.MapFrom(s => s.ID))
+                .ReverseMap()
+                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID2));
+
+            Expression<Func<ParentDTO, bool>> dtoExpression = p => p.Child.Parent.Child.GrandChild.ID2 == 4;
+            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(dtoExpression);
+            var parents =
+                new[]
+                {
+                    new Parent {Child = new Child {GrandChild = new Child {ID = 4}}},
+                    new Parent {Child = new Child {GrandChild = new Child {ID = 5}}}
+                }.AsQueryable();
+
+            parents.Where(expression).Count().ShouldEqual(1);
+        }
+
+        [Fact]
+        public void Crazyier_MultiTiered_Super_Mapping_CustomResolver_Test()
+        {
+            Mapper.CreateMap<Parent, ParentDTO>().ReverseMap();
+            Mapper.CreateMap<Child, ChildDTO>()
+                .ForMember(d => d.ID2, opt => opt.MapFrom(s => s.ID))
+                .ReverseMap()
+                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID2));
+
+            Expression<Func<ParentDTO, bool>> dtoExpression = p => p.Child.Parent.Child.GrandChild.GrandChild.IDs == 4;
+            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(dtoExpression);
+            var parents =
+                new[]
+                {
+                    new Parent {Child = new Child {GrandChild = new Child {GrandChild = new Child {IDs = 4}}}},
+                    new Parent {Child = new Child {GrandChild = new Child {GrandChild = new Child {IDs = 5}}}}
+                }.AsQueryable();
+
+            parents.Where(expression).Count().ShouldEqual(1);
+        }
+
+        [Fact]
+        public void Why_Why_Why_I_Must_Know_Why_You_Would_Go_This_Far_Up_And_Down_The_Property_Tree()
+        {
+            Mapper.CreateMap<Parent, ParentDTO>().ReverseMap();
+            Mapper.CreateMap<Child, ChildDTO>()
+                .ForMember(d => d.ID2, opt => opt.MapFrom(s => s.ID))
+                .ReverseMap()
+                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID2));
+
+            Expression<Func<ParentDTO, bool>> dtoExpression = p => p.Child.Parent.Child.GrandChild.Parent.Child.GrandChild.GrandChild.IDs == 4 && p.Children.Any(c => c.GrandChild.GrandChild.ID2 == 4);
+            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(dtoExpression);
+            var parents =
+                new[]
+                {
+                    new Parent {Child = new Child {GrandChild = new Child {GrandChild = new Child {IDs = 4}}},Children = new[] {new Child {GrandChild = new Child {GrandChild = new Child {ID = 4}}}}},
+                    new Parent {Child = new Child {GrandChild = new Child {GrandChild = new Child {IDs = 5}}},Children = new[] {new Child {GrandChild = new Child {GrandChild = new Child {ID = 5}}}}}
+                }.AsQueryable();
+
+            parents.Where(expression).Count().ShouldEqual(1);
+        }
+    }
+
+}

--- a/src/UnitTests/Bug/ExpressionMapping.cs
+++ b/src/UnitTests/Bug/ExpressionMapping.cs
@@ -198,6 +198,27 @@ namespace AutoMapper.UnitTests.Bug
 
             parents.Where(expression).Count().ShouldEqual(1);
         }
+
+        [Fact]
+        public void EqualsDateTimeExample()
+        {
+            Mapper.CreateMap<Parent, ParentDTO>().ReverseMap();
+            Mapper.CreateMap<Child, ChildDTO>()
+                .ForMember(d => d.ID2, opt => opt.MapFrom(s => s.ID))
+                .ReverseMap()
+                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID2));
+            var year = DateTime.Now.Year;
+            Expression<Func<ParentDTO, bool>> dtoExpression = p => p.DateTime.Year.Equals(year);
+            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(dtoExpression);
+            var parents =
+                new[]
+                {
+                    new Parent {DateTime = DateTime.Now},
+                    new Parent {DateTime = DateTime.Now.AddYears(1)}
+                }.AsQueryable();
+
+            parents.Where(expression).Count().ShouldEqual(1);
+        }
     }
 
 }

--- a/src/UnitTests/Bug/ExpressionMapping.cs
+++ b/src/UnitTests/Bug/ExpressionMapping.cs
@@ -13,6 +13,7 @@ namespace AutoMapper.UnitTests.Bug
         {
             public ICollection<ChildDTO> Children { get; set; }
             public ChildDTO Child { get; set; }
+            public DateTime DateTime { get; set; }
         }
 
         public class ChildDTO
@@ -37,6 +38,7 @@ namespace AutoMapper.UnitTests.Bug
                     _child.Parent = this;
                 }
             }
+            public DateTime DateTime { get; set; }
         }
 
         public class Child
@@ -171,6 +173,27 @@ namespace AutoMapper.UnitTests.Bug
                 {
                     new Parent {Child = new Child {GrandChild = new Child {GrandChild = new Child {IDs = 4}}},Children = new[] {new Child {GrandChild = new Child {GrandChild = new Child {ID = 4}}}}},
                     new Parent {Child = new Child {GrandChild = new Child {GrandChild = new Child {IDs = 5}}},Children = new[] {new Child {GrandChild = new Child {GrandChild = new Child {ID = 5}}}}}
+                }.AsQueryable();
+
+            parents.Where(expression).Count().ShouldEqual(1);
+        }
+
+        [Fact]
+        public void DateTimeExample()
+        {
+            Mapper.CreateMap<Parent, ParentDTO>().ReverseMap();
+            Mapper.CreateMap<Child, ChildDTO>()
+                .ForMember(d => d.ID2, opt => opt.MapFrom(s => s.ID))
+                .ReverseMap()
+                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID2));
+            var year = DateTime.Now.Year;
+            Expression<Func<ParentDTO, bool>> dtoExpression = p => p.DateTime.Year == year;
+            var expression = Mapper.Map<Expression<Func<Parent, bool>>>(dtoExpression);
+            var parents =
+                new[]
+                {
+                    new Parent {DateTime = DateTime.Now},
+                    new Parent {DateTime = DateTime.Now.AddYears(1)}
                 }.AsQueryable();
 
             parents.Where(expression).Count().ShouldEqual(1);

--- a/src/UnitTests/Bug/ExpressionMapping.cs
+++ b/src/UnitTests/Bug/ExpressionMapping.cs
@@ -244,6 +244,13 @@ namespace AutoMapper.UnitTests.Bug
             _predicateExpression = p => p.DateTime.Year == year && p.Child.Parent.Child.GrandChild.Parent.Child.GrandChild.GrandChild.ID_ == 4 && p.Children.Any(c => c.GrandChild.GrandChild.ID_ == 4);
             _valid = new Parent { DateTime = DateTime.Now, Child = new Child { GrandChild = new Child { GrandChild = new Child { ID = 4 } } }, Children = new[] { new Child { GrandChild = new Child { GrandChild = new Child { ID = 4 } } } } };
         }
+
+        [Fact]
+        public void When_Using_Static_Constants()
+        {
+            _predicateExpression = p => p.DateTime.Year.ToString() != string.Empty;
+            _valid = new Parent { DateTime = DateTime.Now };
+        }
     }
 
 }

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Bug\EnumConditionsBug.cs" />
     <Compile Include="Bug\EnumMatchingOnValue.cs" />
     <Compile Include="Bug\ExistingArrays.cs" />
+    <Compile Include="Bug\ExpressionMapping.cs" />
     <Compile Include="Bug\IgnoreAll.cs" />
     <Compile Include="Bug\InheritanceIssue.cs" />
     <Compile Include="Bug\InterfaceSelfMappingBug.cs" />


### PR DESCRIPTION
Fix Issues with Expression Mappings #648 when use properties which types have their own mappings that need to be converted over.

Multiple scenarios have been solved for now including the original problem.
Issue still lies with multiple level same type one to many relationships. (One to many relationships of different types work fine)
Ex: ```Tools.Any(t => t.SubTools.Any(t => t.ID == id))``` will fail to convert over cause Any function will still be assuming ToolDTO instead of Tool as generic parameter type.