### PR TITLE
Adding detail to exception thrown by projection

### DIFF
--- a/src/AutoMapper/QueryableExtensions/Extensions.cs
+++ b/src/AutoMapper/QueryableExtensions/Extensions.cs
@@ -169,7 +169,17 @@ namespace AutoMapper.QueryableExtensions
                 var binder = Binders.FirstOrDefault(b => b.IsMatch(propertyMap, propertyTypeMap, result));
 
                 if (binder == null)
-                    throw new AutoMapperMappingException("Unable to create a map expression from " + result.Type + " to " + propertyMap.DestinationPropertyType);
+                {
+                    var message = string.Format("Unable to create a map expression from {0}.{1} ({2}) to {3}.{4} ({5})",
+                        propertyMap.SourceMember.DeclaringType.Name,
+                        propertyMap.SourceMember.Name,
+                        result.Type,
+                        propertyMap.DestinationProperty.MemberInfo.DeclaringType.Name,
+                        propertyMap.DestinationProperty.Name,
+                        propertyMap.DestinationPropertyType);
+
+                    throw new AutoMapperMappingException(message);
+                }
 
                 var bindExpression = binder.Build(mappingEngine, propertyMap, propertyTypeMap, propertyRequest, result, typePairCount);
 


### PR DESCRIPTION
I hit this exception and was wished it would actually tell me which property couldn't be mapped. This change helped me and maybe it could help someone else.

The exception goes from reading like this 

```
Unable to create a map expression from System.Nullable`1[System.Int32] to System.Int32
``` 

to reading like this 

```
Unable to create a map expression from InvoiceItem.ProductId (System.Nullable`1[System.Int32]) to InvoiceItemModel.ProductId (System.Int32)
```