### PR TITLE
Simple Convention example for member and type maps.

### DIFF
--- a/src/AutoMapper/AutoMapper.csproj
+++ b/src/AutoMapper/AutoMapper.csproj
@@ -90,6 +90,7 @@
     <Compile Include="Internal\ProbingAdapterResolver.cs" />
     <Compile Include="Mapper.cs" />
     <Compile Include="Mappers\AssignableArrayMapper.cs" />
+    <Compile Include="Mappers\CreateMapBasedOnCriteriaMapper.cs" />
     <Compile Include="Mappers\ExplicitConversionOperatorMapper.cs" />
     <Compile Include="Mappers\ExpressionMapper.cs" />
     <Compile Include="Mappers\ImplicitConversionOperatorMapper.cs" />

--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -13,7 +13,7 @@ namespace AutoMapper
     public class ConfigurationStore : IConfigurationProvider, IConfiguration
 	{
 	    private static readonly IDictionaryFactory DictionaryFactory = PlatformAdapter.Resolve<IDictionaryFactory>();
-	    private readonly ITypeMapFactory _typeMapFactory;
+	    internal readonly ITypeMapFactory _typeMapFactory;
 	    private readonly IEnumerable<IObjectMapper> _mappers;
 		internal const string DefaultProfileName = "";
 		

--- a/src/AutoMapper/IMappingEngine.cs
+++ b/src/AutoMapper/IMappingEngine.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace AutoMapper
 {
@@ -157,5 +160,6 @@ namespace AutoMapper
         /// <param name="destinationType">Destination type to use</param>
     	void DynamicMap(object source, object destination, Type sourceType, Type destinationType);
     }
+
 }
 

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -480,5 +480,19 @@ namespace AutoMapper
 	    {
             Configuration.AddGlobalIgnore(startingwith);
 	    }
+
+        public static CreateMapBasedOnCriteriaMapper AddConvension()
+        {
+            var newMapper = CreateMapBasedOnCriteriaMapper.New;
+            MapperRegistry.Mappers.Add(newMapper);
+            return newMapper;
+        }
+
+        public static CustomizedSourceToDestinationMemberMapper AddMemberConvention()
+        {
+            var newConvention = new CustomizedSourceToDestinationMemberMapper();
+            ((Engine.ConfigurationProvider as ConfigurationStore)._typeMapFactory as TypeMapFactory).sourceToDestinationMemberMappers.Add(newConvention);
+            return newConvention;
+        }
 	}
 }

--- a/src/AutoMapper/Mappers/CreateMapBasedOnCriteriaMapper.cs
+++ b/src/AutoMapper/Mappers/CreateMapBasedOnCriteriaMapper.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using AutoMapper.Impl;
+
+namespace AutoMapper.Mappers
+{
+    public class CreateMapBasedOnCriteriaMapper : IObjectMapper
+    {
+        public object Map(ResolutionContext context, IMappingEngineRunner mapper)
+        {
+            var contextTypePair = new TypePair(context.SourceType, context.DestinationType);
+            Func<TypePair, IObjectMapper> missFunc = tp => (context.Engine as MappingEngine)._mappers.FirstOrDefault(m => m.IsMatch(context));
+            var typeMap = mapper.ConfigurationProvider.CreateTypeMap(context.SourceType, context.DestinationType);
+
+            context = context.CreateTypeContext(typeMap, context.SourceValue, context.DestinationValue, context.SourceType, context.DestinationType);
+
+            var map = (context.Engine as MappingEngine)._objectMapperCache.GetOrAdd(contextTypePair, missFunc);
+            return map.Map(context, mapper);
+        }
+
+        public bool IsMatch(ResolutionContext context)
+        {
+            return _convensions.All(c => c(context));
+        }
+
+        private readonly ICollection<Func<ResolutionContext, bool>> _convensions = new Collection<Func<ResolutionContext, bool>>();
+
+        public static CreateMapBasedOnCriteriaMapper New { get { return new CreateMapBasedOnCriteriaMapper(); } }
+        private CreateMapBasedOnCriteriaMapper()
+        {
+            
+        }
+
+        public ICollection<Func<ResolutionContext, bool>> Condition
+        {
+            get { return _convensions; }
+        }
+
+        public bool MatchConvension(ResolutionContext resolutionContext)
+        {
+            return Condition.All(c => c(resolutionContext));
+        }
+    }
+
+    public static class ConventionGeneratorExtensions
+    {
+
+        public static CreateMapBasedOnCriteriaMapper Postfix(this CreateMapBasedOnCriteriaMapper self, string postFix)
+        {
+            return self.Where((s, d) => d.Name == s.Name + postFix || s.Name == d.Name + postFix);
+        }
+        public static CreateMapBasedOnCriteriaMapper Where(this CreateMapBasedOnCriteriaMapper self, Func<Type, Type, bool> condition)
+        {
+            self.Condition.Add(rc => condition(rc.SourceType, rc.DestinationType));
+            return self;
+        }
+
+    }
+
+}

--- a/src/AutoMapper/MappingEngine.cs
+++ b/src/AutoMapper/MappingEngine.cs
@@ -12,8 +12,8 @@ namespace AutoMapper
 	    private static readonly IProxyGeneratorFactory ProxyGeneratorFactory = PlatformAdapter.Resolve<IProxyGeneratorFactory>();
 	    private bool _disposed;
 		private readonly IConfigurationProvider _configurationProvider;
-		private readonly IObjectMapper[] _mappers;
-        private readonly IDictionary<TypePair, IObjectMapper> _objectMapperCache = DictionaryFactory.CreateDictionary<TypePair, IObjectMapper>();
+	    internal readonly IObjectMapper[] _mappers;
+	    internal readonly IDictionary<TypePair, IObjectMapper> _objectMapperCache = DictionaryFactory.CreateDictionary<TypePair, IObjectMapper>();
 	    private readonly Func<Type, object> _serviceCtor;
 
 	    public MappingEngine(IConfigurationProvider configurationProvider)

--- a/src/UnitTests/ConvensionTest.cs
+++ b/src/UnitTests/ConvensionTest.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Linq.Expressions;
+using AutoMapper.Mappers;
+using Should;
+using Xunit;
+
+namespace AutoMapper.UnitTests
+{
+    public class ConvensionTest : AutoMapperSpecBase
+    {
+        public class Client
+        {
+            public int ID { get; set; }
+            public string Value { get; set; }
+            public string Transval { get; set; }
+        }
+
+        public class ClientDto
+        {
+            public int ID { get; set; }
+            public string ValueTransfer { get; set; }
+            public string val { get; set; }
+        }
+
+        [Fact]
+        public void Fact()
+        {
+            Mapper.AddConvension().Postfix("Dto");
+            Mapper.AddMemberConvention().PropertyPostfix("Transfer");
+            Mapper.AddMemberConvention().PropertyPrefix("Trans");
+
+            var a2 = Mapper.Map<ClientDto>(new Client() { Value= "Test", Transval = "test"});
+            a2.ValueTransfer.ShouldEqual("Test");
+            a2.val.ShouldEqual("test");
+
+            var a = Mapper.Map<Client>(new ClientDto() { ValueTransfer = "TestTransfer", val = "testTransfer"});
+            a.Value.ShouldEqual("TestTransfer");
+            a.Transval.ShouldEqual("testTransfer");
+
+            var clients = Mapper.Map<Client[]>(new[] { new ClientDto() });
+            Expression<Func<Client, bool>> expr = c => c.ID < 5;
+            var clientExp = Mapper.Map<Expression<Func<ClientDto,bool>>>(expr);
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -136,6 +136,7 @@
     <Compile Include="ConditionalMapping.cs" />
     <Compile Include="Constructors.cs" />
     <Compile Include="ContextItems.cs" />
+    <Compile Include="ConvensionTest.cs" />
     <Compile Include="ConversionOperators.cs" />
     <Compile Include="CustomFormatters.cs" />
     <Compile Include="CustomMapping.cs" />


### PR DESCRIPTION
Proof of concept.
Added to 3.3 cause I had trouble using latest .Net framework and compiling the solution.

Still very simple in example and scope.
Don't overwrite default behavior of anything, just if the default fails then fall back on convention, then throw error.

Adding type convention just adds a custom IObjectMapper at the end of Mappers list.
Adding member convention, made the default functionality a single class, put it in a list and then user defined conventions get added on the end.

Both conventions work on taking what function the default called and making a list of conditional statements the user has to provide and ANDs them all together.
How they make these is a simple fluent API that just calls extension methods off the base class to simplify statements.  All I have is pre/post fix statements, but you get the point.
Added simple test for convensions with pre-fix and post-fix.

Type map creates new mapping from type so can be cached for next time mapping happens.

This is down and dirty implementation and internally it needs to be re factored.
This is just to show how you could extend without hurting existing functionality, and possibly how you could set up the defaults for member mapping to a list of conditions that can be added and removed just like you can with Object Mappers.