### PR TITLE
Fix Expression`1 -> Expression`1 Error

### DIFF
--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -75,6 +75,11 @@
                 var memberAccessor = node.Member.ToMemberAccessor();
                 var propertyMap = _typeMap.GetExistingPropertyMapFor(memberAccessor);
 
+                if (propertyMap == null)
+                {
+                    // No propertyMap found, just use the original expression.
+                    return node;
+                }
 
                 if (propertyMap.CustomExpression != null)
                 {


### PR DESCRIPTION
TypeMap.GetExistingPropertyMapFor can return null so rather than blowing up, return the original expression.