### PR TITLE
Return also methods from base types when looking for source members

### DIFF
--- a/src/AutoMapper/TypeInfo.cs
+++ b/src/AutoMapper/TypeInfo.cs
@@ -149,7 +149,7 @@ namespace AutoMapper
 
         private MethodInfo[] BuildPublicNoArgMethods()
         {
-            return Type.GetDeclaredMethods()
+            return Type.GetMethods()
                 .Where(mi => mi.IsPublic && !mi.IsStatic)
                 .Where(m => (m.ReturnType != typeof (void)) && (m.GetParameters().Length == 0))
                 .ToArray();

--- a/src/UnitTests/Bug/CollectionBaseClassGetConvention.cs
+++ b/src/UnitTests/Bug/CollectionBaseClassGetConvention.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Should;
+using AutoMapper;
+using Xunit;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public class CollectionBaseClassGetConvention : AutoMapperSpecBase
+    {
+        Destination _destination;
+        static int[] SomeCollection = new[] { 1, 2, 3 };
+
+        public abstract class SourceBase
+        {
+            public IEnumerable<int> GetItems()
+            {
+                return SomeCollection;
+            }
+        }
+
+        public class Source : SourceBase
+        {
+        }
+
+        public class Destination
+        {
+            public IEnumerable<int> Items { get; set; }
+        }
+
+        protected override void Establish_context()
+        {
+            Mapper.CreateMap<Source, Destination>();
+        }
+
+        protected override void Because_of()
+        {
+            _destination = Mapper.Map<Destination>(new Source());
+        }
+
+        [Fact]
+        public void Should_map_collection_with_get_convention()
+        {
+            _destination.Items.SequenceEqual(SomeCollection).ShouldBeTrue();
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Bug\AssignableCollectionBug.cs" />
     <Compile Include="Bug\CannotConvertEnumToNullable.cs" />
     <Compile Include="Bug\BaseMapWithIncludesAndUnincludedMappings.cs" />
+    <Compile Include="Bug\CollectionBaseClassGetConvention.cs" />
     <Compile Include="Bug\ConditionBug.cs" />
     <Compile Include="Bug\ContextValuesIncorrect.cs" />
     <Compile Include="Bug\DestinationCtorCalledTwice.cs" />


### PR DESCRIPTION
#769
[GetMethods] (https://msdn.microsoft.com/en-us/library/td205ybf%28v=vs.110%29.aspx) returns all the members, including from base types. It seems to be supported on all Windows platforms.