### PR TITLE
Dynamically map arrays

### DIFF
--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -281,6 +281,10 @@ namespace AutoMapper
 
                 IncludeBaseMappings(source, destination, tm);
 
+                // keep the cache in sync
+                TypeMap _;
+                _typeMapPlanCache.TryRemove(tp, out _);
+
                 OnTypeMapCreated(tm);
 
                 return tm;

--- a/src/AutoMapper/MappingEngine.cs
+++ b/src/AutoMapper/MappingEngine.cs
@@ -188,8 +188,7 @@ namespace AutoMapper
 
         public object DynamicMap(object source, Type sourceType, Type destinationType)
         {
-            var typeMap = ConfigurationProvider.ResolveTypeMap(source, null, sourceType, destinationType) ??
-                          ConfigurationProvider.CreateTypeMap(sourceType, destinationType);
+            var typeMap = ConfigurationProvider.ResolveTypeMap(source, null, sourceType, destinationType);
 
             var context = new ResolutionContext(typeMap, source, sourceType, destinationType,
                 new MappingOperationOptions
@@ -202,8 +201,7 @@ namespace AutoMapper
 
         public void DynamicMap(object source, object destination, Type sourceType, Type destinationType)
         {
-            var typeMap = ConfigurationProvider.ResolveTypeMap(source, destination, sourceType, destinationType) ??
-                          ConfigurationProvider.CreateTypeMap(sourceType, destinationType);
+            var typeMap = ConfigurationProvider.ResolveTypeMap(source, destination, sourceType, destinationType);
 
             var context = new ResolutionContext(typeMap, source, destination, sourceType, destinationType,
                 new MappingOperationOptions

--- a/src/UnitTests/Bug/DynamicMapArrays.cs
+++ b/src/UnitTests/Bug/DynamicMapArrays.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Linq;
+using Should;
+using Xunit;
+using AutoMapper;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public class DynamicMapArrays : AutoMapperSpecBase
+    {
+        Source[] source;
+        Destination[] destination;
+
+        public class Source
+        {
+            public Source(int value)
+            {
+                Value = value;
+            }
+
+            public int Value { get; set; }
+        }
+
+        public class Destination
+        {
+            public int Value { get; set; }
+        }
+
+        protected override void Because_of()
+        {
+            source = Enumerable.Range(0, 9).Select(i => new Source(i)).ToArray();
+            destination = Mapper.DynamicMap<Destination[]>(source);
+            //Mapper.CreateMap<Source, Destination>();
+            //destination = Mapper.Map<Destination[]>(source);
+        }
+
+        [Fact]
+        public void Should_dynamic_map_the_array()
+        {
+            destination.Length.ShouldEqual(source.Length);
+            Array.TrueForAll(source, s => s.Value == destination[s.Value].Value).ShouldBeTrue(); 
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Bug\AddingConfigurationForNonMatchingDestinationMemberBug.cs" />
     <Compile Include="Bug\DeepInheritanceIssue.cs" />
     <Compile Include="Bug\DuplicateValuesBug.cs" />
+    <Compile Include="Bug\DynamicMapArrays.cs" />
     <Compile Include="Bug\EFCollections.cs" />
     <Compile Include="Bug\EmptyNullSubstituteBug.cs" />
     <Compile Include="Bug\EnumConditionsBug.cs" />


### PR DESCRIPTION
#628 
Not sure what the best solution is but the reasoning is below.
Creating the map for the arrays in DynamicMap is not helpful, we need only the mapping for the element types. 
After dynamically creating the TypeMap, the cache had null for that TypePair because initially the mapping didn't exist, so clear that entry.