### PR TITLE
DynamicMap threading issues

### DIFF
--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -351,9 +351,7 @@ namespace AutoMapper
             var typeMap = _typeMapPlanCache.GetOrAdd(typePair,
                 _ =>
                     GetRelatedTypePairs(_)
-                        .Select(
-                            tp =>
-                                FindTypeMapFor(tp) ?? (_typeMapPlanCache.ContainsKey(tp) ? _typeMapPlanCache[tp] : null))
+                        .Select(tp => FindTypeMapFor(tp) ?? _typeMapPlanCache.GetOrDefault(tp))
                         .FirstOrDefault(tm => tm != null));
 
             return typeMap;

--- a/src/AutoMapper/Internal/PrimitiveExtensions.cs
+++ b/src/AutoMapper/Internal/PrimitiveExtensions.cs
@@ -8,7 +8,14 @@ namespace AutoMapper.Internal
 
 	public static class PrimitiveExtensions
 	{
-		public static bool IsNullableType(this Type type)
+        public static TValue GetOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
+        {
+            TValue value;
+            dictionary.TryGetValue(key, out value);
+            return value;
+        }
+
+        public static bool IsNullableType(this Type type)
 		{
             return type.IsGenericType() && (type.GetGenericTypeDefinition().Equals(typeof (Nullable<>)));
 		}

--- a/src/UnitTests/Bug/MultiThreadingIssues.cs
+++ b/src/UnitTests/Bug/MultiThreadingIssues.cs
@@ -253,3 +253,92 @@ namespace AutoMapper.UnitTests.Bug
     }
 }
 #endif
+
+// The three exceptions I saw while running the multithreading tests for DynamicMap (lbargaoanu)
+
+//Unhandled Exception: System.AggregateException: One or more errors occurred. ---> AutoMapper.AutoMapperMappingException:
+
+//Mapping types:
+//SomeDtoB -> SomeDtoA
+//TestConsole.Program+SomeDtoB -> TestConsole.Program+SomeDtoA
+
+//Destination path:
+//SomeDtoA
+
+//Source value:
+//TestConsole.Program+SomeDtoB ---> System.NullReferenceException: Object reference not set to an instance of an object.
+//   at AutoMapper.MappingEngine.AutoMapper.IMappingEngineRunner.Map(ResolutionContext context) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine.c
+//s:line 256
+//   --- End of inner exception stack trace ---
+//   at AutoMapper.MappingEngine.AutoMapper.IMappingEngineRunner.Map(ResolutionContext context) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine.c
+//s:line 264
+//   at AutoMapper.MappingEngine.DynamicMap(Object source, Type sourceType, Type destinationType) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine
+//.cs:line 199
+//   at AutoMapper.MappingEngine.DynamicMap[TSource, TDestination](TSource source) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine.cs:line 170
+//   at AutoMapper.Mapper.DynamicMap[TSource, TDestination](TSource source) in D:\Projects\AutoMapper\src\AutoMapper\Mapper.cs:line 174
+//   at TestConsole.Program.<>c.<Main>b__6_1() in D:\Projects\TestConsole\TestConsole\Program.cs:line 141
+//   at System.Threading.Tasks.Task.Execute()
+//   --- End of inner exception stack trace ---
+//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout, CancellationToken cancellationToken)
+//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout)
+//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks)
+//   at TestConsole.Program.Main(String[] args) in D:\Projects\TestConsole\TestConsole\Program.cs:line 146
+
+//Unhandled Exception: System.AggregateException: One or more errors occurred. ---> AutoMapper.AutoMapperMappingException:
+
+//Mapping types:
+//SomeDtoB -> SomeDtoA
+//TestConsole.Program+SomeDtoB -> TestConsole.Program+SomeDtoA
+
+//Destination path:
+//SomeDtoA
+
+//Source value:
+//TestConsole.Program+SomeDtoB ---> System.NullReferenceException: Object reference not set to an instance of an object.
+//   at AutoMapper.Mappers.TypeMapMapper.Map(ResolutionContext context, IMappingEngineRunner mapper) in D:\Projects\AutoMapper\src\AutoMapper\Mappers\Ty
+//peMapMapper.cs:line 17
+//   at AutoMapper.MappingEngine.AutoMapper.IMappingEngineRunner.Map(ResolutionContext context) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine.c
+//s:line 260
+//   --- End of inner exception stack trace ---
+//   at AutoMapper.MappingEngine.AutoMapper.IMappingEngineRunner.Map(ResolutionContext context) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine.c
+//s:line 268
+//   at AutoMapper.MappingEngine.DynamicMap(Object source, Type sourceType, Type destinationType) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine
+//.cs:line 199
+//   at AutoMapper.MappingEngine.DynamicMap[TSource, TDestination](TSource source) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine.cs:line 170
+//   at AutoMapper.Mapper.DynamicMap[TSource, TDestination](TSource source) in D:\Projects\AutoMapper\src\AutoMapper\Mapper.cs:line 174
+//   at TestConsole.Program.<>c.<Main>b__6_1() in D:\Projects\TestConsole\TestConsole\Program.cs:line 141
+//   at System.Threading.Tasks.Task.Execute()
+//   --- End of inner exception stack trace ---
+//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout, CancellationToken cancellationToken)
+//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout)
+//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks)
+//   at TestConsole.Program.Main(String[] args) in D:\Projects\TestConsole\TestConsole\Program.cs:line 145
+
+//Unhandled Exception: System.AggregateException: One or more errors occurred. ---> System.Collections.Generic.KeyNotFoundException: The given key was n
+//ot present in the dictionary.
+//   at System.Collections.Concurrent.ConcurrentDictionary`2.get_Item(TKey key)
+//   at AutoMapper.Internal.DictionaryFactoryOverride.ConcurrentDictionaryImpl`2.get_Item(TKey key) in D:\Projects\AutoMapper\src\AutoMapper\Internal\Co
+//ncurrentDictionaryFactory.cs:line 42
+//   at AutoMapper.ConfigurationStore.<ResolveTypeMap>b__87_1(TypePair tp) in D:\Projects\AutoMapper\src\AutoMapper\ConfigurationStore.cs:line 356
+//   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
+//   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
+//   at AutoMapper.ConfigurationStore.<ResolveTypeMap>b__87_0(TypePair _) in D:\Projects\AutoMapper\src\AutoMapper\ConfigurationStore.cs:line 353
+//   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
+//   at AutoMapper.Internal.DictionaryFactoryOverride.ConcurrentDictionaryImpl`2.GetOrAdd(TKey key, Func`2 valueFactory) in D:\Projects\AutoMapper\src\A
+//utoMapper\Internal\ConcurrentDictionaryFactory.cs:line 37
+//   at AutoMapper.ConfigurationStore.ResolveTypeMap(TypePair typePair) in D:\Projects\AutoMapper\src\AutoMapper\ConfigurationStore.cs:line 351
+//   at AutoMapper.ConfigurationStore.ResolveTypeMap(Type sourceType, Type destinationType) in D:\Projects\AutoMapper\src\AutoMapper\ConfigurationStore.
+//cs:line 346
+//   at AutoMapper.ConfigurationStore.ResolveTypeMap(Object source, Object destination, Type sourceType, Type destinationType) in D:\Projects\AutoMapper
+//\src\AutoMapper\ConfigurationStore.cs:line 364
+//   at AutoMapper.MappingEngine.DynamicMap(Object source, Type sourceType, Type destinationType) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine
+//.cs:line 191
+//   at AutoMapper.MappingEngine.DynamicMap[TSource, TDestination](TSource source) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine.cs:line 170
+//   at AutoMapper.Mapper.DynamicMap[TSource, TDestination](TSource source) in D:\Projects\AutoMapper\src\AutoMapper\Mapper.cs:line 174
+//   at TestConsole.Program.<>c.<Main>b__6_1() in D:\Projects\TestConsole\TestConsole\Program.cs:line 143
+//   at System.Threading.Tasks.Task.Execute()
+//   --- End of inner exception stack trace ---
+//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout, CancellationToken cancellationToken)
+//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout)
+//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks)
+//   at TestConsole.Program.Main(String[] args) in D:\Projects\TestConsole\TestConsole\Program.cs:line 145


### PR DESCRIPTION
I broke the DynamicMap threading test with #628.
I found three errors which I put [here](https://github.com/lbargaoanu/AutoMapper/blob/9ba3783c11b1eaebc36e7750fc09e489ad7e0316/src/UnitTests/Bug/MultiThreadingIssues.cs#L257).
Obviously this kind of test is not exactly reliable, but I did try :).
Maybe there is a more elegant fix, but regardless, I think it's difficult to see what happens.
Perhaps separating DynamicMap in a different method would be a good idea, because Map doesn't care about the threading issues (something might happen with generic mappings, but I don't have a failing test).
Also, maybe coarser grained locking would make the code easier to understand. As in wrapping the "find mapper" part of DynamicMap in a lock for the type pair, or something like that.