### PR TITLE
Fixes Include Seal() Problems #762 #683

### DIFF
--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -510,6 +510,7 @@ namespace AutoMapper
 
         private void AssertConfigurationIsValid(IEnumerable<TypeMap> typeMaps)
         {
+            Seal();
             var maps = typeMaps as TypeMap[] ?? typeMaps.ToArray();
             var badTypeMaps =
                 (from typeMap in maps

--- a/src/UnitTests/Bug/MappingInheritance.cs
+++ b/src/UnitTests/Bug/MappingInheritance.cs
@@ -11,17 +11,14 @@ namespace AutoMapper.UnitTests.Bug
 
         protected override void Establish_context()
         {
-            Mapper.Initialize(cfg =>
-            {
-                cfg.CreateMap<Entity, BaseModel>()
+            Mapper.CreateMap<Entity, ViewModel>();
+            Mapper.CreateMap<Entity, BaseModel>()
                     .ForMember(model => model.Value1, mce => mce.MapFrom(entity => entity.Value2))
                     .ForMember(model => model.Value2, mce => mce.MapFrom(entity => entity.Value1))
                     .Include<Entity, EditModel>()
                     .Include<Entity, ViewModel>();
-                cfg.CreateMap<Entity, EditModel>()
-                    .ForMember(model => model.Value3, mce => mce.MapFrom(entity => entity.Value1 + entity.Value2));
-                cfg.CreateMap<Entity, ViewModel>();
-            });
+            Mapper.CreateMap<Entity, EditModel>()
+                .ForMember(model => model.Value3, mce => mce.MapFrom(entity => entity.Value1 + entity.Value2));
         }
 
         protected override void Because_of()

--- a/src/UnitTests/MappingInheritance/IncludedMappingShouldInheritBaseMappings.cs
+++ b/src/UnitTests/MappingInheritance/IncludedMappingShouldInheritBaseMappings.cs
@@ -45,6 +45,20 @@ namespace AutoMapper.UnitTests.Bug
 
             Mapper.AssertConfigurationIsValid();
         }
+        [Fact]
+        public void included_mapping_should_not_care_about_order()
+        {
+            Mapper.Initialize(cfg =>
+            {
+                cfg.CreateMap<ModelSubObject, DtoSubObject>()
+                    .IncludeBase<ModelObject, DtoObject>();
+                cfg.CreateMap<ModelObject, DtoObject>()
+                    .ForMember(d => d.BaseString, m => m.MapFrom(s => s.DifferentBaseString))
+                    ;
+            });
+
+            Mapper.AssertConfigurationIsValid();
+        }
 
         [Fact]
         public void included_mapping_should_inherit_base_ignore_mappings_should_not_throw()


### PR DESCRIPTION
Fixes #762 and #683
Including types will delay the setting of the property maps to Seal().  Seal TypeMap will seal inherited types first, so their inherited type maps will go recursively down to the most inherited map and then back up to the base mapping.  This means order of including Type Maps and IncludeBase no longer matter, they will always seal the most inherited type map and have its property maps persist to the type maps that included it.
AssertConfigIsValid will seal type maps before check property maps.  This will pass all inherited type maps tests without the use of Initialize function.  Actually mapping a type will seal the things it inherits from and put them into the typemapcache, so no need to do Initilize to cache them before hand.