### PR TITLE
Set projection and conversion with same expression

### DIFF
--- a/src/AutoMapper/IMappingExpression.cs
+++ b/src/AutoMapper/IMappingExpression.cs
@@ -130,16 +130,16 @@ namespace AutoMapper
         IMappingExpression<TSource, TDestination> WithProfile(string profileName);
 
         /// <summary>
-        /// Skip member mapping and use a custom expression during LINQ projection
+        /// Skip member mapping and use a custom expression for LINQ projection only
         /// </summary>
         /// <param name="projectionExpression">Projection expression</param>
         void ProjectUsing(Expression<Func<TSource, TDestination>> projectionExpression);
 
         /// <summary>
-        /// Skip member mapping and use a custom expression for both LINQ projection and regular mapping
+        /// Skip member mapping and use a custom expression for both LINQ projection and normal conversion
         /// </summary>
         /// <param name="projectionExpression">Projection expression</param>
-        void ProjectAndMapUsing(Expression<Func<TSource, TDestination>> projectionExpression);
+        void ProjectAndConvertUsing(Expression<Func<TSource, TDestination>> projectionExpression);
 
         /// <summary>
         /// Skip member mapping and use a custom function to convert to the destination type

--- a/src/AutoMapper/IMappingExpression.cs
+++ b/src/AutoMapper/IMappingExpression.cs
@@ -136,6 +136,12 @@ namespace AutoMapper
         void ProjectUsing(Expression<Func<TSource, TDestination>> projectionExpression);
 
         /// <summary>
+        /// Skip member mapping and use a custom expression for both LINQ projection and regular mapping
+        /// </summary>
+        /// <param name="projectionExpression">Projection expression</param>
+        void ProjectAndMapUsing(Expression<Func<TSource, TDestination>> projectionExpression);
+
+        /// <summary>
         /// Skip member mapping and use a custom function to convert to the destination type
         /// </summary>
         /// <param name="mappingFunction">Callback to convert from source type to destination type</param>

--- a/src/AutoMapper/Internal/MappingExpression.cs
+++ b/src/AutoMapper/Internal/MappingExpression.cs
@@ -268,6 +268,11 @@ namespace AutoMapper.Internal
             TypeMap.UseCustomProjection(projectionExpression);
         }
 
+        public void ProjectAndMapUsing(Expression<Func<TSource, TDestination>> projectionExpression)
+        {
+            TypeMap.UseCustomProjection(projectionExpression, true);
+        }
+
         public void NullSubstitute(object nullSubstitute)
         {
             _propertyMap.SetNullSubstitute(nullSubstitute);

--- a/src/AutoMapper/Internal/MappingExpression.cs
+++ b/src/AutoMapper/Internal/MappingExpression.cs
@@ -268,7 +268,7 @@ namespace AutoMapper.Internal
             TypeMap.UseCustomProjection(projectionExpression);
         }
 
-        public void ProjectAndMapUsing(Expression<Func<TSource, TDestination>> projectionExpression)
+        public void ProjectAndConvertUsing(Expression<Func<TSource, TDestination>> projectionExpression)
         {
             TypeMap.UseCustomProjection(projectionExpression, true);
         }

--- a/src/AutoMapper/QueryableExtensions/Extensions.cs
+++ b/src/AutoMapper/QueryableExtensions/Extensions.cs
@@ -68,7 +68,7 @@ namespace AutoMapper.QueryableExtensions
         }
 
         /// <summary>
-        /// Extention method to project from a queryable using the static <see cref="Mapper.Engine"/> property.
+        /// Extension method to project from a queryable using the static <see cref="Mapper.Engine"/> property.
         /// Due to generic parameter inference, you need to call Project().To to execute the map
         /// </summary>
         /// <remarks>Projections are only calculated once and cached</remarks>
@@ -82,7 +82,7 @@ namespace AutoMapper.QueryableExtensions
         }
 
         /// <summary>
-        /// Extention method to project from a queryable using the provided mapping engine
+        /// Extension method to project from a queryable using the provided mapping engine
         /// Due to generic parameter inference, you need to call Project().To to execute the map
         /// </summary>
         /// <remarks>Projections are only calculated once and cached</remarks>
@@ -97,7 +97,7 @@ namespace AutoMapper.QueryableExtensions
         }
 
         /// <summary>
-        /// Extention method to project from a queryable using the static <see cref="Mapper.Engine"/> property.
+        /// Extension method to project from a queryable using the static <see cref="Mapper.Engine"/> property.
         /// </summary>
         /// <remarks>Projections are only calculated once and cached</remarks>
         /// <typeparam name="TDestination">Destination type</typeparam>
@@ -110,7 +110,7 @@ namespace AutoMapper.QueryableExtensions
         }
 
         /// <summary>
-        /// Extention method to project from a queryable using the provided mapping engine
+        /// Extension method to project from a queryable using the provided mapping engine
         /// </summary>
         /// <remarks>Projections are only calculated once and cached</remarks>
         /// <typeparam name="TDestination">Destination type</typeparam>

--- a/src/UnitTests/Projection/ProjectionDeclaration.cs
+++ b/src/UnitTests/Projection/ProjectionDeclaration.cs
@@ -14,13 +14,13 @@ namespace AutoMapper.UnitTests.Projection
         public class ProjectionDeclaration
         {          
             [Fact]
-            public void Projection_expression_can_be_used_for_mapping()
+            public void Projection_expression_can_be_used_for_conversion()
             {
                 string friendlyGreeting = "Hello there!";
 
                 Mapper.Initialize(x => {
                     x.CreateMap<Source, Target>()
-                        .ProjectAndMapUsing(s => new Target { String = friendlyGreeting });
+                        .ProjectAndConvertUsing(s => new Target { String = friendlyGreeting });
                 });
                 
                 var target = Mapper.Map<Target>(new Source());

--- a/src/UnitTests/Projection/ProjectionDeclaration.cs
+++ b/src/UnitTests/Projection/ProjectionDeclaration.cs
@@ -1,0 +1,41 @@
+﻿using System;
+
+namespace AutoMapper.UnitTests.Projection
+{
+    namespace NullableItemsTests
+    {
+        using System.Linq;
+        using QueryableExtensions;
+        using Should;
+        using Should.Core.Assertions;
+        using Xunit;
+
+        
+        public class ProjectionDeclaration
+        {          
+            [Fact]
+            public void Projection_expression_should_be_used_for_mapping()
+            {
+                string friendlyGreeting = "Hello there!";
+
+                Mapper.Initialize(x => {
+                    x.CreateMap<Source, Target>()
+                        .ProjectUsing(s => new Target { String = friendlyGreeting });
+                });
+                
+                var target = Mapper.Map<Target>(new Source());
+
+                target.String.ShouldEqual(friendlyGreeting);
+            }
+            
+
+            class Source { }
+            
+            class Target
+            {
+                public string String { get; set; }
+            }
+            
+        }
+    }
+}

--- a/src/UnitTests/Projection/ProjectionDeclaration.cs
+++ b/src/UnitTests/Projection/ProjectionDeclaration.cs
@@ -14,13 +14,13 @@ namespace AutoMapper.UnitTests.Projection
         public class ProjectionDeclaration
         {          
             [Fact]
-            public void Projection_expression_should_be_used_for_mapping()
+            public void Projection_expression_can_be_used_for_mapping()
             {
                 string friendlyGreeting = "Hello there!";
 
                 Mapper.Initialize(x => {
                     x.CreateMap<Source, Target>()
-                        .ProjectUsing(s => new Target { String = friendlyGreeting });
+                        .ProjectAndMapUsing(s => new Target { String = friendlyGreeting });
                 });
                 
                 var target = Mapper.Map<Target>(new Source());

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -223,6 +223,7 @@
     <Compile Include="Projection\ProjectCollectionListTest.cs" />
     <Compile Include="Projection\ProjectEnumerableToArrayTest.cs" />
     <Compile Include="Projection\ProjectEnumTest.cs" />
+    <Compile Include="Projection\ProjectionDeclaration.cs" />
     <Compile Include="Projection\ProjectTest.cs" />
     <Compile Include="Projection\ToStringTests.cs" />
     <Compile Include="Query\SourceInjectedQuery.cs" />


### PR DESCRIPTION
As per #840 (in part!), when using QueryableExtensions it would be nice if declared projection rules were picked up for normal mapping too. 

The API raises expectations that this should happen already, as ProjectUsing returns void and doesn't allow any run-on clauses: it's final, and seems like it declares everything that needs to be declared. When Mapper.Map is then inadvertently used alongside projections, and it throws an exception, the innocent user may blame AutoMapper and convince himself that something is broken, rather than suspecting his own misunderstanding of the API.

Therefore I've changed the comment on ProjectUsing to be a little more explicit, and also exposed a new ProjectAndConvertUsing method that does as you'd expect.