### PR TITLE
Added Serializable attribute to AutoMapperMappingException

### DIFF
--- a/src/AutoMapper/AutoMapperMappingException.cs
+++ b/src/AutoMapper/AutoMapperMappingException.cs
@@ -5,6 +5,7 @@ namespace AutoMapper
     using System.Linq;
     using System.Text;
 
+    [Serializable]
     public class AutoMapperMappingException : Exception
     {
         private readonly string _message;


### PR DESCRIPTION
In order for WCF to send the exception information over the wire, the exception must be marked with the [Serializable] attribute