### PR TITLE
Fixed Issues with property map inheritance

### DIFF
--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -417,9 +417,9 @@ namespace AutoMapper
 
         private IEnumerable<TypePair> GetRelatedTypePairs(TypePair root)
         {
-            var includeOverrideTypePairs =
+            var includeOverrideTypePairs = 
                 GetAllTypeMaps()
-                    .Where(tm => tm.SourceType.IsAssignableFrom(root.SourceType) && (tm.DestinationTypeOverride ?? tm.DestinationType) != root.DestinationType && tm.DestinationType.IsAssignableFrom(root.DestinationType))
+                    .Where(tm => tm.HasDerivedTypesToInclude() && tm.SourceType.IsAssignableFrom(root.SourceType) && (tm.DestinationTypeOverride ?? tm.DestinationType) != root.DestinationType && tm.DestinationType.IsAssignableFrom(root.DestinationType))
                     .Select(tm => new TypePair(tm.SourceType,tm.DestinationTypeOverride ?? tm.GetDerivedTypeFor(root.SourceType))).ToList();
             var subTypePairs =
                 from sourceType in GetAllTypes(root.SourceType)

--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -417,10 +417,15 @@ namespace AutoMapper
 
         private IEnumerable<TypePair> GetRelatedTypePairs(TypePair root)
         {
-            return
+            var includeOverrideTypePairs =
+                GetAllTypeMaps()
+                    .Where(tm => tm.SourceType.IsAssignableFrom(root.SourceType) && (tm.DestinationTypeOverride ?? tm.DestinationType) != root.DestinationType && tm.DestinationType.IsAssignableFrom(root.DestinationType))
+                    .Select(tm => new TypePair(tm.SourceType,tm.DestinationTypeOverride ?? tm.GetDerivedTypeFor(root.SourceType))).ToList();
+            var subTypePairs =
                 from sourceType in GetAllTypes(root.SourceType)
                 from destinationType in GetAllTypes(root.DestinationType)
                 select new TypePair(sourceType, destinationType);
+            return includeOverrideTypePairs.Concat(subTypePairs);
         }
 
         private IEnumerable<Type> GetAllTypes(Type type)

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -193,7 +193,7 @@ namespace AutoMapper
 
         public bool HasDerivedTypesToInclude()
         {
-            return _includedDerivedTypes.Any();
+            return _includedDerivedTypes.Any() || DestinationTypeOverride != null;
         }
 
         public void UseCustomMapper(Func<ResolutionContext, object> customMapper)

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -183,7 +183,7 @@ namespace AutoMapper
             // This might need to be fixed for multiple derived source types to different dest types
             var match = _includedDerivedTypes.FirstOrDefault(tp => tp.SourceType == derivedSourceType);
 
-            return match == null ? DestinationType : match.DestinationType;
+            return DestinationTypeOverride ?? match?.DestinationType ?? DestinationType;
         }
 
         public bool TypeHasBeenIncluded(Type derivedSourceType, Type derivedDestinationType)

--- a/src/UnitTests/Bug/BaseMapWithIncludesAndUnincludedMappings.cs
+++ b/src/UnitTests/Bug/BaseMapWithIncludesAndUnincludedMappings.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using Should.Core.Assertions;
+using Xunit;
 
 namespace AutoMapper.UnitTests.Bug
 {
@@ -35,6 +36,71 @@ namespace AutoMapper.UnitTests.Bug
             Mapper.CreateMap<A, ADTO>().Include<B, BDTO>();
             Mapper.CreateMap<B, BDTO>();
             var a = Mapper.Map<A, ADTO>(new B(), new BDTO2()); // Throws invalid cast exception trying to convert BDTO2 to BDTO
+        }
+    }
+
+    public class BaseMapChildProperty
+    {
+        public class Container
+        {
+            public BaseA Item { get; set; }
+        }
+
+        public class Container2
+        {
+            public BaseB Item { get; set; }
+        }
+        public class BaseA
+        {
+            public string Name { get; set; }
+        }
+
+        public class BaseB
+        {
+            public string Name { get; set; }
+        }
+
+        public class ProxyOfSubA : SubA
+        {
+        }
+        public class SubA : BaseA
+        {
+            public string Description { get; set; }
+        }
+
+        public class SubB : BaseB
+        {
+            public string Description { get; set; }
+        }
+
+        [Fact]
+        public void TestInitialiserProxyOfSub()
+        {
+            Mapper.Initialize(cfg =>
+            {
+                cfg.CreateMap<SubA, SubB>();
+                cfg.CreateMap<SubA, BaseB>().As<SubB>();
+                cfg.CreateMap<Container, Container2>();
+            });
+
+            var mapped = Mapper.Map<Container, Container2>(new Container() { Item = new ProxyOfSubA() { Name = "Martin", Description = "Hello" } });
+            Assert.IsType<SubB>(mapped.Item);
+
+        }
+
+        [Fact]
+        public void TestInitialiserProxyOfSubInclude()
+        {
+            Mapper.Initialize(cfg =>
+            {
+                cfg.CreateMap<BaseA, BaseB>().Include<SubA, SubB>();
+                cfg.CreateMap<SubA, SubB>();
+                cfg.CreateMap<Container, Container2>();
+            });
+
+            var mapped = Mapper.Map<Container, Container2>(new Container() { Item = new ProxyOfSubA() { Name = "Martin", Description = "Hello" } });
+            Assert.IsType<SubB>(mapped.Item);
+
         }
     }
 }

--- a/src/UnitTests/Bug/BaseMapWithIncludesAndUnincludedMappings.cs
+++ b/src/UnitTests/Bug/BaseMapWithIncludesAndUnincludedMappings.cs
@@ -89,6 +89,20 @@ namespace AutoMapper.UnitTests.Bug
         }
 
         [Fact]
+        public void TestInitialiserProxyOfSub1()
+        {
+            Mapper.Initialize(cfg =>
+            {
+                cfg.CreateMap<BaseA, SubB>();
+                cfg.CreateMap<BaseA, BaseB>();
+            });
+
+            var mapped = Mapper.Map<BaseA, SubB>(new ProxyOfSubA() { Name = "Martin", Description = "Hello" });
+            Assert.IsType<SubB>(mapped);
+
+        }
+
+        [Fact]
         public void TestInitialiserProxyOfSubInclude()
         {
             Mapper.Initialize(cfg =>

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -61,8 +61,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Fixie">
-      <HintPath>..\packages\Fixie.1.0.0.3\lib\net45\Fixie.dll</HintPath>
+    <Reference Include="Fixie, Version=1.0.0.29, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Fixie.1.0.0.29\lib\net45\Fixie.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Rhino.Mocks, Version=3.5.0.1337, Culture=neutral, PublicKeyToken=0b3305902db7183f, processorArchitecture=MSIL">
@@ -326,6 +327,9 @@
       <Project>{8c955148-fa96-4f0d-880d-abb6770f54e9}</Project>
       <Name>AutoMapper.Net4</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/UnitTests/packages.config
+++ b/src/UnitTests/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Fixie" version="1.0.0.3" targetFramework="net453" />
+  <package id="Fixie" version="1.0.0.29" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Fixes #842, #887, and #893

@jbogard I knew there was a reason GetDerivedTypeFor(Type sourceType) existed.