### PR TITLE
Fix for #918

### DIFF
--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -376,8 +376,7 @@ namespace AutoMapper
 
         public TypeMap ResolveTypeMap(ResolutionResult resolutionResult, Type destinationType)
         {
-            return ResolveTypeMap(resolutionResult.Value, null, resolutionResult.Type, destinationType) ??
-                   ResolveTypeMap(resolutionResult.Value, null, resolutionResult.MemberType, destinationType);
+            return ResolveTypeMap(resolutionResult.Type, destinationType) ?? ResolveTypeMap(resolutionResult.MemberType, destinationType);
         }
 
         public TypeMap FindClosedGenericTypeMapFor(ResolutionContext context)
@@ -431,9 +430,6 @@ namespace AutoMapper
         private IEnumerable<Type> GetAllTypes(Type type)
         {
             yield return type;
-
-            if (type.IsValueType() && !type.IsNullableType())
-                yield return typeof (Nullable<>).MakeGenericType(type);
 
             Type baseType = type.BaseType();
             while (baseType != null)

--- a/src/UnitTests/Bug/NullableDateTime.cs
+++ b/src/UnitTests/Bug/NullableDateTime.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Should;
+using AutoMapper;
+using Xunit;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public class NullableDateTime : AutoMapperSpecBase
+    {
+        Destination _destination;
+        DateTime _date = new DateTime(1900, 1, 1);
+
+        public class Source
+        {
+            public DateTime Value { get; set; }
+        }
+
+        public class Destination
+        {
+            public DateTime Value { get; set; }
+        }
+
+        protected override void Establish_context()
+        {
+            Mapper.Initialize(c=>
+            {
+                c.CreateMap<Source, Destination>();
+                c.CreateMap<DateTime, DateTime?>().ConvertUsing(source => source == new DateTime(1900, 1, 1) ? (DateTime?)null : source);
+            });
+        }
+
+        protected override void Because_of()
+        {
+            _destination = Mapper.Map<Destination>(new Source { Value = _date });
+        }
+
+        [Fact]
+        public void Should_map_as_usual()
+        {
+            _destination.Value.ShouldEqual(_date);
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -99,6 +99,7 @@
     <Compile Include="Bug\BaseMapWithIncludesAndUnincludedMappings.cs" />
     <Compile Include="Bug\CollectionBaseClassGetConvention.cs" />
     <Compile Include="Bug\ForAllMaps.cs" />
+    <Compile Include="Bug\NullableDateTime.cs" />
     <Compile Include="Bug\ReverseMapReplaceMemberName.cs" />
     <Compile Include="Bug\JsonNet.cs" />
     <Compile Include="Bug\TargetISet.cs" />


### PR DESCRIPTION
#918 
Exclude Nullable<Type> from related types, but try to find the type map both with the runtime type and the declared type when passed a ResolutionResult