### PR TITLE
Fix for #967

### DIFF
--- a/src/AutoMapper/Internal/IMappingOptionsMemberMapper.cs
+++ b/src/AutoMapper/Internal/IMappingOptionsMemberMapper.cs
@@ -114,7 +114,7 @@ namespace AutoMapper
                 select new { sourceName, destName };
             var match =
                 all.FirstOrDefault(
-                    pair => pair.destName.possibles.Any(p => string.CompareOrdinal(p, pair.sourceName) == 0));
+                    pair => pair.destName.possibles.Any(p => string.Compare(p, pair.sourceName, StringComparison.OrdinalIgnoreCase) == 0));
             return match?.destName.mi;
         }
 
@@ -167,7 +167,7 @@ namespace AutoMapper
                 select new { sourceName, destName };
             var match =
                 all.FirstOrDefault(
-                    pair => pair.destName.possibles.Any(p => string.CompareOrdinal(p, pair.sourceName) == 0));
+                    pair => pair.destName.possibles.Any(p => string.Compare(p, pair.sourceName, StringComparison.OrdinalIgnoreCase) == 0));
             if (match == null)
                 return null;
             return match.destName.mi;
@@ -209,7 +209,7 @@ namespace AutoMapper
 
         public override bool IsMatch(TypeDetails typeInfo, MemberInfo memberInfo, Type destType, string nameToSearch)
         {
-            return string.CompareOrdinal(MatchingName, nameToSearch) == 0;
+            return string.Compare(MatchingName, nameToSearch, StringComparison.OrdinalIgnoreCase) == 0;
         }
     }
 


### PR DESCRIPTION
All member mapping logic is case insensitive now.

Includes PreFix, PostFix, String Replacement, and MapToAttribute.