### PR TITLE
Max depth

### DIFF
--- a/src/AutoMapper/QueryableExtensions/Impl/EnumerableExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/EnumerableExpressionBinder.cs
@@ -37,6 +37,10 @@ namespace AutoMapper.QueryableExtensions.Impl
             if (sourceListType != destinationListType)
             {
                 var transformedExpression = ((IMappingEngineRunner)mappingEngine).CreateMapExpression(listTypePair, typePairCount);
+                if(transformedExpression == null)
+                {
+                    return null;
+                }
                 selectExpression = Expression.Call(
                     typeof (Enumerable),
                     "Select",

--- a/src/AutoMapper/QueryableExtensions/Impl/MappedTypeExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/MappedTypeExpressionBinder.cs
@@ -20,7 +20,10 @@ namespace AutoMapper.QueryableExtensions.Impl
             ExpressionRequest request, ExpressionResolutionResult result, Internal.IDictionary<ExpressionRequest, int> typePairCount)
         {
             var transformedExpression = ((IMappingEngineRunner)mappingEngine).CreateMapExpression(request, result.ResolutionExpression, typePairCount);
-
+            if(transformedExpression == null)
+            {
+                return null;
+            }
             // Handles null source property so it will not create an object with possible non-nullable propeerties 
             // which would result in an exception.
             if (mappingEngine.ConfigurationProvider.AllowNullDestinationValues)

--- a/src/IntegrationTests.Net4/IntegrationTests.Net4.csproj
+++ b/src/IntegrationTests.Net4/IntegrationTests.Net4.csproj
@@ -76,6 +76,7 @@
     <Compile Include="OverrideDestinationMappingsTest.cs" />
     <Compile Include="ProjectToAbstractType.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="MaxDepthWithCollections.cs" />
     <Compile Include="ProxyTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/IntegrationTests.Net4/MaxDepthWithCollections.cs
+++ b/src/IntegrationTests.Net4/MaxDepthWithCollections.cs
@@ -1,0 +1,91 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Data.Entity;
+using System.Linq;
+using AutoMapper.QueryableExtensions;
+using AutoMapper.UnitTests;
+using Xunit;
+
+namespace AutoMapper.IntegrationTests.Net4
+{
+    public class MaxDepthWithCollections : AutoMapperSpecBase
+    {
+        protected override void Establish_context()
+        {
+            Mapper.Initialize(cfg => 
+            {
+                cfg.CreateMap<TrainingCourse, TrainingCourseDto>().MaxDepth(1);
+                cfg.CreateMap<TrainingContent, TrainingContentDto>();
+            });
+        }
+
+        [Fact]
+        public void Should_project_with_MaxDepth()
+        {
+            using(var context = new ClientContext())
+            {
+                var course = context.TrainingCourses.ProjectTo<TrainingCourseDto>().FirstOrDefault(n => n.CourseName == "Course 1");
+            }
+        }
+
+        class Initializer : DropCreateDatabaseAlways<ClientContext>
+        {
+            protected override void Seed(ClientContext context)
+            {
+                var course = new TrainingCourse { CourseName = "Course 1" };
+                context.TrainingCourses.Add(course);
+                var content = new TrainingContent { ContentName = "Content 1", Course = course };
+                context.TrainingContents.Add(content);
+                course.Content.Add(content);
+            }
+        }
+
+        class ClientContext : DbContext
+        {
+            public ClientContext()
+            {
+                Database.SetInitializer(new Initializer());
+            }
+            public DbSet<TrainingCourse> TrainingCourses { get; set; }
+            public DbSet<TrainingContent> TrainingContents { get; set; }
+        }
+
+        public class TrainingCourse
+        {
+            [Key]
+            public int CourseId { get; set; }
+
+            public string CourseName { get; set; }
+
+            public virtual ICollection<TrainingContent> Content { get; set; } = new List<TrainingContent>();
+        }
+
+        public class TrainingContent
+        {
+            [Key]
+            public int ContentId { get; set; }
+
+            public string ContentName { get; set; }
+
+            public virtual TrainingCourse Course { get; set; }
+        }
+
+        public class TrainingCourseDto
+        {
+            public int CourseId { get; set; }
+
+            public string CourseName { get; set; }
+
+            public virtual ICollection<TrainingContentDto> Content { get; set; }
+        }
+
+        public class TrainingContentDto
+        {
+            public int ContentId { get; set; }
+
+            public string ContentName { get; set; }
+
+            public TrainingCourseDto Course { get; set; }
+        }
+    }
+}

--- a/src/IntegrationTests.Net4/MaxDepthWithCollections.cs
+++ b/src/IntegrationTests.Net4/MaxDepthWithCollections.cs
@@ -14,6 +14,7 @@ namespace AutoMapper.IntegrationTests.Net4
         {
             Mapper.Initialize(cfg => 
             {
+                //cfg.AllowNullDestinationValues = false;
                 cfg.CreateMap<TrainingCourse, TrainingCourseDto>().MaxDepth(1);
                 cfg.CreateMap<TrainingContent, TrainingContentDto>();
             });

--- a/src/IntegrationTests.Net4/MaxDepthWithCollections.cs
+++ b/src/IntegrationTests.Net4/MaxDepthWithCollections.cs
@@ -5,11 +5,14 @@ using System.Linq;
 using AutoMapper.QueryableExtensions;
 using AutoMapper.UnitTests;
 using Xunit;
+using Should;
 
 namespace AutoMapper.IntegrationTests.Net4
 {
     public class MaxDepthWithCollections : AutoMapperSpecBase
     {
+        TrainingCourseDto _course;
+
         protected override void Establish_context()
         {
             Mapper.Initialize(cfg => 
@@ -20,13 +23,21 @@ namespace AutoMapper.IntegrationTests.Net4
             });
         }
 
-        [Fact]
-        public void Should_project_with_MaxDepth()
+        protected override void Because_of()
         {
             using(var context = new ClientContext())
             {
-                var course = context.TrainingCourses.ProjectTo<TrainingCourseDto>().FirstOrDefault(n => n.CourseName == "Course 1");
+                _course = context.TrainingCourses.ProjectTo<TrainingCourseDto>().FirstOrDefault(n => n.CourseName == "Course 1");
             }
+        }
+
+        [Fact]
+        public void Should_project_with_MaxDepth()
+        {
+            _course.CourseName.ShouldEqual("Course 1");
+            var content = _course.Content[0];
+            content.ContentName.ShouldEqual("Content 1");
+            content.Course.ShouldBeNull();
         }
 
         class Initializer : DropCreateDatabaseAlways<ClientContext>
@@ -58,7 +69,7 @@ namespace AutoMapper.IntegrationTests.Net4
 
             public string CourseName { get; set; }
 
-            public virtual ICollection<TrainingContent> Content { get; set; } = new List<TrainingContent>();
+            public virtual IList<TrainingContent> Content { get; set; } = new List<TrainingContent>();
         }
 
         public class TrainingContent
@@ -77,7 +88,7 @@ namespace AutoMapper.IntegrationTests.Net4
 
             public string CourseName { get; set; }
 
-            public virtual ICollection<TrainingContentDto> Content { get; set; }
+            public virtual IList<TrainingContentDto> Content { get; set; }
         }
 
         public class TrainingContentDto

--- a/src/IntegrationTests.Net4/ProxyTests.cs
+++ b/src/IntegrationTests.Net4/ProxyTests.cs
@@ -39,7 +39,7 @@
 
         class ClientContext : DbContext
         {
-            public ClientContext() : base(@"Server=(localdb)\v12.0;Integrated Security=true;Initial Catalog = ClientContext;")
+            public ClientContext()
             {
             }
 


### PR DESCRIPTION
The problem is that when reaching max depth we initialize the property with new T. But this can result in an invalid EF expression (duplicate initialization for T). The idea is to skip the property.