### PR TITLE
Removed DataReaderMapperYieldReturnEnabled; reverted ConstructorMappi…

### DIFF
--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -111,7 +111,6 @@ namespace AutoMapper
             set { GetProfile(DefaultProfileName).DefaultMemberConfig.AddMember<NameSplitMember>(_ => _.DestinationMemberNamingConvention = value); }
         }
 
-        public bool DataReaderMapperYieldReturnEnabled { get; set; }
         public IEnumerable<MethodInfo> SourceExtensionMethods => GetProfile(DefaultProfileName).SourceExtensionMethods;
 
         public IEnumerable<IMemberConfiguration> MemberConfigurations => GetProfile(DefaultProfileName).MemberConfigurations;
@@ -131,7 +130,7 @@ namespace AutoMapper
             return condition;
         }
 
-        public bool ConstructorMappingEnabled { get; set; }
+        public bool ConstructorMappingEnabled => GetProfile(DefaultProfileName).ConstructorMappingEnabled;
 
         public IProfileExpression CreateProfile(string profileName)
         {
@@ -170,12 +169,7 @@ namespace AutoMapper
 
         public void DisableConstructorMapping()
         {
-            GetProfile(DefaultProfileName).ConstructorMappingEnabled = false;
-        }
-
-        public void EnableYieldReturnForDataReaderMapper()
-        {
-            GetProfile(DefaultProfileName).DataReaderMapperYieldReturnEnabled = true;
+            GetProfile(DefaultProfileName).DisableConstructorMapping();
         }
 
         public void Seal()

--- a/src/AutoMapper/IConfiguration.cs
+++ b/src/AutoMapper/IConfiguration.cs
@@ -37,18 +37,8 @@ namespace AutoMapper
         void ConstructServicesUsing(Func<Type, object> constructor);
 
         /// <summary>
-        /// Disable constructor mapping. Use this if you don't intend to have AutoMapper try to map to constructors
-        /// </summary>
-        void DisableConstructorMapping();
-
-        /// <summary>
         /// Seal the configuration and optimize maps
         /// </summary>
         void Seal();
-
-        /// <summary>
-        /// Mapping via a data reader will yield return each item, keeping a data reader open instead of eagerly evaluating
-        /// </summary>
-        void EnableYieldReturnForDataReaderMapper();
     }
 }

--- a/src/AutoMapper/IMappingOptions.cs
+++ b/src/AutoMapper/IMappingOptions.cs
@@ -64,11 +64,6 @@ namespace AutoMapper
         bool ConstructorMappingEnabled { get; }
 
         /// <summary>
-        /// For mapping via data readers, enable lazy returning of values instead of immediate evalaution
-        /// </summary>
-        bool DataReaderMapperYieldReturnEnabled { get; }
-
-        /// <summary>
         /// Source extension methods included for search
         /// </summary>
         IEnumerable<MethodInfo> SourceExtensionMethods { get; }

--- a/src/AutoMapper/IProfileConfiguration.cs
+++ b/src/AutoMapper/IProfileConfiguration.cs
@@ -14,8 +14,8 @@ namespace AutoMapper
         IMemberConfiguration AddMemberConfiguration();
         IEnumerable<IConditionalObjectMapper> TypeConfigurations { get; }
         IConditionalObjectMapper AddConditionalObjectMapper();
-        bool ConstructorMappingEnabled { get; set; }
-        bool DataReaderMapperYieldReturnEnabled { get; set; }
+        bool ConstructorMappingEnabled { get; }
+
         IMemberConfiguration DefaultMemberConfig { get; }
         /// <summary>
         /// Source extension methods included for search

--- a/src/AutoMapper/IProfileExpression.cs
+++ b/src/AutoMapper/IProfileExpression.cs
@@ -9,6 +9,11 @@ namespace AutoMapper
     public interface IProfileExpression : IProfileConfiguration
     {
         /// <summary>
+        /// Disable constructor mapping. Use this if you don't intend to have AutoMapper try to map to constructors
+        /// </summary>
+        void DisableConstructorMapping();
+
+        /// <summary>
         /// Creates a mapping configuration from the <typeparamref name="TSource"/> type to the <typeparamref name="TDestination"/> type
         /// </summary>
         /// <typeparam name="TSource">Source type</typeparam>

--- a/src/AutoMapper/Internal/ProfileConfiguration.cs
+++ b/src/AutoMapper/Internal/ProfileConfiguration.cs
@@ -40,11 +40,16 @@ namespace AutoMapper.Internal
             _typeConfigurations.Add(condition);
             return condition;
         }
-        
 
-        public bool ConstructorMappingEnabled { get; set; }
-        public bool DataReaderMapperYieldReturnEnabled { get; set; }
+        public void DisableConstructorMapping()
+        {
+            ConstructorMappingEnabled = false;
+        }
+
+        public bool ConstructorMappingEnabled { get; private set; }
+
         public IMemberConfiguration DefaultMemberConfig { get; }
+
         public IEnumerable<MethodInfo> SourceExtensionMethods => _sourceExtensionMethods;
 
         public Func<PropertyInfo, bool> ShouldMapProperty { get; set; }

--- a/src/AutoMapper/Profile.cs
+++ b/src/AutoMapper/Profile.cs
@@ -190,8 +190,8 @@ namespace AutoMapper
             return condition;
         }
 
-        public bool ConstructorMappingEnabled { get; set; }
-        public bool DataReaderMapperYieldReturnEnabled { get; set; }
+        public bool ConstructorMappingEnabled { get; private set; }
+
         public IEnumerable<MethodInfo> SourceExtensionMethods => _sourceExtensionMethods;
 
         public Func<PropertyInfo, bool> ShouldMapProperty { get; set; }

--- a/src/UnitTests/Tests/TypeMapFactorySpecs.cs
+++ b/src/UnitTests/Tests/TypeMapFactorySpecs.cs
@@ -98,11 +98,6 @@ namespace AutoMapper.UnitTests.Tests
             get { return true; }
         }
 
-        public bool DataReaderMapperYieldReturnEnabled
-        {
-            get { return false; }
-        }
-
         public IEnumerable<MethodInfo> SourceExtensionMethods
         {
             get { return _sourceExtensionMethods; }


### PR DESCRIPTION
…ngEnabled to readonly as property, set by DisableConstructorMapping method
#987
The diff is messed up again. I don't know what to do about that.