### PR TITLE
Add an AllowNull configuration

### DIFF
--- a/src/AutoMapper/IMemberConfigurationExpression.cs
+++ b/src/AutoMapper/IMemberConfigurationExpression.cs
@@ -83,6 +83,11 @@ namespace AutoMapper
         void Ignore();
 
         /// <summary>
+        /// Allow this member to be null. This prevents generating a check condition for it.
+        /// </summary>
+        void AllowNull();
+
+        /// <summary>
         /// Supply a custom mapping order instead of what the .NET runtime returns
         /// </summary>
         /// <param name="mappingOrder">Mapping order value</param>

--- a/src/AutoMapper/Internal/MappingExpression.cs
+++ b/src/AutoMapper/Internal/MappingExpression.cs
@@ -453,6 +453,11 @@ $"Source member {sourceMember} is ambiguous on type {TypeMap.SourceType.FullName
             _propertyMap.Ignore();
         }
 
+        public void AllowNull()
+        {
+            _propertyMap.AllowNull = true;
+        }
+
         public void UseDestinationValue()
         {
             _propertyMap.UseDestinationValue = true;

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -66,6 +66,8 @@ namespace AutoMapper
 
         public bool UseDestinationValue { get; set; }
 
+        public bool AllowNull { get; set; }
+
         internal bool HasCustomValueResolver { get; private set; }
 
         public bool ExplicitExpansion { get; set; }

--- a/src/AutoMapper/QueryableExtensions/Impl/MappedTypeExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/MappedTypeExpressionBinder.cs
@@ -28,7 +28,7 @@ namespace AutoMapper.QueryableExtensions.Impl
             }
             // Handles null source property so it will not create an object with possible non-nullable propeerties 
             // which would result in an exception.
-            if (mappingEngine.ConfigurationProvider.AllowNullDestinationValues)
+            if (mappingEngine.ConfigurationProvider.AllowNullDestinationValues && !propertyMap.AllowNull)
             {
                 var expressionNull = Expression.Constant(null, propertyMap.DestinationPropertyType);
                 transformedExpression =


### PR DESCRIPTION
This is the simplest thing I could think of, and it works. I know that the naming is not appropriate, I think. Should it really be called `AllowNull`?

Usage:
```c#
config
    .CreateMap<News, Dto.NewsDto>()
    .ForMember(n => n.Category, c => c.AllowNull());
```
Where `Category` is another complex DTO of type `CategoryDto`.
Please check [this repro for more details](https://github.com/mrahhal/AutoMapperEFRepro).

This will prevent generating the condition check for `Category` in `NewsDto`. This is necessary only if the relationship between `News` and `Category` is required.

This is supposed to be a workaround for the current release of EF7. (Not sure if EF7 will ever fix the issue because actually it's logical, why would we write a check of null for a relationship that is required?.)

Resolves #1001 