### PR TITLE
Faling test for #1023

### DIFF
--- a/src/AutoMapper/ConstructorParameterMap.cs
+++ b/src/AutoMapper/ConstructorParameterMap.cs
@@ -36,5 +36,10 @@ namespace AutoMapper
         {
             SourceResolvers = resolvers;
         }
+
+        public void ResolveUsing(IValueResolver resolver)
+        {
+            SourceResolvers = new[] { resolver };
+        }
     }
 }

--- a/src/AutoMapper/ICtorParamConfigurationExpression.cs
+++ b/src/AutoMapper/ICtorParamConfigurationExpression.cs
@@ -14,6 +14,12 @@
         /// <typeparam name="TMember">Member type</typeparam>
         /// <param name="sourceMember">Member expression</param>
         void MapFrom<TMember>(Expression<Func<TSource, TMember>> sourceMember);
+
+        /// <summary>
+        /// Map constructor parameter from custom func
+        /// </summary>
+        /// <param name="resolver">Custom func</param>
+        void ResolveUsing(Func<TSource, object> resolver);
     }
 
     public class CtorParamConfigurationExpression<TSource> : ICtorParamConfigurationExpression<TSource>
@@ -29,6 +35,11 @@
         public void MapFrom<TMember>(Expression<Func<TSource, TMember>> sourceMember)
         {
             _ctorParamActions.Add(cpm => cpm.ResolveUsing(new ExpressionBasedResolver<TSource, TMember>(sourceMember)));
+        }
+
+        public void ResolveUsing(Func<TSource, object> resolver)
+        {
+            _ctorParamActions.Add(cpm => cpm.ResolveUsing(new DelegateBasedResolver<TSource, object>((s, c) => resolver(s))));
         }
 
         public void Configure(TypeMap typeMap)

--- a/src/UnitTests/IMappingExpression/ForCtorParam.cs
+++ b/src/UnitTests/IMappingExpression/ForCtorParam.cs
@@ -24,8 +24,8 @@ namespace AutoMapper.UnitTests
 
         protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
         {
-            cfg.CreateMap(typeof (Source), typeof (Dest))
-                .ForCtorParam("thing", opt => opt.MapFrom(src => ((Source) src).Value));
+            cfg.CreateMap(typeof(Source), typeof(Dest))
+                .ForCtorParam("thing", opt => opt.MapFrom(src => ((Source)src).Value));
         });
 
         [Fact]
@@ -34,6 +34,22 @@ namespace AutoMapper.UnitTests
             var dest = Mapper.Map<Source, Dest>(new Source { Value = 5 });
 
             dest.Value1.ShouldEqual(5);
+        }
+
+        [Fact]
+        public void Should_resolve_using_custom_func()
+        {
+            var mapper = new MapperConfiguration(
+                cfg => cfg.CreateMap<Source, Dest>().ForCtorParam("thing", opt => opt.ResolveUsing(src =>
+                {
+                    var rev = src.Value + 3;
+                    return rev;
+                })))
+                .CreateMapper();
+
+            var dest = mapper.Map<Source, Dest>(new Source { Value = 5 });
+
+            dest.Value1.ShouldEqual(8);
         }
     }
 }


### PR DESCRIPTION
This adds a failing test for #1023. If a property

```
public int Bar { get; set; }
```

is added to the `SourceFoo` type, and the setup is updated accordingly,
the test passes, but I would like it to work without that property.