### PR TITLE
CreateMissingMappings adds convention

### DIFF
--- a/src/AutoMapper/ConfigurationStore.cs
+++ b/src/AutoMapper/ConfigurationStore.cs
@@ -95,7 +95,6 @@ namespace AutoMapper
         /// </summary>
         public bool CreateMissingTypeMaps
         {
-            get { return GetProfile(DefaultProfileName).CreateMissingTypeMaps; }
             set { GetProfile(DefaultProfileName).CreateMissingTypeMaps = value; }
         }
 
@@ -405,8 +404,7 @@ namespace AutoMapper
                                 FindTypeMapFor(tp) ??
                                 (!CoveredByObjectMap(typePair)
                                     ? FindConventionTypeMapFor(tp) ??
-                                      FindClosedGenericTypeMapFor(tp) ??
-                                      (CreateMissingTypeMaps ? CreateTypeMap(tp) : null)
+                                      FindClosedGenericTypeMapFor(tp)
                                     : null))
                         .FirstOrDefault(tm => tm != null));
 

--- a/src/AutoMapper/IProfileExpression.cs
+++ b/src/AutoMapper/IProfileExpression.cs
@@ -145,7 +145,7 @@ namespace AutoMapper
         /// <summary>
         /// Create missing type maps during mapping, if necessary
         /// </summary>
-        bool CreateMissingTypeMaps { get; set; }
+        bool CreateMissingTypeMaps { set; }
 
         /// <summary>
         /// Specify common configuration for all type maps.

--- a/src/AutoMapper/Profile.cs
+++ b/src/AutoMapper/Profile.cs
@@ -15,6 +15,7 @@ namespace AutoMapper
     public class Profile : IProfileExpression
     {
         private ConfigurationStore _configurator;
+        private readonly IConditionalObjectMapper _mapMissingTypes;
 
         public Profile(string profileName)
             :this()
@@ -30,6 +31,7 @@ namespace AutoMapper
             IncludeSourceExtensionMethods(typeof(Enumerable).Assembly());
             ShouldMapProperty = p => p.IsPublic();
             ShouldMapField = f => f.IsPublic;
+            _mapMissingTypes = new ConditionalObjectMapper(ProfileName) {Conventions = {tp => true}};
         }
 
         public string ProfileName { get; }
@@ -65,7 +67,17 @@ namespace AutoMapper
             set { DefaultMemberConfig.AddMember<NameSplitMember>(_ => _.DestinationMemberNamingConvention = value); }
         }
 
-        public bool CreateMissingTypeMaps { get; set; }
+
+        public bool CreateMissingTypeMaps
+        {
+            set
+            {
+                if (value)
+                    _typeConfigurations.Add(_mapMissingTypes);
+                else
+                    _typeConfigurations.Remove(_mapMissingTypes);
+            }
+        }
 
         public void ForAllMaps(Action<TypeMap, IMappingExpression> configuration)
         {


### PR DESCRIPTION
This is what I was talking about with CreateMissingMappings property in #1017

Removes extra if statement with a type pair convention that automatically maps everything.

Took out the get cause it doesn't look that useful with the new implementation, but I could put it back in no problem.