### PR TITLE
Marking Profile as abstract and Configure method abstract

### DIFF
--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -73,11 +73,9 @@ namespace AutoMapper
 
         void IConfiguration.AddProfile(Profile profile)
         {
-            profile.Initialize(this);
-
             _profiles.AddOrUpdate(profile.ProfileName, profile, (s, configuration) => profile);
 
-            profile.Configure();
+            profile.Initialize(this);
         }
 
         void IConfiguration.AddProfile<TProfile>() => ((IConfiguration)this).AddProfile(new TProfile());
@@ -363,7 +361,7 @@ namespace AutoMapper
 
         private Profile CreateProfile(string profileName)
         {
-            var profileExpression = new Profile(profileName);
+            var profileExpression = new NamedProfile(profileName);
 
             profileExpression.Initialize(this);
 
@@ -642,9 +640,21 @@ namespace AutoMapper
 
         private Profile GetProfile(string profileName)
         {
-            var expr = _profiles.GetOrAdd(profileName, name => new Profile(profileName));
+            var expr = _profiles.GetOrAdd(profileName, name => new NamedProfile(profileName));
 
             return expr;
+        }
+
+        private class NamedProfile : Profile
+        {
+            public NamedProfile(string profileName) : base(profileName)
+            {
+            }
+
+            protected override void Configure()
+            {
+                // no-op
+            }
         }
 
     }

--- a/src/AutoMapper/Profile.cs
+++ b/src/AutoMapper/Profile.cs
@@ -12,13 +12,13 @@ namespace AutoMapper
     /// <summary>
     /// Provides a named configuration for maps. Naming conventions become scoped per profile.
     /// </summary>
-    public class Profile : IProfileExpression, IProfileConfiguration
+    public abstract class Profile : IProfileExpression, IProfileConfiguration
     {
         private IConfiguration _configurator;
         private readonly IConditionalObjectMapper _mapMissingTypes;
         private readonly List<string> _globalIgnore;
 
-        public Profile(string profileName)
+        protected Profile(string profileName)
             :this()
         {
             ProfileName = profileName;
@@ -37,7 +37,7 @@ namespace AutoMapper
             _memberConfigurations.Add(new MemberConfiguration().AddMember<NameSplitMember>().AddName<PrePostfixName>(_ => _.AddStrings(p => p.Prefixes, "Get")));
         }
 
-        public string ProfileName { get; }
+        public virtual string ProfileName { get; }
 
         public void DisableConstructorMapping()
         {
@@ -160,14 +160,13 @@ namespace AutoMapper
         /// Override this method in a derived class and call the CreateMap method to associate that map with this profile.
         /// Avoid calling the <see cref="Mapper"/> class from this method.
         /// </summary>
-        protected internal virtual void Configure()
-        {
-            // override in a derived class for custom configuration behavior
-        }
+        protected abstract void Configure();
 
         public void Initialize(IConfiguration configurator)
         {
             _configurator = configurator;
+
+            Configure();
         }
 
         

--- a/src/UnitTests/Tests/TypeMapFactorySpecs.cs
+++ b/src/UnitTests/Tests/TypeMapFactorySpecs.cs
@@ -146,10 +146,20 @@ namespace AutoMapper.UnitTests.Tests
             _factory = new TypeMapFactory();
         }
 
+        private class TestProfile : Profile
+        {
+            public override string ProfileName => "Test";
+
+            protected override void Configure()
+            {
+                
+            }
+        }
+
         [Fact]
         public void Should_map_properties_with_same_name()
         {
-            var mappingOptions = new Profile("Test");
+            var mappingOptions = new TestProfile();
             //mappingOptions.SourceMemberNamingConvention = new PascalCaseNamingConvention();
             //mappingOptions.DestinationMemberNamingConvention = new PascalCaseNamingConvention();
 
@@ -182,11 +192,20 @@ namespace AutoMapper.UnitTests.Tests
             public int SomeSourceValue { get; set; }
         }
 
+        private class TestProfile : Profile
+        {
+            public override string ProfileName => "Test";
+
+            protected override void Configure()
+            {
+
+            }
+        }
         protected override void Establish_context()
         {
             var namingConvention = new StubNamingConvention(s => s.Value.ToLower()){SeparatorCharacter = "__", SplittingExpression = new Regex(@"[\p{Ll}\p{Lu}0-9]+(?=__?)")};
 
-            _mappingOptions = new Profile("Test");
+            _mappingOptions = new TestProfile();
             _mappingOptions.AddMemberConfiguration().AddMember<NameSplitMember>(_ =>
             {
                 _.SourceMemberNamingConvention = namingConvention;
@@ -230,11 +249,21 @@ namespace AutoMapper.UnitTests.Tests
             public int some__source__value { get; set; }
         }
 
+        private class TestProfile : Profile
+        {
+            public override string ProfileName => "Test";
+
+            protected override void Configure()
+            {
+
+            }
+        }
+
         protected override void Establish_context()
         {
             var namingConvention = new StubNamingConvention(s => s.Value.ToLower()) { SeparatorCharacter = "__", SplittingExpression = new Regex(@"[\p{Ll}\p{Lu}0-9]+(?=__?)") };
 
-            _mappingOptions = new Profile("Test");
+            _mappingOptions = new TestProfile();
             _mappingOptions.AddMemberConfiguration().AddMember<NameSplitMember>(_ =>
             {
                 _.SourceMemberNamingConvention = new PascalCaseNamingConvention();


### PR DESCRIPTION
The goal is to eliminate some of the bugs around people not using the right method for configuring profiles