### PR TITLE
Obsolete Mutable Profile calls

### DIFF
--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -650,11 +650,6 @@ namespace AutoMapper
             public NamedProfile(string profileName) : base(profileName)
             {
             }
-
-            protected override void Configure()
-            {
-                // no-op
-            }
         }
 
     }

--- a/src/AutoMapper/Profile.cs
+++ b/src/AutoMapper/Profile.cs
@@ -8,7 +8,7 @@ namespace AutoMapper
     using System.Collections.Generic;
     using System.Reflection;
     using Internal;
-
+    
     /// <summary>
     /// Provides a named configuration for maps. Naming conventions become scoped per profile.
     /// </summary>
@@ -39,41 +39,77 @@ namespace AutoMapper
 
         public virtual string ProfileName { get; }
 
-        public void DisableConstructorMapping()
+        [Obsolete("Use interface calls")]
+        public void DisableConstructorMapping() => ((IProfileExpression) this).DisableConstructorMapping();
+        void IProfileExpression.DisableConstructorMapping()
         {
             ConstructorMappingEnabled = false;
         }
 
-        public bool AllowNullDestinationValues { get; set; }
+        [Obsolete("Use interface calls")]
+        public bool AllowNullDestinationValues
+        {
+            get { return ((IProfileExpression)this).AllowNullDestinationValues; }
+            set { ((IProfileExpression)this).AllowNullDestinationValues = value; }
+        }
+        bool IProfileConfiguration.AllowNullDestinationValues => ((IProfileExpression)this).AllowNullDestinationValues;
+        bool IProfileExpression.AllowNullDestinationValues { get; set; }
 
-        public bool AllowNullCollections { get; set; }
+        [Obsolete("Use interface calls")]
+        public bool AllowNullCollections
+        {
+            get { return ((IProfileExpression)this).AllowNullCollections; }
+            set { ((IProfileExpression)this).AllowNullCollections = value; }
+        }
+        bool IProfileConfiguration.AllowNullCollections => ((IProfileExpression)this).AllowNullCollections;
+        bool IProfileExpression.AllowNullCollections { get; set; }
 
-        public IEnumerable<string> GlobalIgnores => _globalIgnore; 
+        public IEnumerable<string> GlobalIgnores => _globalIgnore;
 
+        [Obsolete("Use interface calls")]
         public INamingConvention SourceMemberNamingConvention
         {
-            get
+            get { return ((IProfileExpression)this).SourceMemberNamingConvention; }
+            set { ((IProfileExpression)this).SourceMemberNamingConvention = value; }
+        }
+        INamingConvention IProfileConfiguration.SourceMemberNamingConvention => ((IProfileExpression)this).SourceMemberNamingConvention;
+        INamingConvention IProfileExpression.SourceMemberNamingConvention
         {
+            get
+            {
                 INamingConvention convention = null;
                 DefaultMemberConfig.AddMember<NameSplitMember>(_ => convention = _.SourceMemberNamingConvention);
                 return convention;
-        }
+            }
             set { DefaultMemberConfig.AddMember<NameSplitMember>(_ => _.SourceMemberNamingConvention = value); }
         }
 
+        [Obsolete("Use interface calls")]
         public INamingConvention DestinationMemberNamingConvention
         {
-            get
+            get { return ((IProfileExpression)this).DestinationMemberNamingConvention; }
+            set { ((IProfileExpression)this).DestinationMemberNamingConvention = value; }
+        }
+        INamingConvention IProfileConfiguration.DestinationMemberNamingConvention => ((IProfileExpression)this).DestinationMemberNamingConvention;
+        INamingConvention IProfileExpression.DestinationMemberNamingConvention
         {
+            get
+            {
                 INamingConvention convention = null;
                 DefaultMemberConfig.AddMember<NameSplitMember>(_ => convention = _.DestinationMemberNamingConvention);
                 return convention;
-        }
+            }
             set { DefaultMemberConfig.AddMember<NameSplitMember>(_ => _.DestinationMemberNamingConvention = value); }
         }
 
-
+        [Obsolete("Use interface calls")]
         public bool CreateMissingTypeMaps
+        {
+            get { return ((IProfileExpression)this).CreateMissingTypeMaps; }
+            set { ((IProfileExpression)this).CreateMissingTypeMaps = value; }
+        }
+        bool IProfileConfiguration.CreateMissingTypeMaps => ((IProfileExpression)this).CreateMissingTypeMaps;
+        bool IProfileExpression.CreateMissingTypeMaps
         {
             get
             {
@@ -89,69 +125,92 @@ namespace AutoMapper
             }
         }
 
-        public void ForAllMaps(Action<TypeMap, IMappingExpression> configuration)
-        {
-            _configurator.ForAllMaps(ProfileName, configuration);
-        }
+        [Obsolete("Use interface calls")]
+        public void ForAllMaps(Action<TypeMap, IMappingExpression> configuration) => ((IProfileExpression)this).ForAllMaps(configuration);
+        void IProfileExpression.ForAllMaps(Action<TypeMap, IMappingExpression> configuration) => _configurator.ForAllMaps(ProfileName, configuration);
 
-        public IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>()
+        [Obsolete("Use interface calls")]
+        public IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>() => ((IProfileExpression)this).CreateMap<TSource,TDestination>();
+        IMappingExpression <TSource, TDestination> IProfileExpression.CreateMap<TSource, TDestination>()
         {
             return CreateMap<TSource, TDestination>(MemberList.Destination);
         }
 
-        public IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>(MemberList memberList)
+        [Obsolete("Use interface calls")]
+        public IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>(MemberList memberList) => ((IProfileExpression)this).CreateMap<TSource, TDestination>(memberList);
+        IMappingExpression<TSource, TDestination> IProfileExpression.CreateMap<TSource, TDestination>(MemberList memberList)
         {
             return _configurator.CreateMap<TSource, TDestination>(ProfileName, memberList);
         }
 
-        public IMappingExpression CreateMap(Type sourceType, Type destinationType)
+        [Obsolete("Use interface calls")]
+        public IMappingExpression CreateMap(Type sourceType, Type destinationType) => ((IProfileExpression)this).CreateMap(sourceType, destinationType);
+        IMappingExpression IProfileExpression.CreateMap(Type sourceType, Type destinationType)
         {
             return CreateMap(sourceType, destinationType, MemberList.Destination);
         }
 
-        public IMappingExpression CreateMap(Type sourceType, Type destinationType, MemberList memberList)
+        [Obsolete("Use interface calls")]
+        public IMappingExpression CreateMap(Type sourceType, Type destinationType, MemberList memberList) => ((IProfileExpression)this).CreateMap(sourceType, destinationType, memberList);
+        IMappingExpression IProfileExpression.CreateMap(Type sourceType, Type destinationType, MemberList memberList)
         {
             var map = _configurator.CreateMap(sourceType, destinationType, memberList, ProfileName);
 
             return map;
         }
 
-        public void ClearPrefixes()
+        [Obsolete("Use interface calls")]
+        public void ClearPrefixes() => ((IProfileExpression)this).ClearPrefixes();
+        void IProfileExpression.ClearPrefixes()
         {
             DefaultMemberConfig.AddName<PrePostfixName>(_ => _.Prefixes.Clear());
         }
 
-        public void RecognizeAlias(string original, string alias)
+        [Obsolete("Use interface calls")]
+        public void RecognizeAlias(string original, string alias) => ((IProfileExpression)this).RecognizeAlias(original, alias);
+        void IProfileExpression.RecognizeAlias(string original, string alias)
         {
             DefaultMemberConfig.AddName<ReplaceName>(_ => _.AddReplace(original, alias));
         }
 
-        public void ReplaceMemberName(string original, string newValue)
+        [Obsolete("Use interface calls")]
+        public void ReplaceMemberName(string original, string newValue) => ((IProfileExpression)this).ReplaceMemberName(original, newValue);
+        void IProfileExpression.ReplaceMemberName(string original, string newValue)
         {
             DefaultMemberConfig.AddName<ReplaceName>(_ => _.AddReplace(original, newValue));
         }
 
-        public void RecognizePrefixes(params string[] prefixes)
+        [Obsolete("Use interface calls")]
+        public void RecognizePrefixes(params string[] prefixes) => ((IProfileExpression)this).RecognizePrefixes(prefixes);
+        void IProfileExpression.RecognizePrefixes(params string[] prefixes)
         {
             DefaultMemberConfig.AddName<PrePostfixName>(_ => _.AddStrings(p => p.Prefixes, prefixes));
         }
 
-        public void RecognizePostfixes(params string[] postfixes)
+        [Obsolete("Use interface calls")]
+        public void RecognizePostfixes(params string[] postfixes) => ((IProfileExpression)this).RecognizePostfixes(postfixes);
+        void IProfileExpression.RecognizePostfixes(params string[] postfixes)
         {
             DefaultMemberConfig.AddName<PrePostfixName>(_ => _.AddStrings(p => p.Postfixes, postfixes));
         }
 
-        public void RecognizeDestinationPrefixes(params string[] prefixes)
+        [Obsolete("Use interface calls")]
+        public void RecognizeDestinationPrefixes(params string[] prefixes) => ((IProfileExpression)this).RecognizeDestinationPrefixes(prefixes);
+        void IProfileExpression.RecognizeDestinationPrefixes(params string[] prefixes)
         {
             DefaultMemberConfig.AddName<PrePostfixName>(_ => _.AddStrings(p => p.DestinationPrefixes, prefixes));
         }
 
-        public void RecognizeDestinationPostfixes(params string[] postfixes)
+        [Obsolete("Use interface calls")]
+        public void RecognizeDestinationPostfixes(params string[] postfixes) => ((IProfileExpression)this).RecognizeDestinationPostfixes(postfixes);
+        void IProfileExpression.RecognizeDestinationPostfixes(params string[] postfixes)
         {
             DefaultMemberConfig.AddName<PrePostfixName>(_ => _.AddStrings(p => p.DestinationPostfixes, postfixes));
         }
 
-        public void AddGlobalIgnore(string propertyNameStartingWith)
+        [Obsolete("Use interface calls")]
+        public void AddGlobalIgnore(string propertyNameStartingWith) => ((IProfileExpression)this).AddGlobalIgnore(propertyNameStartingWith);
+        void IProfileExpression.AddGlobalIgnore(string propertyNameStartingWith)
         {
             _globalIgnore.Add(propertyNameStartingWith);
         }
@@ -160,9 +219,15 @@ namespace AutoMapper
         /// Override this method in a derived class and call the CreateMap method to associate that map with this profile.
         /// Avoid calling the <see cref="Mapper"/> class from this method.
         /// </summary>
-        protected abstract void Configure();
+        [Obsolete("Set ConfigurationAction instead")]
+        protected virtual void Configure()
+        {
+            ConfigurationAction(this);
+        }
 
-        public void Initialize(IConfiguration configurator)
+        public Action<IProfileExpression> ConfigurationAction { get; protected set; } = expression => { };
+
+        internal void Initialize(IConfiguration configurator)
         {
             _configurator = configurator;
 
@@ -174,11 +239,16 @@ namespace AutoMapper
 
         private readonly IList<IMemberConfiguration> _memberConfigurations = new List<IMemberConfiguration>();
 
-        public IMemberConfiguration DefaultMemberConfig => _memberConfigurations.First();
+        private IMemberConfiguration DefaultMemberConfig => ((IProfileConfiguration)this).DefaultMemberConfig;
+        IMemberConfiguration IProfileConfiguration.DefaultMemberConfig => _memberConfigurations.First();
 
-        public IEnumerable<IMemberConfiguration> MemberConfigurations => _memberConfigurations;
+        [Obsolete("Use interface calls")]
+        public IEnumerable<IMemberConfiguration> MemberConfigurations => ((IProfileConfiguration)this).MemberConfigurations;
+        IEnumerable<IMemberConfiguration> IProfileConfiguration.MemberConfigurations => _memberConfigurations;
 
-        public IMemberConfiguration AddMemberConfiguration()
+        [Obsolete("Use interface calls")]
+        public IMemberConfiguration AddMemberConfiguration() => ((IProfileExpression)this).AddMemberConfiguration();
+        IMemberConfiguration IProfileExpression.AddMemberConfiguration()
         {
             var condition = new MemberConfiguration();
             _memberConfigurations.Add(condition);
@@ -188,9 +258,13 @@ namespace AutoMapper
 
         private bool _createMissingTypeMaps;
 
-        public IEnumerable<IConditionalObjectMapper> TypeConfigurations => _typeConfigurations;
+        [Obsolete("Use interface calls")]
+        public IEnumerable<IConditionalObjectMapper> TypeConfigurations => ((IProfileConfiguration)this).TypeConfigurations;
+        IEnumerable<IConditionalObjectMapper> IProfileConfiguration.TypeConfigurations => _typeConfigurations;
 
-        public IConditionalObjectMapper AddConditionalObjectMapper()
+        [Obsolete("Use interface calls")]
+        public IConditionalObjectMapper AddConditionalObjectMapper() => ((IProfileExpression)this).AddConditionalObjectMapper();
+        IConditionalObjectMapper IProfileExpression.AddConditionalObjectMapper()
         {
             var condition = new ConditionalObjectMapper(ProfileName);
 
@@ -202,12 +276,28 @@ namespace AutoMapper
         public bool ConstructorMappingEnabled { get; private set; }
 
         public IEnumerable<MethodInfo> SourceExtensionMethods => _sourceExtensionMethods;
+        
+        [Obsolete("Use interface calls")]
+        public Func<PropertyInfo, bool> ShouldMapProperty
+        {
+            get { return ((IProfileExpression)this).ShouldMapProperty; }
+            set { ((IProfileExpression)this).ShouldMapProperty = value; }
+        }
+        Func<PropertyInfo, bool> IProfileConfiguration.ShouldMapProperty => ((IProfileExpression)this).ShouldMapProperty;
+        Func<PropertyInfo, bool> IProfileExpression.ShouldMapProperty { get; set; }
 
-        public Func<PropertyInfo, bool> ShouldMapProperty { get; set; }
+        [Obsolete("Use interface calls")]
+        public Func<FieldInfo, bool> ShouldMapField
+        {
+            get { return ((IProfileExpression)this).ShouldMapField; }
+            set { ((IProfileExpression)this).ShouldMapField = value; }
+        }
+        Func<FieldInfo, bool> IProfileConfiguration.ShouldMapField => ((IProfileExpression)this).ShouldMapField;
+        Func<FieldInfo, bool> IProfileExpression.ShouldMapField { get; set; }
 
-        public Func<FieldInfo, bool> ShouldMapField { get; set; }
-
-        public void IncludeSourceExtensionMethods(Assembly assembly)
+        [Obsolete("Use interface calls")]
+        public void IncludeSourceExtensionMethods(Assembly assembly) => ((IProfileExpression)this).IncludeSourceExtensionMethods(assembly);
+        void IProfileExpression.IncludeSourceExtensionMethods(Assembly assembly)
         {
             //http://stackoverflow.com/questions/299515/c-sharp-reflection-to-identify-extension-methods
             _sourceExtensionMethods.AddRange(assembly.ExportedTypes


### PR DESCRIPTION
Right now Profiles are mutable.  You can edit profiles from the class itself, and getting out of configuration mappings.
```
var profile = new MyProfile();
var config = new MapperConfiguration(cfg => cfg.AddProfile(profile));
profile.CreateMap<Foo, Bar>();
```
So like MapperConfiguration is immutable this is a step towards that for profiles.  Can't remove functionality so obsoleted functions that change state, so in 5.0 they can be taken out and profiles can become immutable as part of the configuration.

`IConfiguration.CreateProfile(string profileName);` also has this problem where you can change it outside the configuration level, but that might be a little too anal about this.  You could even say the other CreateProfile has this problem because in the Action you can set a profile variable to the configuration and edit it later, but at this point it would feel more like a hack and you know this wasn't the intended way of doing things.
This PR doesn't address this, but I can add it or make a new one.