### PR TITLE
Passing test; closes #944

### DIFF
--- a/src/UnitTests/MappingInheritance/GenericsAndInterfaces.cs
+++ b/src/UnitTests/MappingInheritance/GenericsAndInterfaces.cs
@@ -1,0 +1,53 @@
+﻿using Should;
+using Xunit;
+
+namespace AutoMapper.UnitTests.MappingInheritance
+{
+    public class GenericsAndInterfaces : AutoMapperSpecBase
+    {
+        MyClass<ContainerClass> source = new MyClass<ContainerClass> { Container = new ContainerClass { MyProperty = 3 } };
+
+        public interface IMyInterface<T>
+        {
+            T Container { get; set; }
+        }
+
+        public class ContainerClass
+        {
+            public int MyProperty { get; set; }
+        }
+
+        public class ImplementedClass : IMyInterface<ContainerClass>
+        {
+            public ContainerClass Container
+            {
+                get;
+                set;
+            }
+        }
+
+        public class MyClass<T>
+        {
+            public T Container { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => cfg.CreateMap(typeof(MyClass<>), typeof(IMyInterface<>)));
+
+        [Fact]
+        public void ShouldMapToExistingObject()
+        {
+            var destination = new ImplementedClass();
+            Mapper.Map(source, destination, typeof(MyClass<ContainerClass>), typeof(IMyInterface<ContainerClass>));
+            destination.Container.MyProperty.ShouldEqual(3);
+        }
+
+#if !PORTABLE
+        [Fact]
+        public void ShouldMapToNewObject()
+        {
+            var destination = (IMyInterface<ContainerClass>) Mapper.Map(source, typeof(MyClass<ContainerClass>), typeof(ImplementedClass));
+            destination.Container.MyProperty.ShouldEqual(3);
+        }
+#endif
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -209,6 +209,7 @@
     <Compile Include="MappingExceptions.cs" />
     <Compile Include="MappingInheritance\ConventionMappedCollectionShouldMapBaseTypes.cs" />
     <Compile Include="MappingInheritance\IgnoreShouldBeInheritedIfConventionCannotMap.cs" />
+    <Compile Include="MappingInheritance\GenericsAndInterfaces.cs" />
     <Compile Include="MappingInheritance\IncludeBaseBug.cs" />
     <Compile Include="MappingInheritance\IncludedBaseMappingShouldInheritBaseMappings.cs" />
     <Compile Include="MappingInheritance\IncludedMappingShouldInheritBaseMappings.cs" />


### PR DESCRIPTION
For the new object example it uses proxies, so it fails with a cast error if you use the generic Map< ImplementedClass >, but that's [an old story](https://github.com/AutoMapper/AutoMapper/pull/923) :)