### PR TITLE
Added sorting of interfaces (3)

### DIFF
--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -408,7 +408,9 @@ namespace AutoMapper
                 baseType = baseType.BaseType();
             }
 
-            foreach (var interfaceType in type.GetTypeInfo().ImplementedInterfaces)
+            var allInterfaces = type.GetTypeInfo().ImplementedInterfaces.OrderByDescending(t => t, new InterfaceComparer());
+
+            foreach (var interfaceType in allInterfaces)
             {
                 yield return interfaceType;
             }
@@ -530,6 +532,23 @@ namespace AutoMapper
                         DryRunTypeMap(typeMapsChecked, memberContext);
                     }
                 }
+            }
+        }
+        private class InterfaceComparer : IComparer<Type>
+        {
+            public int Compare(Type x, Type y)
+            {
+                var left = x.IsAssignableFrom(y);
+                var right = y.IsAssignableFrom(x);
+                if (left & !right)
+                {
+                    return -1;
+                }
+                if (!left & right)
+                {
+                    return 1;
+                }
+                return 0;
             }
         }
     }

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -583,19 +583,22 @@ namespace AutoMapper
                             .TargetMethods
                             .OrderBy(method => method.DeclaringType, comparer)
                             .Select(method => method.DeclaringType.GetTypeInfo())
-                            .LastOrDefault() ?? _target;
+                            .LastOrDefault();
 
                     var yLastImplementedIn =
                         _target.GetRuntimeInterfaceMap(y)
                             .TargetMethods
                             .OrderBy(method => method.DeclaringType, comparer)
                             .Select(method => method.DeclaringType.GetTypeInfo())
-                            .LastOrDefault() ?? _target;
+                            .LastOrDefault();
 
-                    var xFirstIntroduceTypeIndex =
-                        _typeInheritance.IndexOf(xLastImplementedIn);
-                    var yFirstIntroduceTypeIndex =
-                        _typeInheritance.IndexOf(yLastImplementedIn);
+                    var xFirstIntroduceTypeIndex = xLastImplementedIn != null
+                        ? _typeInheritance.IndexOf(xLastImplementedIn)
+                        : _typeInheritance.FindIndex(type => type.ImplementedInterfaces.Contains(x));
+
+                    var yFirstIntroduceTypeIndex = yLastImplementedIn != null
+                        ? _typeInheritance.IndexOf(yLastImplementedIn)
+                        : _typeInheritance.FindIndex(type => type.ImplementedInterfaces.Contains(y));
 
                     if (xFirstIntroduceTypeIndex < yFirstIntroduceTypeIndex)
                     {

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -399,6 +399,21 @@ namespace AutoMapper
 
         private IEnumerable<Type> GetAllTypes(Type type)
         {
+            var typeInheritance = GetTypeInheritance(type);
+            foreach (var item in typeInheritance)
+                yield return item;
+
+            var interfaceComparer = new InterfaceComparer(type);
+            var allInterfaces = type.GetTypeInfo().ImplementedInterfaces.OrderByDescending(t => t, interfaceComparer);
+
+            foreach (var interfaceType in allInterfaces)
+            {
+                yield return interfaceType;
+            }
+        }
+
+        private static IEnumerable<Type> GetTypeInheritance(Type type)
+        {
             yield return type;
 
             Type baseType = type.BaseType();
@@ -406,13 +421,6 @@ namespace AutoMapper
             {
                 yield return baseType;
                 baseType = baseType.BaseType();
-            }
-
-            var allInterfaces = type.GetTypeInfo().ImplementedInterfaces.OrderByDescending(t => t, new InterfaceComparer());
-
-            foreach (var interfaceType in allInterfaces)
-            {
-                yield return interfaceType;
             }
         }
 
@@ -536,20 +544,72 @@ namespace AutoMapper
         }
         private class InterfaceComparer : IComparer<Type>
         {
+            private readonly List<TypeInfo> _typeInheritance;
+            private readonly TypeInfo _target;
+
+            public InterfaceComparer(Type target)
+            {
+                if (target != null)
+                {
+                    _typeInheritance = GetTypeInheritance(target).Select(type => type.GetTypeInfo()).Reverse().ToList();
+                    _target = _typeInheritance[_typeInheritance.Count - 1];
+                }
+            }
+
             public int Compare(Type x, Type y)
             {
-                var left = x.IsAssignableFrom(y);
-                var right = y.IsAssignableFrom(x);
-                if (left & !right)
+                var xLessOrEqualY = x.IsAssignableFrom(y);
+                var yLessOrEqualX = y.IsAssignableFrom(x);
+
+                if (xLessOrEqualY & !yLessOrEqualX)
                 {
                     return -1;
                 }
-                if (!left & right)
+                if (!xLessOrEqualY & yLessOrEqualX)
                 {
                     return 1;
                 }
+                if (xLessOrEqualY & yLessOrEqualX)
+                {
+                    return 0;
+                }
+
+                if (_target != null && !_target.IsInterface)
+                {
+                    var comparer = new InterfaceComparer(null);
+
+                    var xLastImplementedIn =
+                        _target.GetRuntimeInterfaceMap(x)
+                            .TargetMethods
+                            .OrderBy(method => method.DeclaringType, comparer)
+                            .Select(method => method.DeclaringType.GetTypeInfo())
+                            .LastOrDefault() ?? _target;
+
+                    var yLastImplementedIn =
+                        _target.GetRuntimeInterfaceMap(y)
+                            .TargetMethods
+                            .OrderBy(method => method.DeclaringType, comparer)
+                            .Select(method => method.DeclaringType.GetTypeInfo())
+                            .LastOrDefault() ?? _target;
+
+                    var xFirstIntroduceTypeIndex =
+                        _typeInheritance.IndexOf(xLastImplementedIn);
+                    var yFirstIntroduceTypeIndex =
+                        _typeInheritance.IndexOf(yLastImplementedIn);
+
+                    if (xFirstIntroduceTypeIndex < yFirstIntroduceTypeIndex)
+                    {
+                        return -1;
+                    }
+                    if (yFirstIntroduceTypeIndex > xFirstIntroduceTypeIndex)
+                    {
+                        return 1;
+                    }
+                }
+
                 return 0;
             }
         }
+
     }
 }

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -574,7 +574,7 @@ namespace AutoMapper
                     return 0;
                 }
 
-                if (_target != null && !_target.IsInterface)
+                if (_target != null && !_target.IsInterface && !_target.IsArray)
                 {
                     var comparer = new InterfaceComparer(null);
 

--- a/src/UnitTests/Bug/InterfaceMultipleInheritance.cs
+++ b/src/UnitTests/Bug/InterfaceMultipleInheritance.cs
@@ -1,0 +1,222 @@
+using System;
+using Should;
+using Xunit;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    namespace InterfaceMultipleInheritance
+    {
+        public class InterfaceMultipleInheritanceBug1036 : AutoMapperSpecBase
+        {
+            private MapTo _destination;
+
+            public interface IMapFrom
+            {
+                IMapFromElement Element { get; }
+            }
+
+            public interface IMapFromElement
+            {
+                string Prop { get; }
+            }
+
+            public interface IMapFromElementDerived1 : IMapFromElement
+            {
+                string Prop2 { get; }
+            }
+
+            public interface IMapFromElementDerived2 : IMapFromElement
+            {
+            }
+
+            public interface IMapFromElementDerivedBoth : IMapFromElementDerived1, IMapFromElementDerived2
+            {
+            }
+
+            public interface IMapToElementWritable 
+            {
+                new string Prop { get; set; }
+            }
+
+            public interface IMapToElementWritableDerived : IMapToElementWritable
+            {
+                new string Prop2 { get; set; }
+            }
+
+            public class MapFrom : IMapFrom
+            {
+                public MapFromElement Element { get; set; }
+                IMapFromElement IMapFrom.Element => Element;
+            }
+
+            public class MapFromElement : IMapFromElement
+            {
+                public string Prop { get; set; }
+            }
+
+            public class MapFromElementDerived : MapFromElement, IMapFromElementDerivedBoth
+            {
+                public string Prop { get; set; }
+                public string Prop2 { get; set; }
+            }
+
+            public class MapTo
+            {
+                public IMapToElementWritable Element { get; set; }
+            }
+
+            public abstract class MapToElement : IMapToElementWritable
+            {
+                public string Prop { get; set; }
+            }
+
+            public class MapToElementDerived : MapToElement, IMapToElementWritableDerived
+            {
+                public string Prop2 { get; set; }
+            }
+
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<IMapFrom, MapTo>();
+                cfg.CreateMap<IMapFromElement, IMapToElementWritable>()
+                .Include<IMapFromElementDerived1, IMapToElementWritableDerived>();
+
+                cfg.CreateMap<IMapFromElementDerived1, IMapToElementWritableDerived>()
+                    .ConstructUsing((ResolutionContext item) => new MapToElementDerived());
+            });
+
+            protected override void Because_of()
+            {
+                var source = new MapFrom
+                {
+                    Element = new MapFromElementDerived { Prop = "PROP1", Prop2 = "PROP2" }
+                };
+
+                _destination = Mapper.Map<MapTo>(source);
+            }
+
+            [Fact]
+            public void Should_Map_UsingDerivedInterface()
+            {
+                var element = (IMapToElementWritableDerived)_destination.Element;
+                element.Prop2.ShouldEqual("PROP2");
+            }
+        }
+
+        public class InterfaceMultipleInheritanceBug1016 : AutoMapperSpecBase
+        {
+            private class4DTO _destination;
+
+            public abstract class class1 : iclass1
+            {
+                public string prop1 { get; set; }
+            }
+
+            public class class2 : class1, iclass2
+            {
+                public string prop2 { get; set; }
+            }
+
+            public class class3 : class2, iclass3
+            {
+                public string prop3 { get; set; }
+            }
+
+            public class class4 : class3, iclass4
+            {
+                public string prop4 { get; set; }
+            }
+
+            public abstract class class1DTO : iclass1DTO
+            {
+                public string prop1 { get; set; }
+            }
+
+            public class class2DTO : class1DTO, iclass2DTO
+            {
+                public string prop2 { get; set; }
+            }
+
+            public class class3DTO : class2DTO, iclass3DTO
+            {
+                public string prop3 { get; set; }
+            }
+
+            public class class4DTO : class3DTO, iclass4DTO
+            {
+                public string prop4 { get; set; }
+            }
+
+            public interface iclass1
+            {
+                string prop1 { get; set; }
+            }
+
+            public interface iclass2 : iclass1
+            {
+                string prop2 { get; set; }
+            }
+
+            public interface iclass3 : iclass2
+            {
+                string prop3 { get; set; }
+            }
+
+            public interface iclass4 : iclass3
+            {
+                string prop4 { get; set; }
+            }
+
+            public interface iclass1DTO
+            {
+                string prop1 { get; set; }
+            }
+
+            public interface iclass2DTO : iclass1DTO
+            {
+                string prop2 { get; set; }
+            }
+
+            public interface iclass3DTO : iclass2DTO
+            {
+                string prop3 { get; set; }
+            }
+
+            public interface iclass4DTO : iclass3DTO
+            {
+                string prop4 { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<iclass1, iclass1DTO>()
+                    .Include<iclass2, iclass2DTO>()
+                    .Include<iclass3, iclass3DTO>()
+                    .Include<iclass4, iclass4DTO>();
+                cfg.CreateMap<iclass2, iclass2DTO>();
+                cfg.CreateMap<iclass3, iclass3DTO>();
+                cfg.CreateMap<iclass4, iclass4DTO>()
+                    .ConstructUsing((ResolutionContext rc) => new class4DTO());
+            });
+
+            protected override void Because_of()
+            {
+                iclass4 source = new class4();
+                source.prop1 = "PROP1";
+                source.prop2 = "PROP2";
+                source.prop3 = "PROP3";
+                source.prop4 = "PROP4";
+                _destination = new class4DTO();
+
+                Mapper.Map<iclass4, iclass4DTO>(source, _destination);
+            }
+
+            [Fact]
+            public void Should_Map_UsingDerivedInterface()
+            {
+                _destination.prop4.ShouldEqual("PROP4");
+            }
+        }
+    }
+}

--- a/src/UnitTests/InterfaceMapping.cs
+++ b/src/UnitTests/InterfaceMapping.cs
@@ -9,6 +9,69 @@ namespace AutoMapper.UnitTests
 {
     namespace InterfaceMapping
     {
+        public class When_mapping_to_existing_object_through_interfaces : AutoMapperSpecBase
+        {
+            private class2DTO _result;
+
+            public class class1 : iclass1
+            {
+                public string prop1 { get; set; }
+            }
+
+            public class class2 : class1, iclass2
+            {
+                public string prop2 { get; set; }
+            }
+
+            public class class1DTO : iclass1DTO
+            {
+                public string prop1 { get; set; }
+            }
+
+            public class class2DTO : class1DTO, iclass2DTO
+            {
+                public string prop2 { get; set; }
+            }
+
+            public interface iclass1
+            {
+                string prop1 { get; set; }
+            }
+
+            public interface iclass2
+            {
+                string prop2 { get; set; }
+            }
+
+            public interface iclass1DTO
+            {
+                string prop1 { get; set; }
+            }
+
+            public interface iclass2DTO
+            {
+                string prop2 { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<iclass1, iclass1DTO>();
+                cfg.CreateMap<iclass2, iclass2DTO>();
+            });
+
+            protected override void Because_of()
+            {
+                var bo = new class2 { prop1 = "PROP1", prop2 = "PROP2" };
+                _result = Mapper.Map(bo, new class2DTO());
+            }
+
+            [Fact]
+            public void Should_use_the_most_derived_interface()
+            {
+                _result.prop2.ShouldEqual("PROP2");
+            }
+        }
+
         public class When_mapping_an_interface_to_an_abstract_type : AutoMapperSpecBase
         {
             private DtoObject _result;

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -84,6 +84,7 @@
     </Compile>
     <Compile Include="ArraysAndLists.cs" />
     <Compile Include="AssertionExtensions.cs" />
+    <Compile Include="Bug\InterfaceMultipleInheritance.cs" />
     <Compile Include="Bug\AfterMapNestedObjects.cs" />
     <Compile Include="Bug\AutoMapperInheritanceProblemDemo.cs" />
     <Compile Include="AutoMapperSpecBase.cs" />


### PR DESCRIPTION
Here is more complicated version, that tries to fix problem that @lbargaoanu noted for original (#1037) version and use GetRuntimeInterfaceMap(per suggestion in #1050).

This version will iterate interfaces in such order, that more derived interfaces will be before less derived (for IInterfaceBase:IInterfaceDerived, order will be IInterfaceDerived, IInterfaceBase), and additional prefer interface that have mthod implementation in more derived types.

I'm not sure which option is better (this or #1050), but both of them fix more issues than #1037 or #1058.