### PR TITLE
Restore some static api

### DIFF
--- a/src/AutoMapper/IConfigurationProvider.cs
+++ b/src/AutoMapper/IConfigurationProvider.cs
@@ -121,5 +121,7 @@ namespace AutoMapper
         bool AllowNullCollections { get; }
 
         IExpressionBuilder ExpressionBuilder { get; }
+        IMapper CreateMapper();
+        IMapper CreateMapper(Func<Type, object> serviceCtor);
     }
 }

--- a/src/AutoMapper/IMapper.cs
+++ b/src/AutoMapper/IMapper.cs
@@ -107,7 +107,7 @@ namespace AutoMapper
 
 
         /// <summary>
-        /// Configuration provider for performaing maps
+        /// Configuration provider for performing maps
         /// </summary>
         IConfigurationProvider ConfigurationProvider { get; }
 

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -6,14 +6,128 @@ namespace AutoMapper
     {
         #region Static API
 
-        //public static IConfigurationProvider Configuration { get; private set; }
-        //public static IMapper Instance { get; private set; }
+        /// <summary>
+        /// Configuration provider for performing maps
+        /// </summary>
+        public static IConfigurationProvider Configuration { get; private set; }
 
-        //public static void Initialize(Action<IMapperConfiguration> config)
-        //{
-        //    Configuration = new MapperConfiguration(config);
-        //    Instance = new Mapper(Configuration);
-        //}
+        /// <summary>
+        /// Static mapper instance. You can also create a <see cref="Mapper"/> instance directly using the <see cref="Configuration"/> instance.
+        /// </summary>
+        public static IMapper Instance { get; private set; }
+
+        public static void Initialize(Action<IMapperConfiguration> config)
+        {
+            Configuration = new MapperConfiguration(config);
+            Instance = new Mapper(Configuration);
+        }
+
+        /// <summary>
+        /// Execute a mapping from the source object to a new destination object.
+        /// The source type is inferred from the source object.
+        /// </summary>
+        /// <typeparam name="TDestination">Destination type to create</typeparam>
+        /// <param name="source">Source object to map from</param>
+        /// <returns>Mapped destination object</returns>
+        public static TDestination Map<TDestination>(object source) => Instance.Map<TDestination>(source);
+
+        /// <summary>
+        /// Execute a mapping from the source object to a new destination object with supplied mapping options.
+        /// </summary>
+        /// <typeparam name="TDestination">Destination type to create</typeparam>
+        /// <param name="source">Source object to map from</param>
+        /// <param name="opts">Mapping options</param>
+        /// <returns>Mapped destination object</returns>
+        public static TDestination Map<TDestination>(object source, Action<IMappingOperationOptions> opts)
+            => Instance.Map<TDestination>(source, opts);
+
+        /// <summary>
+        /// Execute a mapping from the source object to a new destination object.
+        /// </summary>
+        /// <typeparam name="TSource">Source type to use, regardless of the runtime type</typeparam>
+        /// <typeparam name="TDestination">Destination type to create</typeparam>
+        /// <param name="source">Source object to map from</param>
+        /// <returns>Mapped destination object</returns>
+        public static TDestination Map<TSource, TDestination>(TSource source)
+            => Instance.Map<TSource, TDestination>(source);
+
+        /// <summary>
+        /// Execute a mapping from the source object to a new destination object with supplied mapping options.
+        /// </summary>
+        /// <typeparam name="TSource">Source type to use</typeparam>
+        /// <typeparam name="TDestination">Destination type to create</typeparam>
+        /// <param name="source">Source object to map from</param>
+        /// <param name="opts">Mapping options</param>
+        /// <returns>Mapped destination object</returns>
+        public static TDestination Map<TSource, TDestination>(TSource source, Action<IMappingOperationOptions<TSource, TDestination>> opts)
+            => Instance.Map(source, opts);
+
+        /// <summary>
+        /// Execute a mapping from the source object to the existing destination object.
+        /// </summary>
+        /// <typeparam name="TSource">Source type to use</typeparam>
+        /// <typeparam name="TDestination">Dsetination type</typeparam>
+        /// <param name="source">Source object to map from</param>
+        /// <param name="destination">Destination object to map into</param>
+        /// <returns>The mapped destination object, same instance as the <paramref name="destination"/> object</returns>
+        public static TDestination Map<TSource, TDestination>(TSource source, TDestination destination)
+            => Instance.Map(source, destination);
+
+        /// <summary>
+        /// Execute a mapping from the source object to the existing destination object with supplied mapping options.
+        /// </summary>
+        /// <typeparam name="TSource">Source type to use</typeparam>
+        /// <typeparam name="TDestination">Destination type</typeparam>
+        /// <param name="source">Source object to map from</param>
+        /// <param name="destination">Destination object to map into</param>
+        /// <param name="opts">Mapping options</param>
+        /// <returns>The mapped destination object, same instance as the <paramref name="destination"/> object</returns>
+        public static TDestination Map<TSource, TDestination>(TSource source, TDestination destination, Action<IMappingOperationOptions<TSource, TDestination>> opts)
+            => Instance.Map(source, destination, opts);
+
+        /// <summary>
+        /// Execute a mapping from the source object to a new destination object with explicit <see cref="System.Type"/> objects
+        /// </summary>
+        /// <param name="source">Source object to map from</param>
+        /// <param name="sourceType">Source type to use</param>
+        /// <param name="destinationType">Destination type to create</param>
+        /// <returns>Mapped destination object</returns>
+        public static object Map(object source, Type sourceType, Type destinationType)
+            => Instance.Map(source, sourceType, destinationType);
+
+        /// <summary>
+        /// Execute a mapping from the source object to a new destination object with explicit <see cref="System.Type"/> objects and supplied mapping options.
+        /// </summary>
+        /// <param name="source">Source object to map from</param>
+        /// <param name="sourceType">Source type to use</param>
+        /// <param name="destinationType">Destination type to create</param>
+        /// <param name="opts">Mapping options</param>
+        /// <returns>Mapped destination object</returns>
+        public static object Map(object source, Type sourceType, Type destinationType, Action<IMappingOperationOptions> opts)
+            => Instance.Map(source, sourceType, destinationType, opts);
+
+        /// <summary>
+        /// Execute a mapping from the source object to existing destination object with explicit <see cref="System.Type"/> objects
+        /// </summary>
+        /// <param name="source">Source object to map from</param>
+        /// <param name="destination">Destination object to map into</param>
+        /// <param name="sourceType">Source type to use</param>
+        /// <param name="destinationType">Destination type to use</param>
+        /// <returns>Mapped destination object, same instance as the <paramref name="destination"/> object</returns>
+        public static object Map(object source, object destination, Type sourceType, Type destinationType)
+            => Instance.Map(source, destination, sourceType, destinationType);
+
+        /// <summary>
+        /// Execute a mapping from the source object to existing destination object with supplied mapping options and explicit <see cref="System.Type"/> objects
+        /// </summary>
+        /// <param name="source">Source object to map from</param>
+        /// <param name="destination">Destination object to map into</param>
+        /// <param name="sourceType">Source type to use</param>
+        /// <param name="destinationType">Destination type to use</param>
+        /// <param name="opts">Mapping options</param>
+        /// <returns>Mapped destination object, same instance as the <paramref name="destination"/> object</returns>
+        public static object Map(object source, object destination, Type sourceType, Type destinationType, Action<IMappingOperationOptions> opts)
+            => Instance.Map(source, destination, sourceType, destinationType, opts);
 
         #endregion
 

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -6,16 +6,43 @@ namespace AutoMapper
     {
         #region Static API
 
+        private static IConfigurationProvider _configuration;
+        private static IMapper _instance;
+
         /// <summary>
         /// Configuration provider for performing maps
         /// </summary>
-        public static IConfigurationProvider Configuration { get; private set; }
+        public static IConfigurationProvider Configuration
+        {
+            get
+            {
+                if (_configuration == null)
+                    throw new InvalidOperationException("Mapper not initialized. Call Initialize with appropriate configuration.");
+
+                return _configuration;
+            }
+            private set { _configuration = value; }
+        }
 
         /// <summary>
         /// Static mapper instance. You can also create a <see cref="Mapper"/> instance directly using the <see cref="Configuration"/> instance.
         /// </summary>
-        public static IMapper Instance { get; private set; }
+        public static IMapper Instance
+        {
+            get
+            {
+                if (_instance == null)
+                    throw new InvalidOperationException("Mapper not initialized. Call Initialize with appropriate configuration.");
 
+                return _instance;
+            }
+            private set { _instance = value; }
+        }
+
+        /// <summary>
+        /// Initialize static configuration instance
+        /// </summary>
+        /// <param name="config">Configuration action</param>
         public static void Initialize(Action<IMapperConfiguration> config)
         {
             Configuration = new MapperConfiguration(config);

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -11,22 +11,6 @@ namespace AutoMapper
     using QueryableExtensions;
     using QueryableExtensions.Impl;
 
-    public class TypeMapRegistry
-    {
-        private readonly ConcurrentDictionary<TypePair, TypeMap> _typeMaps = new ConcurrentDictionary<TypePair, TypeMap>();
-
-        public IEnumerable<TypeMap> TypeMaps => _typeMaps.Values;
-
-        public void RegisterTypeMap(TypeMap typeMap) => _typeMaps.AddOrUpdate(typeMap.Types, typeMap, (tp, tm) => tm);
-
-        public TypeMap GetTypeMap(TypePair typePair)
-        {
-            TypeMap typeMap;
-
-            return _typeMaps.TryGetValue(typePair, out typeMap) ? typeMap : null;
-        }
-    }
-
     public class MapperConfiguration : IConfigurationProvider, IMapperConfiguration
     {
         private readonly IEnumerable<IObjectMapper> _mappers;
@@ -259,6 +243,10 @@ namespace AutoMapper
             AssertConfigurationIsValid(_typeMapRegistry.TypeMaps);
         }
 
+        public IMapper CreateMapper() => new Mapper(this);
+
+        public IMapper CreateMapper(Func<Type, object> serviceCtor) => new Mapper(this, serviceCtor);
+
         public IEnumerable<IObjectMapper> GetMappers() => _mappers;
 
         public IEnumerable<ITypeMapObjectMapper> GetTypeMapMappers() => _typeMapObjectMappers;
@@ -321,10 +309,6 @@ namespace AutoMapper
             }
         }
 
-
-        public IMapper CreateMapper() => new Mapper(this);
-
-        public IMapper CreateMapper(Func<Type, object> serviceCtor) => new Mapper(this, serviceCtor);
 
         private IEnumerable<TypeMap> GetDerivedTypeMaps(TypeMap typeMap)
         {

--- a/src/AutoMapper/QueryableExtensions/Extensions.cs
+++ b/src/AutoMapper/QueryableExtensions/Extensions.cs
@@ -19,12 +19,26 @@ namespace AutoMapper.QueryableExtensions
         /// <typeparam name="TDestination">Destination type</typeparam>
         /// <param name="sourceQuery">Source queryable</param>
         /// <param name="destQuery">Destination queryable</param>
+        /// <returns>Mapped destination queryable</returns>
+        public static IQueryable<TDestination> Map<TSource, TDestination>(this IQueryable<TSource> sourceQuery, IQueryable<TDestination> destQuery)
+            => sourceQuery.Map(destQuery, Mapper.Configuration);
+
+        /// <summary>
+        /// Maps a queryable expression of a source type to a queryable expression of a destination type
+        /// </summary>
+        /// <typeparam name="TSource">Source type</typeparam>
+        /// <typeparam name="TDestination">Destination type</typeparam>
+        /// <param name="sourceQuery">Source queryable</param>
+        /// <param name="destQuery">Destination queryable</param>
         /// <param name="config"></param>
         /// <returns>Mapped destination queryable</returns>
         public static IQueryable<TDestination> Map<TSource, TDestination>(this IQueryable<TSource> sourceQuery, IQueryable<TDestination> destQuery, IConfigurationProvider config)
         {
-            return QueryMapperVisitor.Map<TSource, TDestination>(sourceQuery, destQuery, config);
+            return QueryMapperVisitor.Map(sourceQuery, destQuery, config);
         }
+
+        public static IQueryDataSourceInjection<TSource> UseAsDataSource<TSource>(this IQueryable<TSource> dataSource)
+            => dataSource.UseAsDataSource(Mapper.Instance);
 
         public static IQueryDataSourceInjection<TSource> UseAsDataSource<TSource>(this IQueryable<TSource> dataSource, IMapper mapper)
         {
@@ -37,7 +51,19 @@ namespace AutoMapper.QueryableExtensions
         /// <remarks>Projections are only calculated once and cached</remarks>
         /// <typeparam name="TDestination">Destination type</typeparam>
         /// <param name="source">Queryable source</param>
-        /// <param name="configuration">Maper configuration</param>
+        /// <param name="parameters">Optional parameter object for parameterized mapping expressions</param>
+        /// <param name="membersToExpand">Explicit members to expand</param>
+        /// <returns>Expression to project into</returns>
+        public static IQueryable<TDestination> ProjectTo<TDestination>(this IQueryable source, object parameters, params Expression<Func<TDestination, object>>[] membersToExpand)
+            => source.ProjectTo(Mapper.Configuration, parameters, membersToExpand);
+        
+        /// <summary>
+        /// Extension method to project from a queryable using the provided mapping engine
+        /// </summary>
+        /// <remarks>Projections are only calculated once and cached</remarks>
+        /// <typeparam name="TDestination">Destination type</typeparam>
+        /// <param name="source">Queryable source</param>
+        /// <param name="configuration">Mapper configuration</param>
         /// <param name="parameters">Optional parameter object for parameterized mapping expressions</param>
         /// <param name="membersToExpand">Explicit members to expand</param>
         /// <returns>Expression to project into</returns>
@@ -60,9 +86,34 @@ namespace AutoMapper.QueryableExtensions
             IConfigurationProvider configuration,
             params Expression<Func<TDestination, object>>[] membersToExpand
             )
-        {
-            return source.ProjectTo(configuration, null, membersToExpand);
-        }
+            => source.ProjectTo(configuration, null, membersToExpand);
+
+        /// <summary>
+        /// Extension method to project from a queryable using the provided mapping engine
+        /// </summary>
+        /// <remarks>Projections are only calculated once and cached</remarks>
+        /// <typeparam name="TDestination">Destination type</typeparam>
+        /// <param name="source">Queryable source</param>
+        /// <param name="membersToExpand">Explicit members to expand</param>
+        /// <returns>Expression to project into</returns>
+        public static IQueryable<TDestination> ProjectTo<TDestination>(
+            this IQueryable source,
+            params Expression<Func<TDestination, object>>[] membersToExpand
+            )
+            => source.ProjectTo(Mapper.Configuration, null, membersToExpand);
+
+        /// <summary>
+        /// Projects the source type to the destination type given the mapping configuration
+        /// </summary>
+        /// <typeparam name="TDestination">Destination type to map to</typeparam>
+        /// <param name="source">Queryable source</param>
+        /// <param name="configuration">Mapper configuration</param>
+        /// <param name="parameters">Optional parameter object for parameterized mapping expressions</param>
+        /// <param name="membersToExpand">Explicit members to expand</param>
+        /// <returns>Queryable result, use queryable extension methods to project and execute result</returns>
+        public static IQueryable<TDestination> ProjectTo<TDestination>(this IQueryable source,
+            IDictionary<string, object> parameters, params string[] membersToExpand)
+            => source.ProjectTo<TDestination>(Mapper.Configuration, parameters, membersToExpand);
 
         /// <summary>
         /// Projects the source type to the destination type given the mapping configuration

--- a/src/AutoMapper/TypeMapRegistry.cs
+++ b/src/AutoMapper/TypeMapRegistry.cs
@@ -1,0 +1,21 @@
+namespace AutoMapper
+{
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+
+    public class TypeMapRegistry
+    {
+        private readonly ConcurrentDictionary<TypePair, TypeMap> _typeMaps = new ConcurrentDictionary<TypePair, TypeMap>();
+
+        public IEnumerable<TypeMap> TypeMaps => _typeMaps.Values;
+
+        public void RegisterTypeMap(TypeMap typeMap) => _typeMaps.AddOrUpdate(typeMap.Types, typeMap, (tp, tm) => tm);
+
+        public TypeMap GetTypeMap(TypePair typePair)
+        {
+            TypeMap typeMap;
+
+            return _typeMaps.TryGetValue(typePair, out typeMap) ? typeMap : null;
+        }
+    }
+}

--- a/src/UnitTests/StaticMapping.cs
+++ b/src/UnitTests/StaticMapping.cs
@@ -1,7 +1,9 @@
 ﻿namespace AutoMapper.UnitTests
 {
+    using System.Linq;
     using Should;
     using Xunit;
+    using QueryableExtensions;
 
     public class StaticMapping
     {
@@ -28,6 +30,23 @@
             var dest = Mapper.Map<Source, Dest>(source);
 
             dest.Value.ShouldEqual(source.Value);
+        } 
+
+        [Fact]
+        public void Can_project_statically()
+        {
+            Mapper.Initialize(cfg =>
+            {
+                cfg.CreateMap<Source, Dest>();
+            });
+
+            var source = new Source {Value = 5};
+            var sources = new[] {source}.AsQueryable();
+
+            var dests = sources.ProjectTo<Dest>().ToArray();
+
+            dests.Length.ShouldEqual(1);
+            dests[0].Value.ShouldEqual(source.Value);
         } 
     }
 }

--- a/src/UnitTests/StaticMapping.cs
+++ b/src/UnitTests/StaticMapping.cs
@@ -1,0 +1,33 @@
+﻿namespace AutoMapper.UnitTests
+{
+    using Should;
+    using Xunit;
+
+    public class StaticMapping
+    {
+        public class Source
+        {
+            public int Value { get; set; }
+        }
+
+        public class Dest
+        {
+            public int Value { get; set; }
+        }
+
+        [Fact]
+        public void Can_map_statically()
+        {
+            Mapper.Initialize(cfg =>
+            {
+                cfg.CreateMap<Source, Dest>();
+            });
+
+            var source = new Source {Value = 5};
+
+            var dest = Mapper.Map<Source, Dest>(source);
+
+            dest.Value.ShouldEqual(source.Value);
+        } 
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -299,6 +299,7 @@
     <Compile Include="Should\should\DoubleAssertionExtensions.cs" />
     <Compile Include="Should\should\ObjectAssertExtensions.cs" />
     <Compile Include="Should\should\StringAssertionExtensions.cs" />
+    <Compile Include="StaticMapping.cs" />
     <Compile Include="TesterExtensions.cs" />
     <Compile Include="ConfigurationValidation.cs" />
     <Compile Include="Bug\ProjectConstructorParameters.cs" />


### PR DESCRIPTION
Configuration is still readonly, there's no Mapper.Reset. Just Mapper.Initialize. Also restored the queryable extension methods with overloads that grab the static versions.

Downside is I had to keep the explicit implementations of IMapper on Mapper class. To balance that, I put the factory method for CreateMapper on the IConfigurationProvider interface (you can't do `new Mapper()` and start doing stuff, those are static methods).

@lbargaoanu and @TylerCarlson1 this should be a decent compromise, I think.