### PR TITLE
When using resolve, infer the type of the resolved value

### DIFF
--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -61,19 +61,19 @@ namespace AutoMapper.Configuration
             return expression;
         }
 
-        public void ResolveUsing(Func<TSource, object> resolver)
+        public void ResolveUsing<TMember>(Func<TSource, TMember> resolver)
         {
-            _propertyMapActions.Add(pm => pm.AssignCustomValueResolver(new DelegateBasedResolver<TSource>(r => resolver((TSource)r.Value))));
+            _propertyMapActions.Add(pm => pm.AssignCustomValueResolver(new DelegateBasedResolver<TSource, TMember>(resolver)));
         }
 
-        public void ResolveUsing(Func<ResolutionResult, object> resolver)
+        public void ResolveUsing<TMember>(Func<ResolutionResult, TMember> resolver)
         {
-            _propertyMapActions.Add(pm => pm.AssignCustomValueResolver(new DelegateBasedResolver<TSource>(resolver)));
+            _propertyMapActions.Add(pm => pm.AssignCustomValueResolver(new DelegateBasedResolver<TSource, TMember>(resolver)));
         }
 
-        public void ResolveUsing(Func<ResolutionResult, TSource, object> resolver)
+        public void ResolveUsing<TMember>(Func<ResolutionResult, TSource, TMember> resolver)
         {
-            _propertyMapActions.Add(pm => pm.AssignCustomValueResolver(new DelegateBasedResolver<TSource>(r => resolver(r, (TSource)r.Value))));
+            _propertyMapActions.Add(pm => pm.AssignCustomValueResolver(new DelegateBasedResolver<TSource, TMember>(r => resolver(r, (TSource)r.Value))));
         }
 
         public void MapFrom<TMember>(Expression<Func<TSource, TMember>> sourceMember)
@@ -112,7 +112,7 @@ namespace AutoMapper.Configuration
 
         public void UseValue(object value)
         {
-            _propertyMapActions.Add(pm => pm.AssignCustomValueResolver(new DelegateBasedResolver<TSource>(src => value)));
+            _propertyMapActions.Add(pm => pm.AssignCustomValueResolver(new DelegateBasedResolver<TSource, object>((TSource src) => value)));
         }
 
         public void Condition(Func<TSource, bool> condition)

--- a/src/AutoMapper/Configuration/ResolutionExpression.cs
+++ b/src/AutoMapper/Configuration/ResolutionExpression.cs
@@ -27,7 +27,7 @@ namespace AutoMapper.Configuration
                     pm.SourceMember = body.Member;
                 }
                 var func = sourceMember.Compile();
-                pm.ChainTypeMemberForResolver(new DelegateBasedResolver<TSource>(r => func((TSource) r.Value)));
+                pm.ChainTypeMemberForResolver(new DelegateBasedResolver<TSource, object>(func));
             });
         }
 
@@ -91,7 +91,7 @@ namespace AutoMapper.Configuration
                     pm.SourceMember = body.Member;
                 }
                 var func = sourceMember.Compile();
-                pm.ChainTypeMemberForResolver(new DelegateBasedResolver<TSource>(r => func((TSource) r.Value)));
+                pm.ChainTypeMemberForResolver(new DelegateBasedResolver<TSource, object>(func));
             });
 
             return this;

--- a/src/AutoMapper/ConfigurationValidator.cs
+++ b/src/AutoMapper/ConfigurationValidator.cs
@@ -114,8 +114,8 @@ namespace AutoMapper
                     if (lastResolver != null)
                     {
                         var sourceType = lastResolver.MemberType;
-
-                        if (sourceType.IsGenericParameter)
+                        // when we don't know what the source type is, bail
+                        if (sourceType.IsGenericParameter || sourceType == typeof(object))
                             return;
 
                         var destinationType = propertyMap.DestinationProperty.MemberType;

--- a/src/AutoMapper/Execution/DelegateBasedResolver.cs
+++ b/src/AutoMapper/Execution/DelegateBasedResolver.cs
@@ -2,49 +2,29 @@ namespace AutoMapper.Execution
 {
     using System;
 
-    public class DelegateBasedResolver<TSource> : IValueResolver
-    {
-        private readonly Func<ResolutionResult, object> _method;
-
-        public DelegateBasedResolver(Func<ResolutionResult, object> method)
-        {
-            _method = method;
-        }
-
-        public ResolutionResult Resolve(ResolutionResult source)
-        {
-            if (source.Value != null && !(source.Value is TSource))
-            {
-                throw new ArgumentException($"Expected obj to be of type {typeof (TSource)} but was {source.Value.GetType()}");
-            }
-
-            var result = _method(source);
-
-            return source.New(result);
-        }
-    }
-
     public class DelegateBasedResolver<TSource, TMember> : IMemberResolver
     {
-        private readonly Func<TSource, TMember> _method;
+        private readonly Func<ResolutionResult, TMember> _method;
 
-        public DelegateBasedResolver(Func<TSource, TMember> method)
+        public DelegateBasedResolver(Func<TSource, TMember> method) : this(r=>method((TSource)r.Value))
         {
-            _method = method;
         }
 
-        public ResolutionResult Resolve(ResolutionResult source)
+        public DelegateBasedResolver(Func<ResolutionResult, TMember> method)
         {
-            if (source.Value != null && !(source.Value is TSource))
-            {
-                throw new ArgumentException($"Expected obj to be of type {typeof (TSource)} but was {source.Value.GetType()}");
-            }
-
-            var result = _method((TSource)source.Value);
-
-            return source.New(result, MemberType);
+            _method = method;
         }
 
         public Type MemberType => typeof(TMember);
+
+        public ResolutionResult Resolve(ResolutionResult source)
+        {
+            if(source.Value != null && !(source.Value is TSource))
+            {
+                throw new ArgumentException($"Expected obj to be of type {typeof (TSource)} but was {source.Value.GetType()}");
+            }
+            var result = _method(source);
+            return source.New(result, typeof(TMember));
+        }
     }
 }

--- a/src/AutoMapper/IMemberConfigurationExpression.cs
+++ b/src/AutoMapper/IMemberConfigurationExpression.cs
@@ -41,7 +41,7 @@ namespace AutoMapper
         /// This method cannot be used in conjunction with LINQ query projection
         /// </summary>
         /// <param name="resolver">Callback function to resolve against source type</param>
-        void ResolveUsing(Func<TSource, object> resolver);
+        void ResolveUsing<TMember>(Func<TSource, TMember> resolver);
 
         /// <summary>
         /// Resolve destination member using a custom value resolver callback. Used instead of MapFrom when not simply redirecting a source member
@@ -49,7 +49,7 @@ namespace AutoMapper
         /// This method cannot be used in conjunction with LINQ query projection
         /// </summary>
         /// <param name="resolver">Callback function to resolve against source type</param>
-        void ResolveUsing(Func<ResolutionResult, object> resolver);
+        void ResolveUsing<TMember>(Func<ResolutionResult, TMember> resolver);
 
         /// <summary>
         /// Resolve destination member using a custom value resolver callback. Used instead of MapFrom when not simply redirecting a source member
@@ -57,7 +57,7 @@ namespace AutoMapper
         /// This method cannot be used in conjunction with LINQ query projection
         /// </summary>
         /// <param name="resolver">Callback function to resolve against source type</param>
-        void ResolveUsing(Func<ResolutionResult, TSource, object> resolver);
+        void ResolveUsing<TMember>(Func<ResolutionResult, TSource, TMember> resolver);
 
         /// <summary>
         /// Specify the source member to map from. Can only reference a member on the <typeparamref name="TSource"/> type

--- a/src/UnitTests/Bug/NullableResolveUsing.cs
+++ b/src/UnitTests/Bug/NullableResolveUsing.cs
@@ -1,0 +1,36 @@
+﻿using Xunit;
+using Should;
+using System;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public class NullableResolveUsing : AutoMapperSpecBase
+    {
+        private Destination _destination;
+
+        class Source
+        {
+            public decimal? Number { get; set; }
+        }
+        class Destination
+        {
+            public decimal? OddNumber { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>().ForMember(d=>d.OddNumber, o=>o.ResolveUsing((ResolutionResult r)=>((Source)r.Value).Number));
+        });
+
+        protected override void Because_of()
+        {
+            _destination = Mapper.Map<Destination>(new Source());
+        }
+
+        [Fact]
+        public void Should_map_nullable_decimal_with_ResolveUsing()
+        {
+            _destination.OddNumber.ShouldBeNull();
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Bug\AssertConfigurationIsValidNullables.cs" />
     <Compile Include="Bug\IncludeBaseInheritance.cs" />
     <Compile Include="Bug\IncludeInheritance.cs" />
+    <Compile Include="Bug\NullableResolveUsing.cs" />
     <Compile Include="Bug\NullableDateTime.cs" />
     <Compile Include="Bug\ProjectUsingTheQueriedEntity.cs" />
     <Compile Include="Bug\ReverseMapReplaceMemberName.cs" />


### PR DESCRIPTION
I don't know how this worked before, I just did what made sense :)
This was reported [here](https://github.com/AutoMapper/AutoMapper/issues/1088#issuecomment-181570402).