### PR TITLE
Add DestinationType back into resolving member info conventions. Part 2

### DIFF
--- a/src/AutoMapper/Configuration/Conventions/CaseInsensitiveName.cs
+++ b/src/AutoMapper/Configuration/Conventions/CaseInsensitiveName.cs
@@ -6,7 +6,7 @@ namespace AutoMapper.Configuration.Conventions
 
     public class CaseInsensitiveName : ISourceToDestinationNameMapper
     {
-        public MemberInfo GetMatchingMemberInfo(IGetTypeInfoMembers getTypeInfoMembers, TypeDetails typeInfo, Type destType, string nameToSearch)
+        public MemberInfo GetMatchingMemberInfo(IGetTypeInfoMembers getTypeInfoMembers, TypeDetails typeInfo, Type destType, Type destMemberType, string nameToSearch)
         {
             return
                 getTypeInfoMembers.GetMemberInfos(typeInfo)

--- a/src/AutoMapper/Configuration/Conventions/CaseSensitiveName.cs
+++ b/src/AutoMapper/Configuration/Conventions/CaseSensitiveName.cs
@@ -8,7 +8,7 @@ namespace AutoMapper.Configuration.Conventions
     {
         public bool MethodCaseSensitive { get; set; }
 
-        public MemberInfo GetMatchingMemberInfo(IGetTypeInfoMembers getTypeInfoMembers, TypeDetails typeInfo, Type destType, string nameToSearch)
+        public MemberInfo GetMatchingMemberInfo(IGetTypeInfoMembers getTypeInfoMembers, TypeDetails typeInfo, Type destType, Type destMemberType, string nameToSearch)
         {
             return
                 getTypeInfoMembers.GetMemberInfos(typeInfo)

--- a/src/AutoMapper/Configuration/Conventions/DefaultMember.cs
+++ b/src/AutoMapper/Configuration/Conventions/DefaultMember.cs
@@ -10,11 +10,11 @@ namespace AutoMapper.Configuration.Conventions
     {
         public IParentSourceToDestinationNameMapper NameMapper { get; set; }
 
-        public bool MapDestinationPropertyToSource(IProfileConfiguration options, TypeDetails sourceType, Type destType, string nameToSearch, LinkedList<IValueResolver> resolvers, IMemberConfiguration parent = null)
+        public bool MapDestinationPropertyToSource(IProfileConfiguration options, TypeDetails sourceType, Type destType, Type destMemberType, string nameToSearch, LinkedList<IValueResolver> resolvers, IMemberConfiguration parent = null)
         {
             if (string.IsNullOrEmpty(nameToSearch))
                 return true;
-            var matchingMemberInfo = NameMapper.GetMatchingMemberInfo(sourceType, destType, nameToSearch);
+            var matchingMemberInfo = NameMapper.GetMatchingMemberInfo(sourceType, destType, destMemberType, nameToSearch);
 
             if (matchingMemberInfo != null)
                 resolvers.AddLast(matchingMemberInfo.ToMemberGetter());

--- a/src/AutoMapper/Configuration/Conventions/IChildMemberConfiguration.cs
+++ b/src/AutoMapper/Configuration/Conventions/IChildMemberConfiguration.cs
@@ -5,6 +5,6 @@ namespace AutoMapper.Configuration.Conventions
 
     public interface IChildMemberConfiguration
     {
-        bool MapDestinationPropertyToSource(IProfileConfiguration options, TypeDetails sourceType, Type destType, string nameToSearch, LinkedList<IValueResolver> resolvers, IMemberConfiguration parent);
+        bool MapDestinationPropertyToSource(IProfileConfiguration options, TypeDetails sourceType, Type destType, Type destMemberType, string nameToSearch, LinkedList<IValueResolver> resolvers, IMemberConfiguration parent);
     }
 }

--- a/src/AutoMapper/Configuration/Conventions/IMemberConfiguration.cs
+++ b/src/AutoMapper/Configuration/Conventions/IMemberConfiguration.cs
@@ -13,6 +13,6 @@ namespace AutoMapper.Configuration.Conventions
             where TNameMapper : ISourceToDestinationNameMapper, new();
 
         IParentSourceToDestinationNameMapper NameMapper { get; set; }
-        bool MapDestinationPropertyToSource(IProfileConfiguration options, TypeDetails sourceType, Type destType, string nameToSearch, LinkedList<IValueResolver> resolvers);
+        bool MapDestinationPropertyToSource(IProfileConfiguration options, TypeDetails sourceType, Type destType, Type destMemberType, string nameToSearch, LinkedList<IValueResolver> resolvers);
     }
 }

--- a/src/AutoMapper/Configuration/Conventions/IParentSourceToDestinationNameMapper.cs
+++ b/src/AutoMapper/Configuration/Conventions/IParentSourceToDestinationNameMapper.cs
@@ -8,6 +8,6 @@ namespace AutoMapper.Configuration.Conventions
     {
         ICollection<ISourceToDestinationNameMapper> NamedMappers { get; }
         IGetTypeInfoMembers GetMembers { get; }
-        MemberInfo GetMatchingMemberInfo(TypeDetails typeInfo, Type destType, string nameToSearch);
+        MemberInfo GetMatchingMemberInfo(TypeDetails typeInfo, Type destType, Type destMemberType, string nameToSearch);
     }
 }

--- a/src/AutoMapper/Configuration/Conventions/ISourceToDestinationNameMapper.cs
+++ b/src/AutoMapper/Configuration/Conventions/ISourceToDestinationNameMapper.cs
@@ -5,6 +5,6 @@ namespace AutoMapper.Configuration.Conventions
 
     public interface ISourceToDestinationNameMapper
     {
-        MemberInfo GetMatchingMemberInfo(IGetTypeInfoMembers getTypeInfoMembers, TypeDetails typeInfo, Type destType, string nameToSearch);
+        MemberInfo GetMatchingMemberInfo(IGetTypeInfoMembers getTypeInfoMembers, TypeDetails typeInfo, Type destType, Type destMemberType, string nameToSearch);
     }
 }

--- a/src/AutoMapper/Configuration/Conventions/MapToAttribute.cs
+++ b/src/AutoMapper/Configuration/Conventions/MapToAttribute.cs
@@ -13,7 +13,7 @@ namespace AutoMapper.Configuration.Conventions
             MatchingName = matchingName;
         }
 
-        public override bool IsMatch(TypeDetails typeInfo, MemberInfo memberInfo, Type destType, string nameToSearch)
+        public override bool IsMatch(TypeDetails typeInfo, MemberInfo memberInfo, Type destType, Type destMemberType, string nameToSearch)
         {
             return string.Compare(MatchingName, nameToSearch, StringComparison.OrdinalIgnoreCase) == 0;
         }

--- a/src/AutoMapper/Configuration/Conventions/MemberConfiguration.cs
+++ b/src/AutoMapper/Configuration/Conventions/MemberConfiguration.cs
@@ -45,12 +45,12 @@ namespace AutoMapper.Configuration.Conventions
             MemberMappers.Add(new DefaultMember { NameMapper = NameMapper });
         }
 
-        public bool MapDestinationPropertyToSource(IProfileConfiguration options, TypeDetails sourceType, Type destType, string nameToSearch, LinkedList<IValueResolver> resolvers)
+        public bool MapDestinationPropertyToSource(IProfileConfiguration options, TypeDetails sourceType, Type destType, Type destMemberType, string nameToSearch, LinkedList<IValueResolver> resolvers)
         {
             var foundMap = false;
             foreach (var memberMapper in MemberMappers)
             {
-                foundMap = memberMapper.MapDestinationPropertyToSource(options, sourceType, destType, nameToSearch, resolvers, this);
+                foundMap = memberMapper.MapDestinationPropertyToSource(options, sourceType, destType, destMemberType, nameToSearch, resolvers, this);
                 if (foundMap)
                     break;
             }

--- a/src/AutoMapper/Configuration/Conventions/NameSplitMember.cs
+++ b/src/AutoMapper/Configuration/Conventions/NameSplitMember.cs
@@ -18,7 +18,7 @@ namespace AutoMapper.Configuration.Conventions
             DestinationMemberNamingConvention = new PascalCaseNamingConvention();
         }
 
-        public bool MapDestinationPropertyToSource(IProfileConfiguration options, TypeDetails sourceType, Type destType, string nameToSearch, LinkedList<IValueResolver> resolvers, IMemberConfiguration parent )
+        public bool MapDestinationPropertyToSource(IProfileConfiguration options, TypeDetails sourceType, Type destType, Type destMemberType, string nameToSearch, LinkedList<IValueResolver> resolvers, IMemberConfiguration parent )
         {
             string[] matches = DestinationMemberNamingConvention.SplittingExpression
                 .Matches(nameToSearch)
@@ -30,14 +30,14 @@ namespace AutoMapper.Configuration.Conventions
             {
                 NameSnippet snippet = CreateNameSnippet(matches, i);
 
-                matchingMemberInfo = parent.NameMapper.GetMatchingMemberInfo(sourceType, destType, snippet.First);
+                matchingMemberInfo = parent.NameMapper.GetMatchingMemberInfo(sourceType, destType, destMemberType, snippet.First);
 
                 if (matchingMemberInfo != null)
                 {
                     resolvers.AddLast(matchingMemberInfo.ToMemberGetter());
 
                     var details = new TypeDetails(matchingMemberInfo.GetMemberType(), options);
-                    var foundMatch = parent.MapDestinationPropertyToSource(options, details, destType, snippet.Second, resolvers);
+                    var foundMatch = parent.MapDestinationPropertyToSource(options, details, destType, destMemberType, snippet.Second, resolvers);
 
                     if (!foundMatch)
                         resolvers.RemoveLast();

--- a/src/AutoMapper/Configuration/Conventions/ParentSourceToDestinationNameMapper.cs
+++ b/src/AutoMapper/Configuration/Conventions/ParentSourceToDestinationNameMapper.cs
@@ -11,12 +11,12 @@ namespace AutoMapper.Configuration.Conventions
 
         public ICollection<ISourceToDestinationNameMapper> NamedMappers { get; } = new Collection<ISourceToDestinationNameMapper> {new DefaultName(), new SourceToDestinationNameMapperAttributesMember()};
 
-        public MemberInfo GetMatchingMemberInfo(TypeDetails typeInfo, Type destType, string nameToSearch)
+        public MemberInfo GetMatchingMemberInfo(TypeDetails typeInfo, Type destType, Type destMemberType, string nameToSearch)
         {
             MemberInfo memberInfo = null;
             foreach (var namedMapper in NamedMappers)
             {
-                memberInfo = namedMapper.GetMatchingMemberInfo(GetMembers, typeInfo, destType, nameToSearch);
+                memberInfo = namedMapper.GetMatchingMemberInfo(GetMembers, typeInfo, destType, destMemberType, nameToSearch);
                 if (memberInfo != null)
                     break;
             }

--- a/src/AutoMapper/Configuration/Conventions/PrePostfixName.cs
+++ b/src/AutoMapper/Configuration/Conventions/PrePostfixName.cs
@@ -21,7 +21,7 @@ namespace AutoMapper.Configuration.Conventions
             return this;
         }
 
-        public MemberInfo GetMatchingMemberInfo(IGetTypeInfoMembers getTypeInfoMembers, TypeDetails typeInfo, Type destType, string nameToSearch)
+        public MemberInfo GetMatchingMemberInfo(IGetTypeInfoMembers getTypeInfoMembers, TypeDetails typeInfo, Type destType, Type destMemberType, string nameToSearch)
         {
             var possibleSourceNames = PossibleNames(nameToSearch, DestinationPrefixes, DestinationPostfixes);
             var possibleDestNames = getTypeInfoMembers.GetMemberInfos(typeInfo).Select(mi => new { mi, possibles = PossibleNames(mi.Name, Prefixes, Postfixes) });

--- a/src/AutoMapper/Configuration/Conventions/ReplaceName.cs
+++ b/src/AutoMapper/Configuration/Conventions/ReplaceName.cs
@@ -20,7 +20,7 @@ namespace AutoMapper.Configuration.Conventions
             MemberNameReplacers.Add(new MemberNameReplacer(original, newValue));
             return this;
         }
-        public MemberInfo GetMatchingMemberInfo(IGetTypeInfoMembers getTypeInfoMembers, TypeDetails typeInfo, Type destType, string nameToSearch)
+        public MemberInfo GetMatchingMemberInfo(IGetTypeInfoMembers getTypeInfoMembers, TypeDetails typeInfo, Type destType, Type destMemberType, string nameToSearch)
         {
             var possibleSourceNames = PossibleNames(nameToSearch);
             var possibleDestNames = getTypeInfoMembers.GetMemberInfos(typeInfo).Select(mi => new { mi, possibles = PossibleNames(mi.Name) });

--- a/src/AutoMapper/Configuration/Conventions/SourceToDestinationMapperAttribute.cs
+++ b/src/AutoMapper/Configuration/Conventions/SourceToDestinationMapperAttribute.cs
@@ -5,6 +5,6 @@ namespace AutoMapper.Configuration.Conventions
 
     public abstract class SourceToDestinationMapperAttribute : Attribute
     {
-        public abstract bool IsMatch(TypeDetails typeInfo, MemberInfo memberInfo, Type destType, string nameToSearch);
+        public abstract bool IsMatch(TypeDetails typeInfo, MemberInfo memberInfo, Type destType, Type destMemberType, string nameToSearch);
     }
 }

--- a/src/AutoMapper/Configuration/Conventions/SourceToDestinationNameMapperAttributesMember.cs
+++ b/src/AutoMapper/Configuration/Conventions/SourceToDestinationNameMapperAttributesMember.cs
@@ -10,11 +10,11 @@ namespace AutoMapper.Configuration.Conventions
     {
         private static readonly ConcurrentDictionary<TypeDetails, Dictionary<MemberInfo, IEnumerable<SourceToDestinationMapperAttribute>>> Cache = new ConcurrentDictionary<TypeDetails, Dictionary<MemberInfo, IEnumerable<SourceToDestinationMapperAttribute>>>();
 
-        public MemberInfo GetMatchingMemberInfo(IGetTypeInfoMembers getTypeInfoMembers, TypeDetails typeInfo, Type destType, string nameToSearch)
+        public MemberInfo GetMatchingMemberInfo(IGetTypeInfoMembers getTypeInfoMembers, TypeDetails typeInfo, Type destType, Type destMemberType, string nameToSearch)
         {
             Cache.GetOrAdd(typeInfo, ti => getTypeInfoMembers.GetMemberInfos(ti).ToDictionary(mi => mi, mi => CustomAttributeExtensions.GetCustomAttributes((MemberInfo) mi, typeof(SourceToDestinationMapperAttribute), true).OfType<SourceToDestinationMapperAttribute>()));
 
-            return Cache[typeInfo].FirstOrDefault(kp => kp.Value.Any(_ => _.IsMatch(typeInfo, kp.Key, destType, nameToSearch))).Key;
+            return Cache[typeInfo].FirstOrDefault(kp => kp.Value.Any(_ => _.IsMatch(typeInfo, kp.Key, destType, destMemberType, nameToSearch))).Key;
         }
     }
 }

--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -63,7 +63,7 @@ namespace AutoMapper.Configuration
 
         public void ResolveUsing<TMember>(Func<TSource, TMember> resolver)
         {
-            _propertyMapActions.Add(pm => pm.AssignCustomValueResolver(new DelegateBasedResolver<TSource, TMember>(resolver)));
+            _propertyMapActions.Add(pm => pm.AssignCustomValueResolver(new DelegateBasedResolver<TSource, TMember>(rr => resolver((TSource)rr.Value))));
         }
 
         public void ResolveUsing<TMember>(Func<ResolutionResult, TMember> resolver)
@@ -73,7 +73,7 @@ namespace AutoMapper.Configuration
 
         public void ResolveUsing<TMember>(Func<ResolutionResult, TSource, TMember> resolver)
         {
-            _propertyMapActions.Add(pm => pm.AssignCustomValueResolver(new DelegateBasedResolver<TSource, TMember>(r => resolver(r, (TSource)r.Value))));
+            _propertyMapActions.Add(pm => pm.AssignCustomValueResolver(new DelegateBasedResolver<TSource, TMember>(rr => resolver(rr, (TSource)rr.Value))));
         }
 
         public void MapFrom<TMember>(Expression<Func<TSource, TMember>> sourceMember)
@@ -112,7 +112,7 @@ namespace AutoMapper.Configuration
 
         public void UseValue(object value)
         {
-            _propertyMapActions.Add(pm => pm.AssignCustomValueResolver(new DelegateBasedResolver<TSource, object>((TSource src) => value)));
+            _propertyMapActions.Add(pm => pm.AssignCustomValueResolver(new DelegateBasedResolver<TSource, object>(rr => value)));
         }
 
         public void Condition(Func<TSource, bool> condition)

--- a/src/AutoMapper/Configuration/ResolutionExpression.cs
+++ b/src/AutoMapper/Configuration/ResolutionExpression.cs
@@ -27,7 +27,7 @@ namespace AutoMapper.Configuration
                     pm.SourceMember = body.Member;
                 }
                 var func = sourceMember.Compile();
-                pm.ChainTypeMemberForResolver(new DelegateBasedResolver<TSource, object>(func));
+                pm.ChainTypeMemberForResolver(new DelegateBasedResolver<TSource, object>(rr => func((TSource)rr.Value)));
             });
         }
 
@@ -91,7 +91,7 @@ namespace AutoMapper.Configuration
                     pm.SourceMember = body.Member;
                 }
                 var func = sourceMember.Compile();
-                pm.ChainTypeMemberForResolver(new DelegateBasedResolver<TSource, object>(func));
+                pm.ChainTypeMemberForResolver(new DelegateBasedResolver<TSource, object>(rr => func((TSource)rr.Value)));
             });
 
             return this;

--- a/src/AutoMapper/ConfigurationValidator.cs
+++ b/src/AutoMapper/ConfigurationValidator.cs
@@ -114,6 +114,7 @@ namespace AutoMapper
                     if (lastResolver != null)
                     {
                         var sourceType = lastResolver.MemberType;
+
                         // when we don't know what the source type is, bail
                         if (sourceType.IsGenericParameter || sourceType == typeof(object))
                             return;

--- a/src/AutoMapper/ConstructorMap.cs
+++ b/src/AutoMapper/ConstructorMap.cs
@@ -28,6 +28,7 @@ namespace AutoMapper
         private static readonly IExpressionResultConverter[] ExpressionResultConverters =
         {
             new MemberGetterExpressionResultConverter(),
+            new ExpressionBasedResolverResultConverter(),
             new MemberResolverExpressionResultConverter(),
             new NullSubstitutionExpressionResultConverter()
         };

--- a/src/AutoMapper/Execution/DelegateBasedResolver.cs
+++ b/src/AutoMapper/Execution/DelegateBasedResolver.cs
@@ -1,14 +1,12 @@
+using System.Linq.Expressions;
+
 namespace AutoMapper.Execution
 {
     using System;
 
-    public class DelegateBasedResolver<TSource, TMember> : IMemberResolver
+    public class DelegateBasedResolver<TSource, TMember> : IValueResolver
     {
         private readonly Func<ResolutionResult, TMember> _method;
-
-        public DelegateBasedResolver(Func<TSource, TMember> method) : this(r=>method((TSource)r.Value))
-        {
-        }
 
         public DelegateBasedResolver(Func<ResolutionResult, TMember> method)
         {
@@ -19,11 +17,34 @@ namespace AutoMapper.Execution
 
         public ResolutionResult Resolve(ResolutionResult source)
         {
+            if (source.Value != null && !(source.Value is TSource))
+            {
+                throw new ArgumentException($"Expected obj to be of type {typeof(TSource)} but was {source.Value.GetType()}");
+            }
+            var result = _method(source);
+            return source.New(result, typeof(TMember));
+        }
+    }
+    public class ExpressionBasedResolver<TSource, TMember> : IExpressionResolver
+    {
+        public LambdaExpression Expression { get; }
+        private readonly Func<TSource, TMember> _method;
+
+        public ExpressionBasedResolver(Expression<Func<TSource, TMember>> expression)
+        {
+            Expression = expression;
+            _method = expression.Compile();
+        }
+
+        public Type MemberType => typeof(TMember);
+
+        public ResolutionResult Resolve(ResolutionResult source)
+        {
             if(source.Value != null && !(source.Value is TSource))
             {
                 throw new ArgumentException($"Expected obj to be of type {typeof (TSource)} but was {source.Value.GetType()}");
             }
-            var result = _method(source);
+            var result = _method((TSource)source.Value);
             return source.New(result, typeof(TMember));
         }
     }

--- a/src/AutoMapper/ICtorParamConfigurationExpression.cs
+++ b/src/AutoMapper/ICtorParamConfigurationExpression.cs
@@ -28,7 +28,7 @@
 
         public void MapFrom<TMember>(Expression<Func<TSource, TMember>> sourceMember)
         {
-            _ctorParamActions.Add(cpm => cpm.ResolveUsing(new DelegateBasedResolver<TSource, TMember>(sourceMember.Compile())));
+            _ctorParamActions.Add(cpm => cpm.ResolveUsing(new ExpressionBasedResolver<TSource, TMember>(sourceMember)));
         }
 
         public void Configure(TypeMap typeMap)

--- a/src/AutoMapper/IMemberResolver.cs
+++ b/src/AutoMapper/IMemberResolver.cs
@@ -1,3 +1,5 @@
+using System.Linq.Expressions;
+
 namespace AutoMapper
 {
     using System;
@@ -5,5 +7,10 @@ namespace AutoMapper
     public interface IMemberResolver : IValueResolver
     {
         Type MemberType { get; }
+    }
+
+    public interface IExpressionResolver : IMemberResolver
+    {
+        LambdaExpression Expression { get; }
     }
 }

--- a/src/AutoMapper/Profile.cs
+++ b/src/AutoMapper/Profile.cs
@@ -168,7 +168,7 @@ namespace AutoMapper
         {
             _globalIgnore.Add(propertyNameStartingWith);
         }
-        
+
         private readonly List<MethodInfo> _sourceExtensionMethods = new List<MethodInfo>();
 
         private readonly IList<IMemberConfiguration> _memberConfigurations = new List<IMemberConfiguration>();

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -235,7 +235,7 @@ namespace AutoMapper
             CustomExpression = sourceMember;
             AssignCustomValueResolver(
                 new NullReferenceExceptionSwallowingResolver(
-                    new DelegateBasedResolver<TSource, TMember>(sourceMember.Compile())
+                    new ExpressionBasedResolver<TSource, TMember>(sourceMember)
                     )
                 );
         }

--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -23,6 +23,7 @@ namespace AutoMapper.QueryableExtensions
         private static readonly IExpressionResultConverter[] ExpressionResultConverters =
         {
             new MemberGetterExpressionResultConverter(),
+            new ExpressionBasedResolverResultConverter(),
             new MemberResolverExpressionResultConverter(),
             new NullSubstitutionExpressionResultConverter()
         };

--- a/src/AutoMapper/QueryableExtensions/Impl/DelegateBasedResolverResolutConverter.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/DelegateBasedResolverResolutConverter.cs
@@ -1,0 +1,41 @@
+namespace AutoMapper.QueryableExtensions.Impl
+{
+    using System;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Reflection;
+
+    public class ExpressionBasedResolverResultConverter : IExpressionResultConverter
+    {
+        public ExpressionResolutionResult GetExpressionResolutionResult(
+            ExpressionResolutionResult expressionResolutionResult, PropertyMap propertyMap, IValueResolver valueResolver)
+        {
+            return ExpressionResolutionResult(expressionResolutionResult, (valueResolver as IExpressionResolver).Expression);
+        }
+
+        private static ExpressionResolutionResult ExpressionResolutionResult(
+            ExpressionResolutionResult expressionResolutionResult, LambdaExpression lambdaExpression)
+        {
+            var oldParameter = lambdaExpression.Parameters.Single();
+            var newParameter = expressionResolutionResult.ResolutionExpression;
+            var converter = new ParameterConversionVisitor(newParameter, oldParameter);
+
+            Expression currentChild = converter.Visit(lambdaExpression.Body);
+            Type currentChildType = currentChild.Type;
+
+            return new ExpressionResolutionResult(currentChild, currentChildType);
+        }
+
+        public ExpressionResolutionResult GetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult,
+            ConstructorParameterMap propertyMap, IValueResolver valueResolver)
+        {
+            return ExpressionResolutionResult(expressionResolutionResult, null);
+        }
+
+        public bool CanGetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult,
+            IValueResolver valueResolver)
+        {
+            return valueResolver is IExpressionResolver;
+        }
+    }
+}

--- a/src/AutoMapper/TypeMapFactory.cs
+++ b/src/AutoMapper/TypeMapFactory.cs
@@ -20,7 +20,7 @@ namespace AutoMapper
             {
                 var resolvers = new LinkedList<IValueResolver>();
 
-                if (MapDestinationPropertyToSource(options, sourceTypeInfo, destProperty.GetMemberType(), destProperty.Name, resolvers))
+                if (MapDestinationPropertyToSource(options, sourceTypeInfo, destProperty.DeclaringType, destProperty.GetMemberType(), destProperty.Name, resolvers))
                 {
                     var destPropertyAccessor = destProperty.ToMemberAccessor();
 
@@ -40,9 +40,9 @@ namespace AutoMapper
             return typeMap;
         }
 
-        private bool MapDestinationPropertyToSource(IProfileConfiguration options, TypeDetails sourceTypeInfo, Type destType, string destMemberInfo, LinkedList<IValueResolver> members)
+        private bool MapDestinationPropertyToSource(IProfileConfiguration options, TypeDetails sourceTypeInfo, Type destType, Type destMemberType, string destMemberInfo, LinkedList<IValueResolver> members)
         {
-            return options.MemberConfigurations.Any(_ => _.MapDestinationPropertyToSource(options, sourceTypeInfo, destType, destMemberInfo, members));
+            return options.MemberConfigurations.Any(_ => _.MapDestinationPropertyToSource(options, sourceTypeInfo, destType, destMemberType, destMemberInfo, members));
         }
 
         private bool MapDestinationCtorToSource(TypeMap typeMap, ConstructorInfo destCtor, TypeDetails sourceTypeInfo, IProfileConfiguration options)
@@ -57,7 +57,7 @@ namespace AutoMapper
             {
                 var resolvers = new LinkedList<IValueResolver>();
 
-                var canResolve = MapDestinationPropertyToSource(options, sourceTypeInfo, parameter.GetType(), parameter.Name, resolvers);
+                var canResolve = MapDestinationPropertyToSource(options, sourceTypeInfo, destCtor.DeclaringType, parameter.GetType(), parameter.Name, resolvers);
                 if(!canResolve && parameter.HasDefaultValue)
                 {
                     canResolve = true;


### PR DESCRIPTION
Now Have ExpressionBasedResolver to distinguish the two resolver types