### PR TITLE
Fixed issue #1905 mapping nullable type to nullable type

### DIFF
--- a/src/AutoMapper/Mappers/MapperRegistry.cs
+++ b/src/AutoMapper/Mappers/MapperRegistry.cs
@@ -26,6 +26,7 @@ namespace AutoMapper.Mappers
 #if !PORTABLE
             new TypeConverterMapper(),
 #endif
+            new NullableMapper(),
             new NullableSourceMapper(),
             new ImplicitConversionOperatorMapper(),
             new ExplicitConversionOperatorMapper(),

--- a/src/AutoMapper/Mappers/NullableMapper.cs
+++ b/src/AutoMapper/Mappers/NullableMapper.cs
@@ -11,7 +11,7 @@ namespace AutoMapper.Mappers
 
         public bool IsMatch(TypePair context)
         {
-            return context.DestinationType.IsNullableType();
+            return context.SourceType == typeof(object) && context.DestinationType.IsNullableType();
         }
     }
 }

--- a/src/UnitTests/NullBehavior.cs
+++ b/src/UnitTests/NullBehavior.cs
@@ -405,5 +405,32 @@ namespace AutoMapper.UnitTests
                 _dest.Values6.ShouldBeNull();
             }
         }
-	}
+
+        public class When_mapping_a_nullable_type_to_nullable_type : AutoMapperSpecBase
+        {
+            public class MyNullableDecimalClass
+            {
+                public decimal? MyNullableDecimal { get; set; }
+            }
+
+            public class MyMappedNullableDecimalClass
+            {
+                public decimal? MyMappedNullableDecimal { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<MyNullableDecimalClass, MyMappedNullableDecimalClass>()
+                .ForMember(dest => dest.MyMappedNullableDecimal, opt => opt.ResolveUsing(src => src.MyNullableDecimal));
+            });
+
+            [Fact]
+            public void Should_allow_the_mapper_to_handle_null_values()
+            {
+                var testClass = new MyNullableDecimalClass { MyNullableDecimal = null };
+                var result = Mapper.Map<MyNullableDecimalClass, MyMappedNullableDecimalClass>(testClass);
+                result.MyMappedNullableDecimal.ShouldBeNull();
+            }
+        }
+    }
 }


### PR DESCRIPTION
#1905 Resolving a nullable decimal to a nullable decimal throws Missing type map configuration or unsupported mapping at runtime. version 4.2.0. Aslo adding unit test.