### PR TITLE
Extension methods per type

### DIFF
--- a/src/AutoMapper/IProfileExpression.cs
+++ b/src/AutoMapper/IProfileExpression.cs
@@ -133,6 +133,6 @@ namespace AutoMapper
         string ProfileName { get; }
         IMemberConfiguration AddMemberConfiguration();
         IConditionalObjectMapper AddConditionalObjectMapper();
-        void IncludeSourceExtensionMethods(Assembly assembly);
+        void IncludeSourceExtensionMethods(Type type);
     }
 }

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -95,9 +95,9 @@ namespace AutoMapper
             set { _defaultProfile.CreateMissingTypeMaps = value; }
         }
 
-        void IProfileExpression.IncludeSourceExtensionMethods(Assembly assembly)
+        void IProfileExpression.IncludeSourceExtensionMethods(Type type)
         {
-            _defaultProfile.IncludeSourceExtensionMethods(assembly);
+            _defaultProfile.IncludeSourceExtensionMethods(type);
         }
 
         INamingConvention IProfileExpression.SourceMemberNamingConvention

--- a/src/AutoMapper/Profile.cs
+++ b/src/AutoMapper/Profile.cs
@@ -30,7 +30,7 @@ namespace AutoMapper
         protected Profile()
         {
             ProfileName = GetType().FullName;
-            IncludeSourceExtensionMethods(typeof(Enumerable).Assembly());
+            IncludeSourceExtensionMethods(typeof(Enumerable));
             _memberConfigurations.Add(new MemberConfiguration().AddMember<NameSplitMember>().AddName<PrePostfixName>(_ => _.AddStrings(p => p.Prefixes, "Get")));
         }
 
@@ -206,14 +206,9 @@ namespace AutoMapper
 
         public Func<FieldInfo, bool> ShouldMapField { get; set; } = f => f.IsPublic();
 
-        public void IncludeSourceExtensionMethods(Assembly assembly)
+        public void IncludeSourceExtensionMethods(Type type)
         {
-            //http://stackoverflow.com/questions/299515/c-sharp-reflection-to-identify-extension-methods
-            _sourceExtensionMethods.AddRange(assembly.ExportedTypes
-                .Where(type => type.IsSealed() && !type.IsGenericType() && !type.IsNested)
-                .SelectMany(type => type.GetDeclaredMethods().Where(mi => mi.IsStatic))
-                .Where(method => method.IsDefined(typeof(ExtensionAttribute), false))
-                .Where(method => method.GetParameters().Length == 1));
+            _sourceExtensionMethods.AddRange(type.GetDeclaredMethods().Where(m => m.IsStatic && m.IsDefined(typeof(ExtensionAttribute), false) && m.GetParameters().Length == 1));
         }
 
         void IProfileConfiguration.Register(TypeMapRegistry typeMapRegistry)

--- a/src/UnitTests/ExtensionMethods.cs
+++ b/src/UnitTests/ExtensionMethods.cs
@@ -33,7 +33,7 @@ namespace AutoMapper.UnitTests
 
 		    protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
 		    {
-		        cfg.IncludeSourceExtensionMethods(Assembly.GetExecutingAssembly());
+		        cfg.IncludeSourceExtensionMethods(typeof(When_extension_method_returns_value_type_SourceExtensions));
 		        cfg.CreateMap<Source, Destination>();
 		    });
 
@@ -85,7 +85,7 @@ namespace AutoMapper.UnitTests
 
 		    protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
 		    {
-		        cfg.IncludeSourceExtensionMethods(Assembly.GetExecutingAssembly());
+		        cfg.IncludeSourceExtensionMethods(typeof(When_extension_method_returns_object_SourceExtensions));
 		        cfg.CreateMap<Source, Destination>();
 		    });
 


### PR DESCRIPTION
There is no need to probe, just pass the type containing the extension methods.
I don't know if Queryable matters.
https://github.com/AutoMapper/AutoMapper/pull/1089#issuecomment-181484686