### PR TITLE
Small changes to expression-binding behaviour II

### DIFF
--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -31,10 +31,10 @@ namespace AutoMapper.QueryableExtensions
         private static readonly IExpressionBinder[] Binders =
         {
             new NullableExpressionBinder(),
-            new AssignableExpressionBinder(),
             new EnumerableExpressionBinder(),
             new MappedTypeExpressionBinder(),
             new CustomProjectionExpressionBinder(),
+            new AssignableExpressionBinder(),
             new StringExpressionBinder()
         };
 

--- a/src/UnitTests/Projection/NullableItemsTests.cs
+++ b/src/UnitTests/Projection/NullableItemsTests.cs
@@ -16,7 +16,10 @@ namespace AutoMapper.UnitTests.Projection
 
             public NullChildItemTest()
             {
-                _config = new MapperConfiguration(cfg => cfg.CreateMap<Parent, ParentDto>());
+                _config = new MapperConfiguration(cfg => {
+                    cfg.CreateMap<Parent, ParentDto>();
+                    cfg.AllowNullCollections = true;
+                });
             }
 
             [Fact]
@@ -35,8 +38,9 @@ namespace AutoMapper.UnitTests.Projection
                 projected[0].Value.ShouldEqual(5);
                 projected[0].ChildValue.ShouldBeNull();
                 projected[0].ChildGrandChildValue.ShouldBeNull();
+                projected[0].Nephews.ShouldBeNull();
             }
-
+                       
 
             public class ParentDto
             {
@@ -44,6 +48,7 @@ namespace AutoMapper.UnitTests.Projection
                 public int? ChildValue { get; set; }
                 public int? ChildGrandChildValue { get; set; }
                 public DateTime? Date { get; set; }
+                public Child[] Nephews { get; set; }
             }
 
 
@@ -51,6 +56,7 @@ namespace AutoMapper.UnitTests.Projection
             {
                 public int Value { get; set; }
                 public Child Child { get; set; }
+                public Child[] Nephews { get; set; }
             }
 
             public class Child

--- a/src/UnitTests/Projection/ProjectionTests.cs
+++ b/src/UnitTests/Projection/ProjectionTests.cs
@@ -1,0 +1,99 @@
+﻿namespace AutoMapper.UnitTests.Projection
+{
+    using System.Linq;
+    using Xunit;
+    using Should;
+    using AutoMapper;
+    using QueryableExtensions;
+
+    public class ProjectionTests
+    {
+        string _niceGreeting = "Hello";
+        string _badGreeting = "GRRRRR";
+        
+
+        [Fact]
+        public void Direct_assignability_shouldnt_trump_custom_projection() {
+            Mapper.Initialize(x => {
+                x.CreateMap<string, string>()
+                    .ProjectUsing(s => _niceGreeting);
+
+                x.CreateMap<Source, Target>();
+                x.CreateMap<SourceChild, TargetChild>();
+            });
+
+            var target = new[] { new Source() { Greeting = _badGreeting } }
+                            .AsQueryable()
+                            .ProjectTo<Target>()
+                            .First();
+
+            target.Greeting.ShouldEqual(_niceGreeting);
+        }
+
+
+        [Fact]
+        public void Root_is_subject_to_custom_projection() {
+            Mapper.Initialize(x => {
+                x.CreateMap<Source, Target>()
+                    .ProjectUsing(s => new Target() { Greeting = _niceGreeting });
+            });
+
+            var target = new[] { new Source() }
+                            .AsQueryable()
+                            .ProjectTo<Target>()
+                            .First();
+
+            target.Greeting.ShouldEqual(_niceGreeting);
+        }
+
+
+        [Fact]
+        public void Child_nodes_are_subject_to_custom_projection() {
+            Mapper.Initialize(x => {
+                x.CreateMap<SourceChild, TargetChild>()
+                    .ProjectUsing(s => new TargetChild() { Greeting = _niceGreeting });
+
+                x.CreateMap<Source, Target>();
+            });
+
+            var target = new[] { new Source() }
+                            .AsQueryable()
+                            .ProjectTo<Target>()
+                            .First();
+
+            target.Child.Greeting.ShouldEqual(_niceGreeting);
+        }
+
+
+
+
+        class Source
+        {
+            public string Greeting { get; set; }
+            public int Number { get; set; }
+            public SourceChild Child { get; set; }
+
+            public Source() {
+                Child = new SourceChild();
+            }
+        }
+
+        class SourceChild
+        {
+            public string Greeting { get; set; }
+        }
+
+
+        class Target
+        {
+            public string Greeting { get; set; }
+            public int? Number { get; set; }
+            public TargetChild Child { get; set; }
+        }
+
+        class TargetChild
+        {
+            public string Greeting { get; set; }
+        }
+    }
+}

--- a/src/UnitTests/Query/SourceInjectedQuery.cs
+++ b/src/UnitTests/Query/SourceInjectedQuery.cs
@@ -21,7 +21,7 @@ namespace AutoMapper.UnitTests.Query
         {
             public int SrcValue { get; set; }
             public string StringValue { get; set; }
-            public string[] Strings { get; set; }
+            public string[] Strings { get; set; } = new string[0];
         }
 
         public class Destination

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -250,6 +250,7 @@
     <Compile Include="Projection\ProjectCollectionListTest.cs" />
     <Compile Include="Projection\ProjectEnumerableToArrayTest.cs" />
     <Compile Include="Projection\ProjectEnumTest.cs" />
+    <Compile Include="Projection\ProjectionTests.cs" />
     <Compile Include="Projection\ProjectTest.cs" />
     <Compile Include="Projection\GenericsTests.cs" />
     <Compile Include="Projection\ToStringTests.cs" />


### PR DESCRIPTION
Hi, this is a simplified version of #852, this time skipping the gratuitous refactoring (and also some of the side issues, which I'll treat separately).

Basically, this PR: 
* Moves the `AssignableExpressionBinder` down the list of binders, so that it allows other binding behaviours a chance to do their stuff when projecting like to like
* Fixes up `EnumerableExpressionBinder` to add null-guards when `config.AllowNullCollections` is set to true - nulls were previously always copied over by `AssignableExpressionBinder`
