### PR TITLE
Make TypePair a struct

### DIFF
--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -351,7 +351,7 @@ namespace AutoMapper
 
             var typeMap = _profiles
                 .Cast<IProfileConfiguration>()
-                .Select(p => p.ConfigureClosedGenericTypeMap(_typeMapRegistry, typePair, openGenericTypes))
+                .Select(p => p.ConfigureClosedGenericTypeMap(_typeMapRegistry, typePair, openGenericTypes.Value))
                 .FirstOrDefault(t => t != null);
 
             return typeMap;

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -200,10 +200,14 @@ namespace AutoMapper
 
         public Type GetDerivedTypeFor(Type derivedSourceType)
         {
+            if(DestinationTypeOverride != null)
+            {
+                return DestinationTypeOverride;
+            }
             // This might need to be fixed for multiple derived source types to different dest types
             var match = _includedDerivedTypes.FirstOrDefault(tp => tp.SourceType == derivedSourceType);
 
-            return DestinationTypeOverride ?? match?.DestinationType ?? DestinationType;
+            return match.DestinationType ?? DestinationType;
         }
 
         public bool TypeHasBeenIncluded(TypePair derivedTypes)

--- a/src/AutoMapper/TypePair.cs
+++ b/src/AutoMapper/TypePair.cs
@@ -7,7 +7,7 @@ namespace AutoMapper
     using System.Reflection;
 
     [DebuggerDisplay("{SourceType.Name}, {DestinationType.Name}")]
-    public class TypePair : IEquatable<TypePair>
+    public struct TypePair : IEquatable<TypePair>
     {
         public static bool operator ==(TypePair left, TypePair right) => Equals(left, right);
 
@@ -26,16 +26,14 @@ namespace AutoMapper
 
         public Type DestinationType { get; }
 
-        public bool Equals(TypePair other) => !ReferenceEquals(null, other) && (ReferenceEquals(this, other) ||
-                                                                                SourceType == other.SourceType &&
-                                                                                DestinationType == other.DestinationType);
+        public bool Equals(TypePair other) => SourceType == other.SourceType && DestinationType == other.DestinationType;
 
         public override bool Equals(object obj) => !ReferenceEquals(null, obj) &&
                                                    (ReferenceEquals(this, obj) || obj.GetType() == GetType() && Equals((TypePair) obj));
 
         public override int GetHashCode() => _hashcode;
 
-        public TypePair GetOpenGenericTypePair()
+        public TypePair? GetOpenGenericTypePair()
         {
             var isGeneric = SourceType.IsGenericType()
                             && DestinationType.IsGenericType()
@@ -54,9 +52,10 @@ namespace AutoMapper
 
         public IEnumerable<TypePair> GetRelatedTypePairs()
         {
+            var @this = this;
             var subTypePairs =
                 from destinationType in GetAllTypes(DestinationType)
-                from sourceType in GetAllTypes(SourceType)
+                from sourceType in @this.GetAllTypes(@this.SourceType)
                 select new TypePair(sourceType, destinationType);
             return subTypePairs;
         }


### PR DESCRIPTION
[Before](https://cloud.githubusercontent.com/assets/4517428/13281693/e85e1e18-daed-11e5-8920-7def940347d8.png) & [after](https://cloud.githubusercontent.com/assets/4517428/13282395/70fb9310-daf1-11e5-941d-65d0ece6f158.png).
We could try the same for ResolutionContext and ResolutionResult. It's true that the ResolutionContext is too big right now.
[The test project](https://github.com/lbargaoanu/AutoMapperBenchmark).