### PR TITLE
Reuse the ResolutionContext for properties and enumerable items

### DIFF
--- a/src/AutoMapper/IMapper.cs
+++ b/src/AutoMapper/IMapper.cs
@@ -119,6 +119,7 @@ namespace AutoMapper
 
     public interface IRuntimeMapper : IMapper
     {
+        object Map(ResolutionContext context);
         object Map(object source, object destination, Type sourceType, Type destinationType, ResolutionContext parent);
         bool ShouldMapSourceValueAsNull(ResolutionContext context);
         bool ShouldMapSourceCollectionAsNull(ResolutionContext context);

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -257,6 +257,8 @@ namespace AutoMapper
             return MapCore(source, destination, sourceType, destinationType, options);
         }
 
+        object IRuntimeMapper.Map(ResolutionContext context) => _engine.Map(context);
+
         object IRuntimeMapper.Map(object source, object destination, Type sourceType, Type destinationType, ResolutionContext parent)
             => MapCore(source, destination, sourceType, destinationType, parent);
 

--- a/src/AutoMapper/Mappers/EnumerableMapperBase.cs
+++ b/src/AutoMapper/Mappers/EnumerableMapperBase.cs
@@ -38,9 +38,12 @@ namespace AutoMapper.Mappers
             ClearEnumerable(enumerable);
 
             int i = 0;
+            var itemContext = new ResolutionContext(context);
             foreach (object item in enumerableValue)
             {
-                object mappedValue = context.Mapper.Map(item, null, sourceElementType, destElementType, context);
+                var typeMap = context.ConfigurationProvider.ResolveTypeMap(item, null, sourceElementType, destElementType);
+                itemContext.Fill(item, null, sourceElementType, destElementType, typeMap);
+                var mappedValue = context.Mapper.Map(itemContext);
 
                 SetElementValue(enumerable, mappedValue, i);
 

--- a/src/AutoMapper/ResolutionContext.cs
+++ b/src/AutoMapper/ResolutionContext.cs
@@ -17,27 +17,27 @@ namespace AutoMapper
         /// <summary>
         /// Current type map
         /// </summary>
-        public TypeMap TypeMap { get; }
+        public TypeMap TypeMap { get; private set; }
 
         /// <summary>
         /// Current source type
         /// </summary>
-        public Type SourceType { get; }
+        public Type SourceType { get; private set; }
 
         /// <summary>
         /// Current attempted destination type
         /// </summary>
-        public Type DestinationType { get; }
+        public Type DestinationType { get; private set; }
 
         /// <summary>
         /// Source value
         /// </summary>
-        public object SourceValue { get; }
+        public object SourceValue { get; private set; }
 
         /// <summary>
         /// Destination value
         /// </summary>
-        public object DestinationValue { get; }
+        public object DestinationValue { get; private set; }
 
         /// <summary>
         /// Parent resolution context
@@ -62,7 +62,7 @@ namespace AutoMapper
         /// <summary>
         /// Source and destination type pair
         /// </summary>
-        public TypePair Types { get; }
+        public TypePair Types { get; private set; }
 
         public bool IsSourceValueNull => Equals(null, SourceValue);
 
@@ -79,6 +79,24 @@ namespace AutoMapper
             DestinationType = destinationType ?? typeMap?.DestinationType ?? parent.DestinationType;
 
             Types = new TypePair(SourceType, DestinationType);
+        }
+
+        internal ResolutionContext(ResolutionContext parent)
+        {
+            Parent = parent;
+            Options = parent.Options;
+            Mapper = parent.Mapper;
+            InstanceCache = parent.InstanceCache;
+        }
+
+        internal void Fill(object source, object destination, Type sourceType, Type destinationType, TypeMap typeMap)
+        {
+           SourceType = sourceType ?? typeMap?.SourceType ?? Parent.SourceType;
+           DestinationType = destinationType ?? typeMap?.DestinationType ?? Parent.DestinationType;
+           Types = new TypePair(SourceType, DestinationType);
+           SourceValue = source;
+           DestinationValue = destination;
+           TypeMap = typeMap;
         }
 
         public ResolutionContext(object source, object destination, Type sourceType, Type destinationType, TypeMap typeMap, MappingOperationOptions options, IRuntimeMapper mapper)


### PR DESCRIPTION
[Before](https://cloud.githubusercontent.com/assets/4517428/13432667/4e3990e4-dfd7-11e5-9531-821a4f685911.png) & [after](https://cloud.githubusercontent.com/assets/4517428/13432666/4e31b73e-dfd7-11e5-9dde-73b812268fd4.png).
[The test project](https://github.com/lbargaoanu/AutoMapperBenchmark).