### PR TITLE
Fixed localdb version in integration tests

### DIFF
--- a/src/IntegrationTests.Net4/App.config
+++ b/src/IntegrationTests.Net4/App.config
@@ -7,7 +7,7 @@
   <entityFramework>
     <!--<defaultConnectionFactory type="System.Data.Entity.Infrastructure.LocalDbConnectionFactory, EntityFramework">
       <parameters>
-        <parameter value="v12.0" />
+        <parameter value="mssqllocaldb" />
       </parameters>
     </defaultConnectionFactory>-->
     <providers>

--- a/src/IntegrationTests.Net4/TestDbConfiguration.cs
+++ b/src/IntegrationTests.Net4/TestDbConfiguration.cs
@@ -16,7 +16,7 @@ namespace AutoMapper.IntegrationTests.Net4
             }
             else
             {
-                SetDefaultConnectionFactory(new LocalDbConnectionFactory("v12.0"));
+                SetDefaultConnectionFactory(new LocalDbConnectionFactory("mssqllocaldb"));
             }
         }
     }


### PR DESCRIPTION
Had to change localdb version to get it working with SqlServer 2014 - "v12.0" becomes "mssqllocaldb"

See third post on here:
https://connect.microsoft.com/SQLServer/feedback/details/845278/sql-server-2014-express-localdb-does-not-create-automatic-instance-v12-0

This should replace #977