### PR TITLE
Unnecessary allocations in EnumerableMapper

### DIFF
--- a/src/AutoMapper/Mappers/CollectionMapper.cs
+++ b/src/AutoMapper/Mappers/CollectionMapper.cs
@@ -1,24 +1,15 @@
+using System;
+using System.Collections.Generic;
+using AutoMapper.Configuration;
+
 namespace AutoMapper.Mappers
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Reflection;
-    using Configuration;
-
     public class CollectionMapper : IObjectMapper
     {
         public object Map(ResolutionContext context)
         {
-            Type genericType = typeof (EnumerableMapper<,>);
-
-            var collectionType = context.DestinationType;
-            var elementType = TypeHelper.GetElementType(context.DestinationType);
-
-            var enumerableMapper = genericType.MakeGenericType(collectionType, elementType);
-
-            var objectMapper = (IObjectMapper) Activator.CreateInstance(enumerableMapper);
-
-            return objectMapper.Map(context);
+            var enumerableMapper = TypeHelper.GetEnumerableMapper(context.DestinationType);
+            return enumerableMapper.Map(context);
         }
 
         public bool IsMatch(TypePair context)
@@ -27,44 +18,40 @@ namespace AutoMapper.Mappers
 
             return isMatch;
         }
+    }
 
-        #region Nested type: EnumerableMapper
-
-        private class EnumerableMapper<TCollection, TElement> : EnumerableMapperBase<TCollection>
-            where TCollection : ICollection<TElement>
+    internal class EnumerableMapper<TCollection, TElement> : EnumerableMapperBase<TCollection>
+        where TCollection : ICollection<TElement>
+    {
+        public override bool IsMatch(TypePair context)
         {
-            public override bool IsMatch(TypePair context)
-            {
-                throw new NotImplementedException();
-            }
-
-            protected override void SetElementValue(TCollection destination, object mappedValue, int index)
-            {
-                destination.Add((TElement) mappedValue);
-            }
-
-            protected override void ClearEnumerable(TCollection enumerable)
-            {
-                enumerable.Clear();
-            }
-
-            protected override TCollection CreateDestinationObjectBase(Type destElementType, int sourceLength)
-            {
-                Object collection;
-
-                if (typeof (TCollection).IsInterface())
-                {
-                    collection = new List<TElement>();
-                }
-                else
-                {
-                    collection = ObjectCreator.CreateDefaultValue(typeof (TCollection));
-                }
-
-                return (TCollection) collection;
-            }
+            throw new NotImplementedException();
         }
 
-        #endregion
+        protected override void SetElementValue(TCollection destination, object mappedValue, int index)
+        {
+            destination.Add((TElement)mappedValue);
+        }
+
+        protected override void ClearEnumerable(TCollection enumerable)
+        {
+            enumerable.Clear();
+        }
+
+        protected override TCollection CreateDestinationObjectBase(Type destElementType, int sourceLength)
+        {
+            Object collection;
+
+            if(typeof(TCollection).IsInterface())
+            {
+                collection = new List<TElement>();
+            }
+            else
+            {
+                collection = ObjectCreator.CreateDefaultValue(typeof(TCollection));
+            }
+
+            return (TCollection)collection;
+        }
     }
 }

--- a/src/AutoMapper/Mappers/EnumerableMapperBase.cs
+++ b/src/AutoMapper/Mappers/EnumerableMapperBase.cs
@@ -16,11 +16,11 @@ namespace AutoMapper.Mappers
                 return null;
             }
 
-            ICollection<object> enumerableValue = ((IEnumerable) context.SourceValue ?? new object[0])
-                .Cast<object>()
-                .ToList();
+            ICollection enumerableValue = (context.SourceValue as ICollection) ??
+                                                          ((IEnumerable)context.SourceValue)?.Cast<object>().ToArray() ??
+                                                          new object[0];
 
-            Type sourceElementType = TypeHelper.GetElementType(context.SourceType, enumerableValue);
+            Type sourceElementType = TypeHelper.GetElementType(context.SourceType);
             Type destElementType = TypeHelper.GetElementType(context.DestinationType);
 
             // If you can just assign the collection from one side to the other and the element types don't need to be mapped

--- a/src/AutoMapper/Mappers/EnumerableMapperBase.cs
+++ b/src/AutoMapper/Mappers/EnumerableMapperBase.cs
@@ -16,10 +16,6 @@ namespace AutoMapper.Mappers
                 return null;
             }
 
-            ICollection enumerableValue = (context.SourceValue as ICollection) ??
-                                                          ((IEnumerable)context.SourceValue)?.Cast<object>().ToArray() ??
-                                                          new object[0];
-
             Type sourceElementType = TypeHelper.GetElementType(context.SourceType);
             Type destElementType = TypeHelper.GetElementType(context.DestinationType);
 
@@ -30,7 +26,9 @@ namespace AutoMapper.Mappers
                 if (elementTypeMap == null)
                     return context.SourceValue;
             }
-
+            ICollection enumerableValue = (context.SourceValue as ICollection) ??
+                                                          ((IEnumerable)context.SourceValue)?.Cast<object>().ToArray() ??
+                                                          new object[0];
             var sourceLength = enumerableValue.Count;
             var destination = GetOrCreateDestinationObject(context, destElementType, sourceLength);
             var enumerable = GetEnumerableFor(destination);

--- a/src/AutoMapper/Mappers/EnumerableToDictionaryMapper.cs
+++ b/src/AutoMapper/Mappers/EnumerableToDictionaryMapper.cs
@@ -23,7 +23,7 @@ namespace AutoMapper.Mappers
             var sourceEnumerableValue = (IEnumerable)context.SourceValue ?? new object[0];
             IEnumerable<object> enumerableValue = sourceEnumerableValue.Cast<object>();
 
-            Type sourceElementType = TypeHelper.GetElementType(context.SourceType, sourceEnumerableValue);
+            Type sourceElementType = TypeHelper.GetElementType(context.SourceType);
             Type genericDestDictType = context.DestinationType.GetDictionaryType();
             Type destKeyType = genericDestDictType.GetTypeInfo().GenericTypeArguments[0];
             Type destValueType = genericDestDictType.GetTypeInfo().GenericTypeArguments[1];


### PR DESCRIPTION
[Before](https://cloud.githubusercontent.com/assets/4517428/13701838/1e96f930-e793-11e5-81e0-c2d8c0df02df.png) & [after](https://cloud.githubusercontent.com/assets/4517428/13701837/1e8536d2-e793-11e5-9904-0ae5b639ed95.png). One idea is to have only one cache, but only ICollections need the EnumerableMapper and arrays don't need the element type cache.

cache the element type of the enumerable
cache the enumerable mapper object for the destination type
don't copy the source if it's ICollection
