### PR TITLE
Query inherited interfaces to find member

### DIFF
--- a/src/UnitTests/Bug/QueryableInterfaceInheritanceIssue.cs
+++ b/src/UnitTests/Bug/QueryableInterfaceInheritanceIssue.cs
@@ -1,0 +1,83 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using AutoMapper.QueryableExtensions;
+using Should;
+using Xunit;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public interface IBaseQueryableInterface
+    {
+        IPropertyInterface PropertyInterface { get; set; }
+    }
+
+    public interface IQueryableInterface : IBaseQueryableInterface
+    {
+        string AnotherProperty { get; set; }
+    }
+
+    public interface IPropertyInterface
+    {
+        int PropertyInterfaceId { get; set; }
+    }
+
+    public class QueryableInterfaceImpl : IQueryableInterface
+    {
+        public IPropertyInterface PropertyInterface { get; set; }
+        public string AnotherProperty { get; set; }
+    }
+
+    public class PropertyInterfaceImpl : IPropertyInterface
+    {
+        public int PropertyInterfaceId { get; set; }
+    }
+
+    public class QueryableDto
+    {
+        public int PropertyInterfaceId { get; set; }
+        public string AnotherProperty { get; set; }
+    }
+
+
+    public class QueryableInterfaceInheritanceIssue : AutoMapperSpecBase
+    {
+        [Fact]
+        public void QueryableShouldMapSpecifiedBaseInterfaceMember()
+        {
+            var inputList =
+                new List<IQueryableInterface>()
+                {
+                    new QueryableInterfaceImpl()
+                    {
+                        AnotherProperty = "One",
+                        PropertyInterface = new PropertyInterfaceImpl() {PropertyInterfaceId = 1}
+                    },
+                    new QueryableInterfaceImpl()
+                    {
+                        AnotherProperty = "Two",
+                        PropertyInterface = new PropertyInterfaceImpl() {PropertyInterfaceId = 2}
+                    }
+                };
+            // Currently throws exception
+            var result = inputList.AsQueryable().ProjectTo<QueryableDto>(ConfigProvider).ToList();
+            result.ShouldNotBeNull();
+            result.ShouldBeOfLength(2);
+            result.FirstOrDefault(dto => dto.AnotherProperty == "One" && dto.PropertyInterfaceId == 1).ShouldNotBeNull();
+            result.FirstOrDefault(dto => dto.AnotherProperty == "Two" && dto.PropertyInterfaceId == 2).ShouldNotBeNull();
+        }
+
+
+        protected override MapperConfiguration Configuration
+        {
+            get
+            {
+                return
+                    new MapperConfiguration(
+                        cfg =>
+                            cfg.CreateMap<IQueryableInterface, QueryableDto>()
+                                .ForMember(dto => dto.PropertyInterfaceId,
+                                    opt => opt.MapFrom(qi => qi.PropertyInterface.PropertyInterfaceId)));
+            }
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Bug\NullableResolveUsing.cs" />
     <Compile Include="Bug\NullableDateTime.cs" />
     <Compile Include="Bug\ProjectUsingTheQueriedEntity.cs" />
+    <Compile Include="Bug\QueryableInterfaceInheritanceIssue.cs" />
     <Compile Include="Bug\ReverseMapReplaceMemberName.cs" />
     <Compile Include="Bug\JsonNet.cs" />
     <Compile Include="Bug\TargetISet.cs" />


### PR DESCRIPTION
Addresses #1181.  When the source type of a mapping is an interface, and a property from a base interface is referenced in `MapFrom`, the `ProjectTo` method fails with an exception.  The `MemberResolverExpressionResultConverter.VisitMember` method presumed that `Type.GetMember(string)` always returns at least one `MemberInfo` instance.  However, that method does not return members from inherited interfaces, so those interfaces need to be queried separately to find the desired `MemberInfo` instance.