### PR TITLE
Make the null substitute type safe

### DIFF
--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -27,7 +27,7 @@ namespace AutoMapper.Configuration
 
         public IMemberAccessor DestinationMember => _destinationMember;
 
-        public void NullSubstitute(object nullSubstitute)
+        public void NullSubstitute(TMember nullSubstitute)
         {
             _propertyMapActions.Add(pm => pm.SetNullSubstitute(nullSubstitute));
         }

--- a/src/AutoMapper/IMemberConfigurationExpression.cs
+++ b/src/AutoMapper/IMemberConfigurationExpression.cs
@@ -8,13 +8,13 @@ namespace AutoMapper
     /// </summary>
     /// <typeparam name="TSource">Source type for this member</typeparam>
     /// <typeparam name="TMember">Type for this member</typeparam>
-    public interface IMemberConfigurationExpression<TSource, out TMember>
+    public interface IMemberConfigurationExpression<TSource, TMember>
     {
         /// <summary>
         /// Substitute a custom value when the source member resolves as null
         /// </summary>
         /// <param name="nullSubstitute">Value to use</param>
-        void NullSubstitute(object nullSubstitute);
+        void NullSubstitute(TMember nullSubstitute);
 
         /// <summary>
         /// Resolve destination member using a custom value resolver

--- a/src/UnitTests/Bug/NullSubstituteType.cs
+++ b/src/UnitTests/Bug/NullSubstituteType.cs
@@ -1,0 +1,36 @@
+﻿using Xunit;
+using Should;
+using System;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public class NullSubstituteType : AutoMapperSpecBase
+    {
+        private Destination _destination;
+
+        class Source
+        {
+            public long? Number { get; set; }
+        }
+        class Destination
+        {
+            public long? Number { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>().ForMember(d => d.Number, o => o.NullSubstitute(0));
+        });
+
+        protected override void Because_of()
+        {
+            _destination = Mapper.Map<Source, Destination>(new Source());
+        }
+
+        [Fact]
+        public void Should_substitute_zero_for_null()
+        {
+            _destination.Number.ShouldEqual(0);
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -104,6 +104,7 @@
     <Compile Include="Bug\AssertConfigurationIsValidNullables.cs" />
     <Compile Include="Bug\IncludeBaseInheritance.cs" />
     <Compile Include="Bug\IncludeInheritance.cs" />
+    <Compile Include="Bug\NullSubstituteType.cs" />
     <Compile Include="Bug\NullableResolveUsing.cs" />
     <Compile Include="Bug\NullableDateTime.cs" />
     <Compile Include="Bug\ProjectUsingTheQueriedEntity.cs" />


### PR DESCRIPTION
I don't know if this is the right fix, but #1183 seems reasonable.