### PR TITLE
Change ReplaceName's PossibleNames() to merge enumerables with Union …

### DIFF
--- a/src/AutoMapper/Internal/IMappingOptionsMemberMapper.cs
+++ b/src/AutoMapper/Internal/IMappingOptionsMemberMapper.cs
@@ -180,7 +180,7 @@ namespace AutoMapper
         {
             return 
                 MemberNameReplacers.Select(r => nameToSearch.Replace(r.OriginalValue, r.NewValue))
-                    .Concat(new[] { MemberNameReplacers.Aggregate(nameToSearch, (s, r) => s.Replace(r.OriginalValue, r.NewValue)), nameToSearch })
+                    .Union(new[] { MemberNameReplacers.Aggregate(nameToSearch, (s, r) => s.Replace(r.OriginalValue, r.NewValue)), nameToSearch })
                     .ToList();
         }
     }


### PR DESCRIPTION
Change ReplaceName's PossibleNames() to merge enumerables with Union instead of Concat to avoid duplicates.