### PR TITLE
[Wip] Constructor performance

### DIFF
--- a/src/AutoMapper/Execution/DelegateFactory.cs
+++ b/src/AutoMapper/Execution/DelegateFactory.cs
@@ -10,10 +10,10 @@ namespace AutoMapper.Execution
 
     public class DelegateFactory
     {
-        private readonly ConcurrentDictionary<Type, LateBoundCtor> _ctorCache =
-            new ConcurrentDictionary<Type, LateBoundCtor>();
+        private readonly ConcurrentDictionary<Type, Expression> _ctorCache =
+            new ConcurrentDictionary<Type, Expression>();
 
-        private readonly Func<Type, LateBoundCtor> _generateConstructor;
+        private readonly Func<Type, Expression> _generateConstructor;
 
         public DelegateFactory()
         {
@@ -112,21 +112,20 @@ namespace AutoMapper.Execution
 
             return lambda;
         }
-
-        public LateBoundCtor CreateCtor(Type type)
+        
+        public Expression CreateCtor(Type type)
         {
             var ctor = _ctorCache.GetOrAdd(type, _generateConstructor);
             return ctor;
         }
 
-        private static LateBoundCtor GenerateConstructor(Type type)
+        private static Expression GenerateConstructor(Type type)
         {
             //handle valuetypes
             if(!type.IsClass())
             {
-                var ctorExpression =
-                    Expression.Lambda<LateBoundCtor>(Expression.Convert(Expression.New(type), typeof(object)));
-                return ctorExpression.Compile();
+                var ctorExpression = Expression.Convert(Expression.New(type), typeof(object));
+                return ctorExpression;
             }
             else
             {
@@ -145,10 +144,8 @@ namespace AutoMapper.Execution
                     .Select(p => Expression.Constant(p.DefaultValue, p.ParameterType)).ToArray();
 
                 //create the ctor expression
-                var ctorExpression =
-                    Expression.Lambda<LateBoundCtor>(Expression.Convert(Expression.New(ctorWithOptionalArgs, args),
-                        typeof(object)));
-                return ctorExpression.Compile();
+                var ctorExpression = Expression.Convert(Expression.New(ctorWithOptionalArgs, args), typeof(object));
+                return ctorExpression;
             }
         }
 

--- a/src/AutoMapper/Mappers/ObjectCreator.cs
+++ b/src/AutoMapper/Mappers/ObjectCreator.cs
@@ -1,3 +1,5 @@
+using System.Linq.Expressions;
+
 namespace AutoMapper.Mappers
 {
     using System;
@@ -59,7 +61,8 @@ namespace AutoMapper.Mappers
                 ? CreateArray(type.GetElementType(), 0)
                 : type == typeof (string)
                     ? null
-                    : DelegateFactory.CreateCtor(type)();
+                    : Expression.Lambda<Func<object>>(DelegateFactory.CreateCtor(type)).Compile()();
+
         }
     }
 

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -639,8 +639,11 @@ namespace AutoMapper
                     throw new PlatformNotSupportedException("Mapping to interfaces through proxies not supported.");
                 };
 #else
-                var destinationType = new ProxyGenerator().GetProxyType(DestinationType);
-                return Expression.Lambda<Func<ResolutionContext, object>>(ObjectCreator.DelegateFactory.CreateCtor(destinationType), Expression.Parameter(typeof(ResolutionContext))).Compile();
+                return context =>
+                {
+                    var destinationType = new ProxyGenerator().GetProxyType(DestinationType);
+                    return Expression.Lambda<Func<object>>(ObjectCreator.DelegateFactory.CreateCtor(destinationType)).Compile()();
+                };
 #endif
             }
 

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -633,17 +633,13 @@ namespace AutoMapper
 
             if (DestinationType.IsInterface())
             {
-                var destinationType = DestinationType;
-                return context =>
-                {
 #if PORTABLE
-                    throw new PlatformNotSupportedException("Mapping to interfaces through proxies not supported.");
+                
+                return context => throw new PlatformNotSupportedException("Mapping to interfaces through proxies not supported.");
 #else
-                    destinationType = new ProxyGenerator().GetProxyType(destinationType);
-
-                    return Expression.Lambda<Func<ResolutionContext, object>>(ObjectCreator.DelegateFactory.CreateCtor(destinationType), Expression.Parameter(typeof(ResolutionContext))).Compile();
+                var destinationType = new ProxyGenerator().GetProxyType(DestinationType);
+                return Expression.Lambda<Func<ResolutionContext, object>>(ObjectCreator.DelegateFactory.CreateCtor(destinationType), Expression.Parameter(typeof(ResolutionContext))).Compile();
 #endif
-                };
             }
 
             if (DestinationType.IsAbstract())

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -634,8 +634,10 @@ namespace AutoMapper
             if (DestinationType.IsInterface())
             {
 #if PORTABLE
-                
-                return context => throw new PlatformNotSupportedException("Mapping to interfaces through proxies not supported.");
+                return context =>
+                {
+                    throw new PlatformNotSupportedException("Mapping to interfaces through proxies not supported.");
+                };
 #else
                 var destinationType = new ProxyGenerator().GetProxyType(DestinationType);
                 return Expression.Lambda<Func<ResolutionContext, object>>(ObjectCreator.DelegateFactory.CreateCtor(destinationType), Expression.Parameter(typeof(ResolutionContext))).Compile();

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -641,7 +641,7 @@ namespace AutoMapper
 #else
                     destinationType = new ProxyGenerator().GetProxyType(destinationType);
 
-                    return ObjectCreator.DelegateFactory.CreateCtor(destinationType)();
+                    return Expression.Lambda<Func<ResolutionContext, object>>(ObjectCreator.DelegateFactory.CreateCtor(destinationType), Expression.Parameter(typeof(ResolutionContext))).Compile();
 #endif
                 };
             }
@@ -652,9 +652,7 @@ namespace AutoMapper
             if (DestinationType.IsGenericTypeDefinition())
                 return _ => null;
 
-            var ctor = ObjectCreator.DelegateFactory.CreateCtor(DestinationType);
-
-            return context => ctor();
+            return Expression.Lambda<Func<ResolutionContext, object>>(ObjectCreator.DelegateFactory.CreateCtor(DestinationType), Expression.Parameter(typeof(ResolutionContext))).Compile();
         }
     }
 }

--- a/src/UnitTests/Internal/DelegateFactoryTests.cs
+++ b/src/UnitTests/Internal/DelegateFactoryTests.cs
@@ -123,30 +123,6 @@ namespace AutoMapper.UnitTests
 		}
 
         [Fact]
-		public void Test_with_create_ctor()
-		{
-			var sourceType = typeof(Source);
-
-			LateBoundCtor ctor = DelegateFactory.CreateCtor(sourceType);
-
-			var target = ctor();
-
-			target.ShouldBeType<Source>();
-		}
-
-		[Fact]
-		public void Test_with_value_object_create_ctor()
-		{
-			var sourceType = typeof(ValueSource);
-
-			LateBoundCtor ctor = DelegateFactory.CreateCtor(sourceType);
-
-			var target = ctor();
-
-			target.ShouldBeType<ValueSource>();
-		}
-
-        [Fact]
         public void Create_ctor_should_throw_when_default_constructor_is_missing()
         {
             var type = typeof(NoDefaultConstructor);


### PR DESCRIPTION
Generate Constructor expression instead of calling a function that calls another function that calls a lambda that creates object

This performance should be similar to compiling expressions for mapping vs making calls that make other calls inside other calls.