### PR TITLE
Flatten nested children using ProjectTo

### DIFF
--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -307,7 +307,7 @@
 
             private Expression ConvertCustomExpression(Expression node, PropertyMap propertyMap)
             {
-                var replaced = new ParameterReplacementVisitor(node);
+                var replaced = new ParameterConversionVisitor(node, propertyMap.CustomExpression.Parameters.FirstOrDefault());
                 var newBody = replaced.Visit(propertyMap.CustomExpression.Body);
                 return newBody;
             }

--- a/src/AutoMapper/QueryableExtensions/Impl/CustomProjectionExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/CustomProjectionExpressionBinder.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace AutoMapper.QueryableExtensions.Impl
 {
     using System.Collections.Concurrent;
@@ -17,7 +19,7 @@ namespace AutoMapper.QueryableExtensions.Impl
 
         private static MemberAssignment BindCustomProjectionExpression(PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionResolutionResult result)
         {
-            var visitor = new ParameterReplacementVisitor(result.ResolutionExpression);
+            var visitor = new ParameterConversionVisitor(result.ResolutionExpression, propertyTypeMap.CustomProjection.Parameters.FirstOrDefault());
 
             var replaced = visitor.Visit(propertyTypeMap.CustomProjection.Body);
 


### PR DESCRIPTION
Can't just go replace all parameters.  What about sublambdas.  You must tell it what it must replace.

ProjectTo parameter replacer replaces sub lambdas. as well as the base lambda.

Also since most are using lambdas to do parameter replacement visitor, the ReplaceParameters extension method https://github.com/AutoMapper/AutoMapper/pull/1211#discussion_r58068857 would be a good choice to use here as well.