### PR TITLE
[WIP] Remove PropertyMap Casting

### DIFF
--- a/src/AutoMapper/AutoMapperMappingException.cs
+++ b/src/AutoMapper/AutoMapperMappingException.cs
@@ -45,6 +45,14 @@ namespace AutoMapper
             Types = context.Types;
         }
 
+        public AutoMapperMappingException(ResolutionContext context, Exception inner, PropertyMap propertyMap)
+            : base(null, inner)
+        {
+            Context = context;
+            Types = context.Types;
+            PropertyMap = propertyMap;
+        }
+
         public AutoMapperMappingException(ResolutionContext context, string message)
             : this(context)
         {

--- a/src/AutoMapper/ConstructorMap.cs
+++ b/src/AutoMapper/ConstructorMap.cs
@@ -16,7 +16,7 @@ namespace AutoMapper
         private Func<ResolutionContext, object> _ctorFunc;
 
         public ConstructorInfo Ctor { get; }
-        public TypeMap TypeMap { get; private set; }
+        public TypeMap TypeMap { get; }
         internal IEnumerable<ConstructorParameterMap> CtorParams => _ctorParams;
 
         public ConstructorMap(ConstructorInfo ctor, TypeMap typeMap)
@@ -63,9 +63,10 @@ namespace AutoMapper
                 return;
 
             var srcParam = Expression.Parameter(typeof(object), "src");
+            var source = Expression.Convert(srcParam, TypeMap.SourceType);
             var ctxtParam = Expression.Parameter(typeof(ResolutionContext), "ctxt");
 
-            var ctorArgs = CtorParams.Select(p => p.BuildExpression(srcParam, ctxtParam, typeMapRegistry));
+            var ctorArgs = CtorParams.Select(p => p.CreateExpression(typeMapRegistry).ReplaceParameters(source, ctxtParam));
 
             ctorArgs =
                 ctorArgs.Zip(Ctor.GetParameters(),

--- a/src/AutoMapper/ConstructorParameterMap.cs
+++ b/src/AutoMapper/ConstructorParameterMap.cs
@@ -39,8 +39,7 @@ namespace AutoMapper
             if (CustomExpression != null)
             {
                 var newParam = Expression.Parameter(typeof(object), "m");
-                var expr = new ConvertingVisitor(CustomExpression.Parameters[0], newParam).Visit(CustomExpression.Body);
-                expr = new IfNotNullVisitor().Visit(expr);
+                var expr = new ConvertingVisitor(CustomExpression.Parameters[0], newParam).Visit(CustomExpression.Body).IfNotNull();
                 var lambda = Expression.Lambda<Func<object, object>>(Expression.Convert(expr, typeof(object)), newParam);
                 Func<object, object> mapFunc = lambda.Compile();
 
@@ -56,8 +55,7 @@ namespace AutoMapper
                     SourceMembers.Aggregate<IMemberGetter, LambdaExpression>(
                         (Expression<Func<ResolutionContext, object>>)
                             (ctxt => ctxt.SourceValue),
-                        (expression, resolver) =>
-                            (LambdaExpression)new ExpressionConcatVisitor(resolver.GetExpression).Visit(expression));
+                        (expression, resolver) => resolver.GetExpression.Concat(expression));
 
                 var outerResolver =
                     (Expression<Func<ResolutionContext, object>>)

--- a/src/AutoMapper/ConstructorParameterMap.cs
+++ b/src/AutoMapper/ConstructorParameterMap.cs
@@ -10,7 +10,7 @@ namespace AutoMapper
 
     public class ConstructorParameterMap
     {
-        private readonly ConstructorMap _ctorMap;
+        internal readonly ConstructorMap _ctorMap;
 
         public ConstructorParameterMap(ConstructorMap ctorMap, ParameterInfo parameter, IMemberGetter[] sourceMembers, bool canResolve)
         {
@@ -30,65 +30,6 @@ namespace AutoMapper
 
         public Type SourceType => CustomExpression?.ReturnType ?? SourceMembers.LastOrDefault()?.MemberType;
         public Type DestinationType => Parameter.ParameterType;
-
-        public Expression BuildExpression(ParameterExpression srcParam, ParameterExpression ctxtParam, TypeMapRegistry typeMapRegistry)
-        {
-            if (CustomExpression != null)
-                return CustomExpression.ConvertReplaceParameters(srcParam).IfNotNull();
-
-            if (CustomValueResolver != null)
-            {
-                return Expression.Invoke(Expression.Constant(CustomValueResolver), srcParam, ctxtParam);
-            }
-
-            if (!SourceMembers.Any() && Parameter.IsOptional)
-            {
-                return Expression.Constant(Parameter.DefaultValue);
-            }
-
-            if (typeMapRegistry.GetTypeMap(new TypePair(SourceType, DestinationType)) == null
-                 && Parameter.IsOptional)
-            {
-                return Expression.Constant(Parameter.DefaultValue);
-            }
-
-            var valueResolverExpr = SourceMembers.Aggregate(
-                (Expression)Expression.Convert(srcParam, _ctorMap.TypeMap.SourceType),
-                (inner, getter) => getter.MemberInfo is MethodInfo
-                    ? getter.MemberInfo.IsStatic()
-                        ? Expression.Call(null, (MethodInfo)getter.MemberInfo, inner)
-                        : (Expression)Expression.Call(inner, (MethodInfo)getter.MemberInfo)
-                    : Expression.MakeMemberAccess(getter.MemberInfo.IsStatic() ? null : inner, getter.MemberInfo)
-                );
-            valueResolverExpr = valueResolverExpr.IfNotNull();
-
-            if ((SourceType.IsEnumerableType() && SourceType != typeof (string))
-                || typeMapRegistry.GetTypeMap(new TypePair(SourceType, DestinationType)) != null
-                || ((!EnumMapper.EnumToEnumMapping(new TypePair(SourceType, DestinationType)) ||
-                     EnumMapper.EnumToNullableTypeMapping(new TypePair(SourceType, DestinationType))) &&
-                    EnumMapper.EnumToEnumMapping(new TypePair(SourceType, DestinationType)))
-                || !DestinationType.IsAssignableFrom(SourceType))
-            {
-                /*
-                var value = context.Mapper.Map(result, null, sourceType, destinationType, context);
-                 */
-
-                var mapperProp = Expression.MakeMemberAccess(ctxtParam, typeof (ResolutionContext).GetProperty("Mapper"));
-                var mapMethod = typeof (IRuntimeMapper).GetMethod("Map",
-                    new[] {typeof (object), typeof (object), typeof (Type), typeof (Type), typeof (ResolutionContext)});
-                valueResolverExpr = Expression.Call(
-                    mapperProp,
-                    mapMethod,
-                    valueResolverExpr.ToObject(),
-                    Expression.Constant(null),
-                    Expression.Constant(SourceType),
-                    Expression.Constant(DestinationType),
-                    ctxtParam
-                    );
-            }
-
-
-            return valueResolverExpr;
-        }
+        
     }
 }

--- a/src/AutoMapper/ConstructorParameterMap.cs
+++ b/src/AutoMapper/ConstructorParameterMap.cs
@@ -34,12 +34,7 @@ namespace AutoMapper
         public Expression BuildExpression(ParameterExpression srcParam, ParameterExpression ctxtParam, TypeMapRegistry typeMapRegistry)
         {
             if (CustomExpression != null)
-            {
-                var expr = new ConvertingVisitor(CustomExpression.Parameters[0], srcParam).Visit(CustomExpression.Body);
-                expr = new IfNotNullVisitor().Visit(expr);
-
-                return expr;
-            }
+                return CustomExpression.ConvertReplaceParameters(srcParam).IfNotNull();
 
             if (CustomValueResolver != null)
             {
@@ -65,7 +60,7 @@ namespace AutoMapper
                         : (Expression)Expression.Call(inner, (MethodInfo)getter.MemberInfo)
                     : Expression.MakeMemberAccess(getter.MemberInfo.IsStatic() ? null : inner, getter.MemberInfo)
                 );
-            valueResolverExpr = new IfNotNullVisitor().Visit(valueResolverExpr);
+            valueResolverExpr = valueResolverExpr.IfNotNull();
 
             if ((SourceType.IsEnumerableType() && SourceType != typeof (string))
                 || typeMapRegistry.GetTypeMap(new TypePair(SourceType, DestinationType)) != null

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -243,7 +243,7 @@ namespace AutoMapper
 
             if (typeMap != null)
                 if (typeMap.DestinationCtor != null)
-                    return typeMap.DestinationCtor(context);
+                    return typeMap.DestinationCtor.Compile()(context);
                 else if (typeMap.ConstructDestinationUsingServiceLocator)
                     return context.Options.ServiceCtor(destinationType);
                 else if (typeMap.ConstructorMap?.CanResolve == true)

--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -243,7 +243,7 @@
                     replacedExpression = _parentMappingVisitor.Visit(node.Expression);
 
                 if (propertyMap.CustomExpression != null)
-                    return ConvertCustomExpression(replacedExpression, propertyMap);
+                    return propertyMap.CustomExpression.ReplaceParameters(replacedExpression);
 
                 Func<Expression,IMemberGetter,Expression> getExpression = (current, memberGetter) => Expression.MakeMemberAccess(current, memberGetter.MemberInfo);
 
@@ -292,13 +292,6 @@
                     _destSubTypes = (propertyMap.SourceMember as PropertyInfo).PropertyType.GetTypeInfo().GenericTypeArguments.Concat(new []{ (propertyMap.SourceMember as PropertyInfo).PropertyType }).ToList();
                 else if (propertyMap.SourceMember is FieldInfo)
                     _destSubTypes = (propertyMap.SourceMember as FieldInfo).FieldType.GetTypeInfo().GenericTypeArguments;
-            }
-
-            private Expression ConvertCustomExpression(Expression node, PropertyMap propertyMap)
-            {
-                var replaced = new ParameterConversionVisitor(node, propertyMap.CustomExpression.Parameters.FirstOrDefault());
-                var newBody = replaced.Visit(propertyMap.CustomExpression.Body);
-                return newBody;
             }
         }
     }

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -598,7 +598,7 @@ namespace AutoMapper
             }
             else if (propertyMap._customResolverFunc != null)
             {
-                valueResolverFunc = Convert(Invoke(Constant(propertyMap._customResolverFunc), srcParam, ctxtParam), propertyMap.DestinationPropertyType);
+                valueResolverFunc = TryCatch(Convert(Invoke(Constant(propertyMap._customResolverFunc), srcParam, ctxtParam), propertyMap.DestinationPropertyType), Catch(typeof(Exception), Default(propertyMap.DestinationPropertyType)));
             }
             else if (propertyMap.CustomExpression != null)
             {

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -510,16 +510,6 @@ namespace AutoMapper
             Expression mapperExpr;
             if (propertyMap.DestinationProperty.MemberInfo is FieldInfo)
             {
-                //if (propertyMap.DestinationProperty.MemberInfo.DeclaringType.IsValueType())
-                //{
-                //    var field = (FieldInfo)propertyMap.DestinationProperty.MemberInfo;
-                //    mapperExpr = Call(
-                //        Constant(field),
-                //        typeof(FieldInfo).GetMethod("SetValue", new[] { typeof(object), typeof(object) }),
-                //        destParam.ToObject(),
-                //        valueResolverExpr.ToObject());
-                //}
-                //else
                 {
                     if (propertyMap.SourceType != propertyMap.DestinationPropertyType)
                         mapperExpr = Assign(destMember, Convert(valueResolverExpr, propertyMap.DestinationPropertyType));
@@ -534,14 +524,6 @@ namespace AutoMapper
                 {
                     mapperExpr = valueResolverExpr;
                 }
-                //else if (propertyMap.DestinationProperty.MemberInfo.DeclaringType.IsValueType())
-                //{
-                //    mapperExpr = Call(
-                //        Constant(setter),
-                //        typeof(MethodInfo).GetMethod("Invoke", new[] { typeof(object), typeof(object[]) }),
-                //        destParam.ToObject(),
-                //        NewArrayInit(typeof(object), valueResolverExpr.ToObject()));
-                //}
                 else
                 {
                     if (propertyMap.SourceType != propertyMap.DestinationPropertyType)

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -510,16 +510,16 @@ namespace AutoMapper
             Expression mapperExpr;
             if (propertyMap.DestinationProperty.MemberInfo is FieldInfo)
             {
-                if (propertyMap.DestinationProperty.MemberInfo.DeclaringType.IsValueType())
-                {
-                    var field = (FieldInfo)propertyMap.DestinationProperty.MemberInfo;
-                    mapperExpr = Call(
-                        Constant(field),
-                        typeof(FieldInfo).GetMethod("SetValue", new[] { typeof(object), typeof(object) }),
-                        destParam.ToObject(),
-                        valueResolverExpr.ToObject());
-                }
-                else
+                //if (propertyMap.DestinationProperty.MemberInfo.DeclaringType.IsValueType())
+                //{
+                //    var field = (FieldInfo)propertyMap.DestinationProperty.MemberInfo;
+                //    mapperExpr = Call(
+                //        Constant(field),
+                //        typeof(FieldInfo).GetMethod("SetValue", new[] { typeof(object), typeof(object) }),
+                //        destParam.ToObject(),
+                //        valueResolverExpr.ToObject());
+                //}
+                //else
                 {
                     if (propertyMap.SourceType != propertyMap.DestinationPropertyType)
                         mapperExpr = Assign(destMember, Convert(valueResolverExpr, propertyMap.DestinationPropertyType));
@@ -534,14 +534,14 @@ namespace AutoMapper
                 {
                     mapperExpr = valueResolverExpr;
                 }
-                else if (propertyMap.DestinationProperty.MemberInfo.DeclaringType.IsValueType())
-                {
-                    mapperExpr = Call(
-                        Constant(setter),
-                        typeof(MethodInfo).GetMethod("Invoke", new[] { typeof(object), typeof(object[]) }),
-                        destParam.ToObject(),
-                        NewArrayInit(typeof(object), valueResolverExpr.ToObject()));
-                }
+                //else if (propertyMap.DestinationProperty.MemberInfo.DeclaringType.IsValueType())
+                //{
+                //    mapperExpr = Call(
+                //        Constant(setter),
+                //        typeof(MethodInfo).GetMethod("Invoke", new[] { typeof(object), typeof(object[]) }),
+                //        destParam.ToObject(),
+                //        NewArrayInit(typeof(object), valueResolverExpr.ToObject()));
+                //}
                 else
                 {
                     if (propertyMap.SourceType != propertyMap.DestinationPropertyType)

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -600,7 +600,7 @@ namespace AutoMapper
                     sourceFunc = srcParam;
                 }
                 
-                valueResolverFunc = Convert(Call(ctor, typeof(IValueResolver).GetMethod("Resolve"), sourceFunc, ctxtParam), propertyMap.DestinationPropertyType);
+                valueResolverFunc = Convert(Call(ctor, typeof(IValueResolver).GetMethod("Resolve"), sourceFunc.ToObject(), ctxtParam), propertyMap.DestinationPropertyType);
             }
             else if (propertyMap.CustomValue != null)
             {

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -430,7 +430,7 @@ namespace AutoMapper
         public static Expression IfNullElse(this Expression expression, params Expression[] ifElse)
         {
             return ifElse.Any()
-                ? IfThenElse(NotEqual(expression, Constant(null)), expression, ifElse.First().IfNullElse(ifElse.Skip(1).ToArray()))
+                ? Condition(NotEqual(expression, Constant(null)), expression, ifElse.First().IfNullElse(ifElse.Skip(1).ToArray()))
                 : expression;
         }
 

--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -87,12 +87,10 @@ namespace AutoMapper.QueryableExtensions
             {
                 throw QueryMapperHelper.MissingMapException(request.SourceType, request.DestinationType);
             }
-
-            var customProjection = typeMap.CustomProjection;
-            if (customProjection != null)
+            
+            if (typeMap.CustomProjection != null)
             {
-                var parameterReplacer = instanceParameter is ParameterExpression ? new ParameterConversionVisitor(instanceParameter, customProjection.Parameters.FirstOrDefault()) : null;
-                return parameterReplacer == null ? customProjection.Body : parameterReplacer.Visit(customProjection.Body);
+                return typeMap.CustomProjection.ReplaceParameters(instanceParameter);
             }
 
             var bindings = new List<MemberBinding>();
@@ -109,11 +107,8 @@ namespace AutoMapper.QueryableExtensions
                 bindings = CreateMemberBindings(request, typeMap, instanceParameter, typePairCount);
             }
             Expression constructorExpression = typeMap.DestinationConstructorExpression(instanceParameter);
-            var ctorParamReplacer = instanceParameter is ParameterExpression ? new ParameterConversionVisitor(instanceParameter, ((LambdaExpression)constructorExpression).Parameters.FirstOrDefault()) : null;
-            if (ctorParamReplacer != null)
-            {
-                constructorExpression = ctorParamReplacer.Visit(constructorExpression);
-            }
+            if (instanceParameter is ParameterExpression)
+                constructorExpression = ((LambdaExpression) constructorExpression).ReplaceParameters(instanceParameter);
             var visitor = new NewFinderVisitor();
             visitor.Visit(constructorExpression);
 

--- a/src/AutoMapper/QueryableExtensions/Impl/CustomProjectionExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/CustomProjectionExpressionBinder.cs
@@ -19,11 +19,7 @@ namespace AutoMapper.QueryableExtensions.Impl
 
         private static MemberAssignment BindCustomProjectionExpression(PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionResolutionResult result)
         {
-            var visitor = new ParameterConversionVisitor(result.ResolutionExpression, propertyTypeMap.CustomProjection.Parameters.FirstOrDefault());
-
-            var replaced = visitor.Visit(propertyTypeMap.CustomProjection.Body);
-
-            return Expression.Bind(propertyMap.DestinationProperty.MemberInfo, replaced);
+            return Expression.Bind(propertyMap.DestinationProperty.MemberInfo, propertyTypeMap.CustomProjection.ReplaceParameters(result.ResolutionExpression));
         }
     }
 }

--- a/src/AutoMapper/QueryableExtensions/Impl/MemberResolverExpressionResultConverter.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/MemberResolverExpressionResultConverter.cs
@@ -16,11 +16,7 @@ namespace AutoMapper.QueryableExtensions.Impl
         private static ExpressionResolutionResult ExpressionResolutionResult(
             ExpressionResolutionResult expressionResolutionResult, LambdaExpression lambdaExpression)
         {
-            var oldParameter = lambdaExpression.Parameters.Single();
-            var newParameter = expressionResolutionResult.ResolutionExpression;
-            var converter = new ParameterConversionVisitor(newParameter, oldParameter);
-
-            Expression currentChild = converter.Visit(lambdaExpression.Body);
+            Expression currentChild = lambdaExpression.ReplaceParameters(expressionResolutionResult.ResolutionExpression);
             Type currentChildType = currentChild.Type;
 
             return new ExpressionResolutionResult(currentChild, currentChildType);

--- a/src/AutoMapper/ResolutionContext.cs
+++ b/src/AutoMapper/ResolutionContext.cs
@@ -192,7 +192,7 @@ namespace AutoMapper
             yield return context;
         }
 
-        internal void BeforeMap(object destination)
+        public void BeforeMap(object destination)
         {
             if(Parent == null)
             {
@@ -200,7 +200,7 @@ namespace AutoMapper
             }
         }
 
-        internal void AfterMap(object destination)
+        public void AfterMap(object destination)
         {
             if(Parent == null)
             {

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -554,7 +554,7 @@ namespace AutoMapper
             var autoMapException = Parameter(typeof (AutoMapperMappingException), "ex");
             var exception = Parameter(typeof(Exception), "ex");
 
-            var mappingExceptionCtor = typeof(AutoMapperMappingException).GetConstructor(new [] { typeof(ResolutionContext), typeof(Exception), typeof(PropertyMap)});
+            var mappingExceptionCtor = typeof(AutoMapperMappingException).GetTypeInfo().DeclaredConstructors.First(ci => ci.GetParameters().Count() == 3);
 
             return TryCatch(Block(typeof(void), pm._mapperExpr.ReplaceParameters(replaceExpressions)),
                 MakeCatchBlock(typeof (AutoMapperMappingException), autoMapException, Block(Assign(Property(autoMapException, "PropertyMap"), Constant(pm)),Rethrow()), null),
@@ -599,7 +599,7 @@ namespace AutoMapper
             if (DestinationType.IsInterface())
             {
 #if PORTABLE
-                Expression.Lambda<Func<ResolutionContext, object>>(Expression.Throw(Expression.Constant(new PlatformNotSupportedException("Mapping to interfaces through proxies not supported."))), ctxtParam);
+                Lambda<Func<ResolutionContext, object>>(Block(typeof(object), Throw(Constant(new PlatformNotSupportedException("Mapping to interfaces through proxies not supported."))), Constant(null)), ctxtParam);
 #else
                 var ctor = Call(Constant(ObjectCreator.DelegateFactory), typeof(DelegateFactory).GetMethod("CreateCtor", new[] { typeof(Type) }), Call(New(typeof(ProxyGenerator)), typeof(ProxyGenerator).GetMethod("GetProxyType"), Constant(DestinationType)));
                 return Lambda<Func<ResolutionContext, object>>(Invoke(ctor), ctxtParam);

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -589,7 +589,7 @@ namespace AutoMapper
                 return Lambda<Func<ResolutionContext, object>>(Invoke(Property(Property(ctxtParam, "Options"), "ServiceCtor"), Constant(DestinationType)), ctxtParam);
 
             if (ConstructorMap?.CanResolve == true)
-                return Lambda<Func<ResolutionContext, object>>(Invoke(Call(Constant(ConstructorMap), typeof(ConstructorMap).GetMethod("ResolveValue"), ctxtParam)), ctxtParam);
+                return Lambda<Func<ResolutionContext, object>>(Call(Constant(ConstructorMap), typeof(ConstructorMap).GetMethod("ResolveValue"), ctxtParam), ctxtParam);
 
             if (DestinationType.IsInterface())
             {


### PR DESCRIPTION
Moves the Expression creation to another class, and then replaces parameters at the PropertyMap level.
Made some extension methods as well to help things be more readable.

Property map will convert parameters to Source and Destination type, but the expression generated will assume the types are already set correctly.  What's good about this that you can convert the same expression over for the TypeMap.  You can just replace the parameters with variables you set when generating the TypeMap expression, and not have to re-write the PropertyMap Expression generating code.

Only real problems having right now are with struct's, so what probably needs to be done is convert the expressions to use ref if ValueType, so can pass object over to be set correctly, or something like that.