### PR TITLE
Finish IObjectMapExpression conversions

### DIFF
--- a/src/AutoMapper/ConstructorParameterMap.cs
+++ b/src/AutoMapper/ConstructorParameterMap.cs
@@ -66,9 +66,6 @@ namespace AutoMapper
 
             if ((SourceType.IsEnumerableType() && SourceType != typeof (string))
                 || typeMapRegistry.GetTypeMap(new TypePair(SourceType, DestinationType)) != null
-                || ((!EnumMapper.EnumToEnumMapping(new TypePair(SourceType, DestinationType)) ||
-                     EnumMapper.EnumToNullableTypeMapping(new TypePair(SourceType, DestinationType))) &&
-                    EnumMapper.EnumToEnumMapping(new TypePair(SourceType, DestinationType)))
                 || !DestinationType.IsAssignableFrom(SourceType))
             {
                 /*

--- a/src/AutoMapper/Mappers/ArrayMapper.cs
+++ b/src/AutoMapper/Mappers/ArrayMapper.cs
@@ -9,7 +9,7 @@ namespace AutoMapper.Mappers
     using System.Reflection;
     using Configuration;
 
-    public class ArrayMapper : IObjectMapper, IObjectMapExpression
+    public class ArrayMapper : IObjectMapExpression
     {
         public static TDestination Map<TDestination,TSource, TSourceElement>(TSource source, ResolutionContext context)
             where TSource : IEnumerable

--- a/src/AutoMapper/Mappers/AssignableMapper.cs
+++ b/src/AutoMapper/Mappers/AssignableMapper.cs
@@ -2,9 +2,7 @@ using System.Linq.Expressions;
 
 namespace AutoMapper.Mappers
 {
-    using System.Reflection;
-
-    public class AssignableMapper : IObjectMapper, IObjectMapExpression
+    public class AssignableMapper : IObjectMapExpression
     {
         public object Map(ResolutionContext context)
         {

--- a/src/AutoMapper/Mappers/CollectionMapper.cs
+++ b/src/AutoMapper/Mappers/CollectionMapper.cs
@@ -1,16 +1,14 @@
 using System.Collections;
-using System.Collections.ObjectModel;
 using System.Linq;
 using System.Linq.Expressions;
 
 namespace AutoMapper.Mappers
 {
-    using System;
     using System.Collections.Generic;
     using System.Reflection;
     using Configuration;
 
-    public class CollectionMapper : IObjectMapper, IObjectMapExpression
+    public class CollectionMapper :  IObjectMapExpression
     {
         public static TDestination Map<TSource, TSourceItem, TDestination, TDestinationItem>(TSource source, TDestination destination, ResolutionContext context)
             where TSource : IEnumerable

--- a/src/AutoMapper/Mappers/ConvertMapper.cs
+++ b/src/AutoMapper/Mappers/ConvertMapper.cs
@@ -7,7 +7,7 @@ namespace AutoMapper.Mappers
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
 
-    public class ConvertMapper : IObjectMapper, IObjectMapExpression
+    public class ConvertMapper : IObjectMapExpression
     {
         private readonly IReadOnlyDictionary<TypePair, LambdaExpression> _converters = new ReadOnlyDictionary<TypePair, LambdaExpression>(new Dictionary<TypePair, LambdaExpression>
         {

--- a/src/AutoMapper/Mappers/DictionaryMapper.cs
+++ b/src/AutoMapper/Mappers/DictionaryMapper.cs
@@ -7,11 +7,8 @@ namespace AutoMapper.Mappers
     using System.Linq;
     using System.Reflection;
     using Configuration;
-
-    // So IEnumerable<T> inherits IEnumerable
-    // but IDictionary<TKey, TValue> DOES NOT inherit IDictionary
-    // Fiddlesticks.
-    public class DictionaryMapper : IObjectMapper, IObjectMapExpression
+    
+    public class DictionaryMapper : IObjectMapExpression
     {
         public static TDestination Map<TSource, TSourceKey, TSourceValue, TDestination, TDestinationKey, TDestinationValue>(TSource source, TDestination destination, ResolutionContext context)
             where TSource : IDictionary<TSourceKey, TSourceValue>

--- a/src/AutoMapper/Mappers/DynamicMappers.cs
+++ b/src/AutoMapper/Mappers/DynamicMappers.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.CSharp.RuntimeBinder;
@@ -9,39 +11,34 @@ using Binder = Microsoft.CSharp.RuntimeBinder.Binder;
 namespace AutoMapper.Mappers
 {
     using Execution;
-
-    public abstract class DynamicMapper : IObjectMapper
+    
+    public class FromDynamicMapper : IObjectMapper, IObjectMapExpression
     {
-        public abstract bool IsMatch(TypePair context);
-
-        public object Map(ResolutionContext context)
+        public static TDestination Map<TSource, TDestination>(TSource source, TDestination destination, ResolutionContext context)
+            where TSource : DynamicObject
         {
-            var source = context.SourceValue;
-            var destination = context.Mapper.CreateObject(context);
-            foreach(var member in MembersToMap(source, destination))
+            if (destination == null)
+                destination = (TDestination) (!context.ConfigurationProvider.AllowNullDestinationValues
+                    ? ObjectCreator.CreateNonNullValue(typeof (TDestination))
+                    : ObjectCreator.CreateObject(typeof (TDestination)));
+            foreach (var member in new TypeDetails(typeof(TDestination)).PublicWriteAccessors)
             {
                 object sourceMemberValue;
                 try
                 {
-                    sourceMemberValue = GetSourceMember(member, source);
+                    sourceMemberValue = GetDynamically(member, source);
                 }
-                catch(RuntimeBinderException)
+                catch (RuntimeBinderException)
                 {
                     continue;
                 }
                 var destinationMemberValue = ReflectionHelper.Map(context, member, sourceMemberValue);
-                SetDestinationMember(member, destination, destinationMemberValue);
+                member.SetMemberValue(destination, destinationMemberValue);
             }
             return destination;
         }
 
-        protected abstract IEnumerable<MemberInfo> MembersToMap(object source, object destination);
-
-        protected abstract object GetSourceMember(MemberInfo member, object target);
-
-        protected abstract void SetDestinationMember(MemberInfo member, object target, object value);
-
-        protected object GetDynamically(MemberInfo member, object target)
+        private static object GetDynamically(MemberInfo member, object target)
         {
             var binder = Binder.GetMember(CSharpBinderFlags.None, member.Name, member.GetMemberType(),
                                                             new[] { CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null) });
@@ -49,61 +46,76 @@ namespace AutoMapper.Mappers
             return callsite.Target(callsite, target);
         }
 
-        protected void SetDynamically(MemberInfo member, object target, object value)
-        {
-            var binder = Binder.SetMember(CSharpBinderFlags.None, member.Name, member.GetMemberType(),
-                                                            new[]{
-                                                                    CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
-                                                                    CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
-                                                            });
-            var callsite = CallSite<Func<CallSite, object, object, object>>.Create(binder);
-            callsite.Target(callsite, target, value);
-        }
-    }
+        private static readonly MethodInfo MapMethodInfo = typeof(FromDynamicMapper).GetAllMethods().First(_ => _.IsStatic);
 
-    public class FromDynamicMapper : DynamicMapper
-    {
-        public override bool IsMatch(TypePair context)
+        public object Map(ResolutionContext context)
+        {
+            return MapMethodInfo.MakeGenericMethod(context.SourceType, context.DestinationType).Invoke(null, new[] { context.SourceValue, context.DestinationValue, context });
+        }
+
+        public bool IsMatch(TypePair context)
         {
             return context.SourceType.IsDynamic() && !context.DestinationType.IsDynamic();
         }
 
-        protected override IEnumerable<MemberInfo> MembersToMap(object source, object destination)
+        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
-            return new TypeDetails(destination.GetType()).PublicWriteAccessors;
-        }
-
-        protected override object GetSourceMember(MemberInfo member, object target)
-        {
-            return GetDynamically(member, target);
-        }
-
-        protected override void SetDestinationMember(MemberInfo member, object target, object value)
-        {
-            member.SetMemberValue(target, value);
+            return Expression.Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression, destExpression, contextExpression);
         }
     }
 
-    public class ToDynamicMapper : DynamicMapper
+    public class ToDynamicMapper : IObjectMapper, IObjectMapExpression
     {
-        public override bool IsMatch(TypePair context)
+        public static TDestination Map<TSource, TDestination>(TSource source, TDestination destination, ResolutionContext context)
+            where TDestination : DynamicObject
+        {
+            if (destination == null)
+                destination = (TDestination)(!context.ConfigurationProvider.AllowNullDestinationValues
+                    ? ObjectCreator.CreateNonNullValue(typeof(TDestination))
+                    : ObjectCreator.CreateObject(typeof(TDestination)));
+            foreach (var member in new TypeDetails(typeof(TSource)).PublicWriteAccessors)
+            {
+                object sourceMemberValue;
+                try
+                {
+                    sourceMemberValue = member.GetMemberValue(source);
+                }
+                catch (RuntimeBinderException)
+                {
+                    continue;
+                }
+                var destinationMemberValue = ReflectionHelper.Map(context, member, sourceMemberValue);
+                SetDynamically(member, destination, destinationMemberValue);
+            }
+            return destination;
+        }
+
+        private static void SetDynamically(MemberInfo member, object target, object value)
+        {
+            var binder = Binder.SetMember(CSharpBinderFlags.None, member.Name, member.GetMemberType(),
+                new[]{
+                    CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null),
+                    CSharpArgumentInfo.Create(CSharpArgumentInfoFlags.None, null)
+                });
+            var callsite = CallSite<Func<CallSite, object, object, object>>.Create(binder);
+            callsite.Target(callsite, target, value);
+        }
+
+        private static readonly MethodInfo MapMethodInfo = typeof(ToDynamicMapper).GetAllMethods().First(_ => _.IsStatic);
+
+        public object Map(ResolutionContext context)
+        {
+            return MapMethodInfo.MakeGenericMethod(context.SourceType, context.DestinationType).Invoke(null, new[] { context.SourceValue, context.DestinationValue, context });
+        }
+
+        public bool IsMatch(TypePair context)
         {
             return context.DestinationType.IsDynamic() && !context.SourceType.IsDynamic();
         }
 
-        protected override IEnumerable<MemberInfo> MembersToMap(object source, object destination)
+        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
-            return new TypeDetails(source.GetType()).PublicReadAccessors;
-        }
-
-        protected override object GetSourceMember(MemberInfo member, object target)
-        {
-            return member.GetMemberValue(target);
-        }
-
-        protected override void SetDestinationMember(MemberInfo member, object target, object value)
-        {
-            SetDynamically(member, target, value);
+            return Expression.Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression, destExpression, contextExpression);
         }
     }
 }

--- a/src/AutoMapper/Mappers/DynamicMappers.cs
+++ b/src/AutoMapper/Mappers/DynamicMappers.cs
@@ -12,7 +12,7 @@ namespace AutoMapper.Mappers
 {
     using Execution;
     
-    public class FromDynamicMapper : IObjectMapper, IObjectMapExpression
+    public class FromDynamicMapper : IObjectMapExpression
     {
         public static TDestination Map<TSource, TDestination>(TSource source, TDestination destination, ResolutionContext context)
             where TSource : DynamicObject
@@ -64,7 +64,7 @@ namespace AutoMapper.Mappers
         }
     }
 
-    public class ToDynamicMapper : IObjectMapper, IObjectMapExpression
+    public class ToDynamicMapper : IObjectMapExpression
     {
         public static TDestination Map<TSource, TDestination>(TSource source, TDestination destination, ResolutionContext context)
             where TDestination : DynamicObject

--- a/src/AutoMapper/Mappers/EnumMapper.cs
+++ b/src/AutoMapper/Mappers/EnumMapper.cs
@@ -1,42 +1,14 @@
 using System.ComponentModel;
 using System.Linq.Expressions;
 using static System.Linq.Expressions.Expression;
-using static AutoMapper.ExpressionExtensions;
 
 namespace AutoMapper.Mappers
 {
     using System;
     using System.Reflection;
     using System.Linq;
-    using Configuration;
-
-    //public class EnumToStringMapper : IObjectMapper, IObjectMapExpression
-    //{
-    //    public static string Map<TSource>(TSource source, ResolutionContext context)
-    //    {
-    //        return source.ToString();
-    //    }
-
-    //    private static readonly MethodInfo MapMethodInfo = typeof(EnumToStringMapper).GetAllMethods().First(_ => _.IsStatic);
-
-    //    public object Map(ResolutionContext context)
-    //    {
-    //        return MapMethodInfo.MakeGenericMethod(context.SourceType).Invoke(null, new[] { context.SourceValue, context });
-    //    }
-
-    //    public bool IsMatch(TypePair context)
-    //    {
-    //        var sourceEnumType = TypeHelper.GetEnumerationType(context.SourceType);
-    //        return sourceEnumType != null && context.DestinationType == typeof (string);
-    //    }
-
-    //    public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
-    //    {
-    //        return Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type), sourceExpression, contextExpression);
-    //    }
-    //}
-
-    public class StringToEnumMapper : IObjectMapper
+    
+    public class StringToEnumMapper : IObjectMapExpression
     {
         public static TDestination Map<TDestination>(string source)
         {
@@ -64,7 +36,7 @@ namespace AutoMapper.Mappers
         }
     }
 
-    public class EnumToEnumMapper : IObjectMapper
+    public class EnumToEnumMapper : IObjectMapExpression
     {
         public static TDestination Map<TSource, TDestination>(TSource source)
         {
@@ -110,7 +82,7 @@ namespace AutoMapper.Mappers
         }
     }
 
-    public class EnumToUnderlyingTypeMapper : IObjectMapper
+    public class EnumToUnderlyingTypeMapper : IObjectMapExpression
     {
         public static TDestination Map<TSource, TDestination>(TSource source)
         {

--- a/src/AutoMapper/Mappers/EnumerableMapper.cs
+++ b/src/AutoMapper/Mappers/EnumerableMapper.cs
@@ -9,7 +9,7 @@ namespace AutoMapper.Mappers
     using System.Reflection;
     using Configuration;
 
-    public class EnumerableMapper : IObjectMapper, IObjectMapExpression
+    public class EnumerableMapper : IObjectMapExpression
     {
         public static TDestination Map<TSource, TDestination, TDestinationElement>(TSource source, TDestination destination, ResolutionContext context)
             where TSource : class, IEnumerable

--- a/src/AutoMapper/Mappers/EnumerableToDictionaryMapper.cs
+++ b/src/AutoMapper/Mappers/EnumerableToDictionaryMapper.cs
@@ -9,7 +9,7 @@ namespace AutoMapper.Mappers
     using System.Reflection;
     using Configuration;
 
-    public class EnumerableToDictionaryMapper : IObjectMapper, IObjectMapExpression
+    public class EnumerableToDictionaryMapper : IObjectMapExpression
     {
         public static TDestination Map<TSource, TSourceElement, TDestination, TDestinationKey, TDestinationValue>(TSource source, TDestination destination, ResolutionContext context)
            where TSource : IEnumerable<TSourceElement>

--- a/src/AutoMapper/Mappers/ExplicitConversionOperatorMapper.cs
+++ b/src/AutoMapper/Mappers/ExplicitConversionOperatorMapper.cs
@@ -5,7 +5,7 @@ namespace AutoMapper.Mappers
     using System.Linq;
     using System.Reflection;
 
-    public class ExplicitConversionOperatorMapper : IObjectMapper, IObjectMapExpression
+    public class ExplicitConversionOperatorMapper : IObjectMapExpression
     {
         public object Map(ResolutionContext context)
         {

--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -11,7 +11,7 @@ namespace AutoMapper.Mappers
     using Configuration;
     using Execution;
 
-    public class ExpressionMapper : IObjectMapper, IObjectMapExpression
+    public class ExpressionMapper : IObjectMapExpression
     {
         public static TDestination Map<TSource, TDestination>(TSource expression, ResolutionContext context)
             where TSource : LambdaExpression

--- a/src/AutoMapper/Mappers/FlagsEnumMapper.cs
+++ b/src/AutoMapper/Mappers/FlagsEnumMapper.cs
@@ -6,7 +6,7 @@ namespace AutoMapper.Mappers
     using System;
     using System.Linq;
 
-    public class FlagsEnumMapper : IObjectMapper, IObjectMapExpression
+    public class FlagsEnumMapper : IObjectMapExpression
     {
         public static TDestination Map<TSource, TDestination>(TSource source, ResolutionContext context)
             where TDestination : struct

--- a/src/AutoMapper/Mappers/HashSetMapper.cs
+++ b/src/AutoMapper/Mappers/HashSetMapper.cs
@@ -8,7 +8,7 @@ namespace AutoMapper.Mappers
     using System.Linq;
     using Configuration;
 
-    public class HashSetMapper : IObjectMapper, IObjectMapExpression
+    public class HashSetMapper : IObjectMapExpression
     {
         public static ISet<TDestination> Map<TSource, TDestination>(IEnumerable<TSource> source, ISet<TDestination> destination, ResolutionContext context)
         {

--- a/src/AutoMapper/Mappers/ImplicitConversionOperatorMapper.cs
+++ b/src/AutoMapper/Mappers/ImplicitConversionOperatorMapper.cs
@@ -6,7 +6,7 @@ namespace AutoMapper.Mappers
     using System.Reflection;
     using Configuration;
 
-    public class ImplicitConversionOperatorMapper : IObjectMapper, IObjectMapExpression
+    public class ImplicitConversionOperatorMapper : IObjectMapExpression
     {
         public object Map(ResolutionContext context)
         {

--- a/src/AutoMapper/Mappers/MapperRegistry.cs
+++ b/src/AutoMapper/Mappers/MapperRegistry.cs
@@ -8,7 +8,9 @@ namespace AutoMapper.Mappers
         {
             new ExpressionMapper(), 
             new FlagsEnumMapper(),
-            new EnumMapper(),
+            new StringToEnumMapper(), 
+            new EnumToEnumMapper(), 
+            new EnumToUnderlyingTypeMapper(),
             new MultidimensionalArrayMapper(),
             new PrimitiveArrayMapper(),
             new ArrayMapper(),

--- a/src/AutoMapper/Mappers/MultidimensionalArrayMapper.cs
+++ b/src/AutoMapper/Mappers/MultidimensionalArrayMapper.cs
@@ -9,7 +9,7 @@ namespace AutoMapper.Mappers
     using System.Linq;
     using Configuration;
 
-    public class MultidimensionalArrayMapper : IObjectMapper, IObjectMapExpression
+    public class MultidimensionalArrayMapper : IObjectMapExpression
     {
         static MultidimensionalArrayFiller filler;
 

--- a/src/AutoMapper/Mappers/NameValueCollectionMapper.cs
+++ b/src/AutoMapper/Mappers/NameValueCollectionMapper.cs
@@ -8,7 +8,7 @@ namespace AutoMapper.Mappers
 {
     using System.Collections.Specialized;
 
-    public class NameValueCollectionMapper : IObjectMapper, IObjectMapExpression
+    public class NameValueCollectionMapper : IObjectMapExpression
     {
         public static NameValueCollection Map(NameValueCollection source)
         {

--- a/src/AutoMapper/Mappers/NullableMapper.cs
+++ b/src/AutoMapper/Mappers/NullableMapper.cs
@@ -4,7 +4,7 @@ namespace AutoMapper.Mappers
 {
     using Configuration;
 
-    public class NullableMapper : IObjectMapper, IObjectMapExpression
+    public class NullableMapper : IObjectMapExpression
     {
         public object Map(ResolutionContext context)
         {

--- a/src/AutoMapper/Mappers/NullableSourceMapper.cs
+++ b/src/AutoMapper/Mappers/NullableSourceMapper.cs
@@ -6,30 +6,29 @@ namespace AutoMapper.Mappers
 {
     using Configuration;
 
-    public class NullableSourceMapper : IObjectMapper
+    public class NullableSourceMapper : IObjectMapper, IObjectMapExpression
     {
-        public static TDestination Map<TDestination>(object source, ResolutionContext context)
+        public static TDestination Map<TDestination>(TDestination? source)
+            where TDestination : struct
         {
-            return (TDestination) (source ?? (context.ConfigurationProvider.AllowNullDestinationValues
-                ? ObjectCreator.CreateNonNullValue(typeof (TDestination))
-                : ObjectCreator.CreateObject(typeof (TDestination))));
+            return source.GetValueOrDefault();
         }
 
         private static readonly MethodInfo MapMethodInfo = typeof(NullableSourceMapper).GetAllMethods().First(_ => _.IsStatic);
 
         public object Map(ResolutionContext context)
         {
-            return MapMethodInfo.MakeGenericMethod(context.DestinationType).Invoke(null, new [] {context.SourceValue, context});
+            return MapMethodInfo.MakeGenericMethod(context.DestinationType).Invoke(null, new [] {context.SourceValue});
         }
 
         public bool IsMatch(TypePair context)
         {
-            return context.SourceType.IsNullableType() && !context.DestinationType.IsNullableType();
+            return context.SourceType.IsNullableType() && !context.DestinationType.IsNullableType() && context.DestinationType == context.SourceType.GetTypeOfNullable();
         }
 
         public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
-            return Expression.Call(null, MapMethodInfo.MakeGenericMethod(destExpression.Type), sourceExpression, contextExpression);
+            return Expression.Call(null, MapMethodInfo.MakeGenericMethod(destExpression.Type), sourceExpression);
         }
     }
 }

--- a/src/AutoMapper/Mappers/NullableSourceMapper.cs
+++ b/src/AutoMapper/Mappers/NullableSourceMapper.cs
@@ -6,7 +6,7 @@ namespace AutoMapper.Mappers
 {
     using Configuration;
 
-    public class NullableSourceMapper : IObjectMapper, IObjectMapExpression
+    public class NullableSourceMapper : IObjectMapExpression
     {
         public static TDestination Map<TDestination>(TDestination? source)
             where TDestination : struct

--- a/src/AutoMapper/Mappers/PrimitiveArrayMapper.cs
+++ b/src/AutoMapper/Mappers/PrimitiveArrayMapper.cs
@@ -6,7 +6,7 @@ namespace AutoMapper.Mappers
     using System;
     using System.Reflection;
 
-    public class PrimitiveArrayMapper : IObjectMapper, IObjectMapExpression
+    public class PrimitiveArrayMapper : IObjectMapExpression
     {
         public static TDestElement[] Map<TSourceElement, TDestElement>(TSourceElement[] source, ResolutionContext context)
         {

--- a/src/AutoMapper/Mappers/PrimitiveArrayMapper.cs
+++ b/src/AutoMapper/Mappers/PrimitiveArrayMapper.cs
@@ -1,33 +1,45 @@
-﻿namespace AutoMapper.Mappers
+﻿using System.Linq;
+using System.Linq.Expressions;
+
+namespace AutoMapper.Mappers
 {
     using System;
     using System.Reflection;
 
-    public class PrimitiveArrayMapper : IObjectMapper
+    public class PrimitiveArrayMapper : IObjectMapper, IObjectMapExpression
     {
-        public object Map(ResolutionContext context)
+        public static TDestElement[] Map<TSourceElement, TDestElement>(TSourceElement[] source, ResolutionContext context)
         {
-            if (context.IsSourceValueNull && context.Mapper.ShouldMapSourceCollectionAsNull(context))
+            if (source == null && context.Mapper.ShouldMapSourceCollectionAsNull(context))
             {
                 return null;
             }
 
-            if (!context.IsSourceValueNull && context.DestinationType.IsAssignableFrom(context.SourceType))
+            if (source != null && typeof(TDestElement).IsAssignableFrom(typeof(TSourceElement)))
             {
-                return context.SourceValue;
+                return source as TDestElement[];
             }
-
-            Type sourceElementType = TypeHelper.GetElementType(context.SourceType);
-            Type destElementType = TypeHelper.GetElementType(context.DestinationType);
-
-            Array sourceArray = (Array) context.SourceValue ?? ObjectCreator.CreateArray(sourceElementType, 0);
+            
+            var sourceArray = source ?? new TSourceElement[0];
 
             int sourceLength = sourceArray.Length;
-            Array destArray = ObjectCreator.CreateArray(destElementType, sourceLength);
+            TDestElement[] destArray = new TDestElement[sourceLength];
 
             Array.Copy(sourceArray, destArray, sourceLength);
 
             return destArray;
+        }
+
+        private static readonly MethodInfo MapMethodInfo = typeof(PrimitiveArrayMapper).GetAllMethods().First(_ => _.IsStatic);
+
+        public object Map(ResolutionContext context)
+        {
+            Type sourceElementType = TypeHelper.GetElementType(context.SourceType);
+            Type destElementType = TypeHelper.GetElementType(context.SourceType);
+
+            return
+                MapMethodInfo.MakeGenericMethod(sourceElementType, destElementType)
+                    .Invoke(null, new[] { context.SourceValue, context });
         }
 
         private bool IsPrimitiveArrayType(Type type)
@@ -47,6 +59,15 @@
                    IsPrimitiveArrayType(context.SourceType) &&
                    (TypeHelper.GetElementType(context.DestinationType)
                        .Equals(TypeHelper.GetElementType(context.SourceType)));
+        }
+
+        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        {
+            Type sourceElementType = TypeHelper.GetElementType(sourceExpression.Type);
+            Type destElementType = TypeHelper.GetElementType(destExpression.Type);
+
+            return Expression.Call(null,
+                MapMethodInfo.MakeGenericMethod(sourceElementType, destElementType), sourceExpression, contextExpression);
         }
     }
 }

--- a/src/AutoMapper/Mappers/ReadOnlyCollectionMapper.cs
+++ b/src/AutoMapper/Mappers/ReadOnlyCollectionMapper.cs
@@ -10,7 +10,7 @@ namespace AutoMapper.Mappers
     using System.Collections.ObjectModel;
     using Configuration;
 
-    public class ReadOnlyCollectionMapper : IObjectMapper, IObjectMapExpression
+    public class ReadOnlyCollectionMapper : IObjectMapExpression
     {
         public static ReadOnlyCollection<TDestinationItem> Map<TSource, TSourceItem, TDestinationItem>(TSource source, ResolutionContext context)
             where TSource : IEnumerable

--- a/src/AutoMapper/Mappers/StringDictionaryMapper.cs
+++ b/src/AutoMapper/Mappers/StringDictionaryMapper.cs
@@ -9,7 +9,7 @@ namespace AutoMapper.Mappers
     using System;
     using Execution;
 
-    public class ToStringDictionaryMapper : IObjectMapper, IObjectMapExpression
+    public class ToStringDictionaryMapper : IObjectMapExpression
     {
         public static Dictionary<string, object> MembersDictionary(ResolutionContext context)
         {

--- a/src/AutoMapper/Mappers/StringMapper.cs
+++ b/src/AutoMapper/Mappers/StringMapper.cs
@@ -1,9 +1,8 @@
 ﻿using System.Linq.Expressions;
-using System.Reflection;
 
 namespace AutoMapper.Mappers
 {
-    public class StringMapper : IObjectMapper, IObjectMapExpression
+    public class StringMapper : IObjectMapExpression
     {
         public object Map(ResolutionContext context)
         {

--- a/src/AutoMapper/Mappers/StringMapper.cs
+++ b/src/AutoMapper/Mappers/StringMapper.cs
@@ -17,7 +17,7 @@ namespace AutoMapper.Mappers
 
         public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
-            return Expression.Condition(Expression.Equal(sourceExpression, Expression.Constant(null)),
+            return Expression.Condition(Expression.Equal(sourceExpression, Expression.Default(sourceExpression.Type)),
                 Expression.Constant(null, typeof (string)),
                 Expression.Call(sourceExpression, typeof (object).GetMethod("ToString")));
         }

--- a/src/AutoMapper/Mappers/TypeConverterMapper.cs
+++ b/src/AutoMapper/Mappers/TypeConverterMapper.cs
@@ -1,3 +1,7 @@
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
 #if !PORTABLE
 namespace AutoMapper.Mappers
 {
@@ -5,34 +9,40 @@ namespace AutoMapper.Mappers
     using System.ComponentModel;
     using Configuration;
 
-    public class TypeConverterMapper : IObjectMapper
+    public class TypeConverterMapper : IObjectMapper, IObjectMapExpression
     {
-        public object Map(ResolutionContext context)
+        private static TDestination Map<TSource, TDestination>(TSource source, ResolutionContext context)
         {
-            if (context.SourceValue == null)
+            if (source == null)
             {
-                return context.Mapper.CreateObject(context);
+                return (TDestination)(context.ConfigurationProvider.AllowNullDestinationValues
+                 ? ObjectCreator.CreateNonNullValue(typeof(TDestination))
+                 : ObjectCreator.CreateObject(typeof(TDestination)));
             }
-            Func<object> converter = GetConverter(context);
-            return converter?.Invoke();
+            return GetConverter<TSource, TDestination>(source);
         }
 
-        private static Func<object> GetConverter(ResolutionContext context)
+        private static TDestination GetConverter<TSource, TDestination>(TSource source)
         {
-            TypeConverter typeConverter = GetTypeConverter(context.SourceType);
-            if (typeConverter.CanConvertTo(context.DestinationType))
-                return () => typeConverter.ConvertTo(context.SourceValue, context.DestinationType);
-            if (context.DestinationType.IsNullableType() &&
-                typeConverter.CanConvertTo(Nullable.GetUnderlyingType(context.DestinationType)))
-                return
-                    () =>
-                        typeConverter.ConvertTo(context.SourceValue, Nullable.GetUnderlyingType(context.DestinationType));
+            TypeConverter typeConverter = GetTypeConverter(typeof(TSource));
+            if (typeConverter.CanConvertTo(typeof(TDestination)))
+                return (TDestination)typeConverter.ConvertTo(source, typeof(TDestination));
+            if (typeof(TDestination).IsNullableType() &&
+                typeConverter.CanConvertTo(Nullable.GetUnderlyingType(typeof(TDestination))))
+                return (TDestination)typeConverter.ConvertTo(source, Nullable.GetUnderlyingType(typeof(TDestination)));
 
-            typeConverter = GetTypeConverter(context.DestinationType);
-            if (typeConverter.CanConvertFrom(context.SourceType))
-                return () => typeConverter.ConvertFrom(context.SourceValue);
+            typeConverter = GetTypeConverter(typeof(TDestination));
+            if (typeConverter.CanConvertFrom(typeof(TSource)))
+                return (TDestination)typeConverter.ConvertFrom(source);
 
-            return null;
+            return default(TDestination);
+        }
+
+        private static readonly MethodInfo MapMethodInfo = typeof(TypeConverterMapper).GetAllMethods().First(_ => _.IsStatic);
+
+        public object Map(ResolutionContext context)
+        {
+            return MapMethodInfo.MakeGenericMethod(context.SourceType, context.DestinationType).Invoke(null, new[] { context.SourceValue, context });
         }
 
         public bool IsMatch(TypePair context)
@@ -44,6 +54,11 @@ namespace AutoMapper.Mappers
                    (context.DestinationType.IsNullableType() &&
                     sourceTypeConverter.CanConvertTo(Nullable.GetUnderlyingType(context.DestinationType)) ||
                     destTypeConverter.CanConvertFrom(context.SourceType));
+        }
+
+        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        {
+            return Expression.Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression, contextExpression);
         }
 
         private static TypeConverter GetTypeConverter(Type type)

--- a/src/AutoMapper/Mappers/TypeConverterMapper.cs
+++ b/src/AutoMapper/Mappers/TypeConverterMapper.cs
@@ -9,7 +9,7 @@ namespace AutoMapper.Mappers
     using System.ComponentModel;
     using Configuration;
 
-    public class TypeConverterMapper : IObjectMapper, IObjectMapExpression
+    public class TypeConverterMapper : IObjectMapExpression
     {
         private static TDestination Map<TSource, TDestination>(TSource source, ResolutionContext context)
         {

--- a/src/UnitTests/Bug/ExpressionMapping.cs
+++ b/src/UnitTests/Bug/ExpressionMapping.cs
@@ -27,6 +27,37 @@ namespace AutoMapper.UnitTests.Bug
         }
     }
 
+    public class ExpressionPropertyMapping : NonValidatingSpecBase
+    {
+
+        public class SourceExpressionHolder
+        {
+            public Expression<Func<ExpressionMapping.ParentDTO, bool>> Expression { get; set; }
+        }
+
+        public class DestExpressionHolder
+        {
+            public Expression<Func<ExpressionMapping.Parent, bool>> Expression { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<SourceExpressionHolder, DestExpressionHolder>().ReverseMap();
+            cfg.CreateMap<ExpressionMapping.Parent, ExpressionMapping.ParentDTO>().ReverseMap();
+            cfg.CreateMap<ExpressionMapping.Child, ExpressionMapping.ChildDTO>()
+                .ForMember(d => d.ID_, opt => opt.MapFrom(s => s.ID))
+                .ReverseMap()
+                .ForMember(d => d.ID, opt => opt.MapFrom(s => s.ID_));
+        });
+
+        [Fact]
+        public void Should_Map_Expressions_UsingExpressions()
+        {
+            var source = new SourceExpressionHolder() { Expression = p => p.Child != null };
+            var dest = Mapper.Map<DestExpressionHolder>(source);
+        }
+    }
+
     public class ExpressionMapping : NonValidatingSpecBase
     {
         public class GrandParentDTO
@@ -119,7 +150,7 @@ namespace AutoMapper.UnitTests.Bug
             //var a = items2.ToList();
             items2.Count().ShouldEqual(1);
         }
-
+        
         [Fact]
         public void GrandParent_Mapping_To_Sub_Sub_Property_Condition()
         {

--- a/src/UnitTests/IMappingExpression/NonGenericProjectEnumTest.cs
+++ b/src/UnitTests/IMappingExpression/NonGenericProjectEnumTest.cs
@@ -73,7 +73,7 @@
         {
             var customers = new[] { new Customer() { FirstName = "Bill", LastName = "White", CustomerType = CustomerType.Vip } }.AsQueryable();
 
-            var projected = _mapper.Map<CustomerDto[]>(customers);
+            var projected = customers.ProjectTo<CustomerDto>(_mapper.ConfigurationProvider);
             projected.ShouldNotBeNull();
             Assert.Equal(customers.Single().CustomerType.ToString().ToUpper(), projected.Single().CustomerType);
         }


### PR DESCRIPTION
Want to also point out INullableSourceMapper changed a bit cause there's no reason to null check and do the context assert nulls, because the `Nullable<T>` is a stuct, thus it can't be null and the check isn't needed.  Also it's much simplified to read.

Also make sure when to check nullable to null they are the same types so that double? -> int won't be tried and it will say Un-mapped types instead of can't cast double? to int.

Still going to go through a few more mappers to convert them to IObjectMapExpression.