### PR TITLE
Make seal last and move newing up create map functions before do config and seal.

### DIFF
--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -39,15 +39,15 @@ namespace AutoMapper
 
             _profiles.Add(_defaultProfile);
 
+            ExpressionBuilder = new ExpressionBuilder(this);
+            _getTypeMap = GetTypeMap;
+            _createMapperFunc = CreateMapperFunc;
+
             _validator = new ConfigurationValidator(this);
 
             configure(this);
 
             Seal();
-
-            ExpressionBuilder = new ExpressionBuilder(this);
-            _getTypeMap = GetTypeMap;
-            _createMapperFunc = CreateMapperFunc;
         }
 
         public string ProfileName => "";

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -35,15 +35,14 @@ namespace AutoMapper
         public MapperConfiguration(Action<IMapperConfiguration> configure, IEnumerable<IObjectMapper> mappers)
         {
             _mappers = mappers;
-            _defaultProfile = new NamedProfile(ProfileName);
-
-            _profiles.Add(_defaultProfile);
-
-            ExpressionBuilder = new ExpressionBuilder(this);
             _getTypeMap = GetTypeMap;
             _createMapperFunc = CreateMapperFunc;
 
+            _defaultProfile = new NamedProfile(ProfileName);
+            _profiles.Add(_defaultProfile);
+            
             _validator = new ConfigurationValidator(this);
+            ExpressionBuilder = new ExpressionBuilder(this);
 
             configure(this);
 

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -36,7 +36,7 @@ namespace AutoMapper
         {
             _mappers = mappers;
             _getTypeMap = GetTypeMap;
-            _createMapperFunc = CreateMapperFunc;
+            _createMapperFuncs = CreateMapperFuncs;
 
             _defaultProfile = new NamedProfile(ProfileName);
             _profiles.Add(_defaultProfile);


### PR DESCRIPTION
Issue with AutoMapper.Collection it's going to need to call IConfiguration.ResolveTypeMap which is done on seal now.  The problem is the thing gets sealed without the functions to actively run ResolveTypeMaps,  therefore I get exceptions.