### PR TITLE
We know you aren't null already quit asking

### DIFF
--- a/src/AutoMapper/ExpressionExtensions.cs
+++ b/src/AutoMapper/ExpressionExtensions.cs
@@ -64,7 +64,7 @@
             private readonly IList<MemberExpression> AllreadyUpdated = new List<MemberExpression>();
             protected override Expression VisitMember(MemberExpression node)
             {
-                if (AllreadyUpdated.Contains(node))
+                if (AllreadyUpdated.Contains(node) || node.Expression is ParameterExpression)
                     return base.VisitMember(node);
                 AllreadyUpdated.Add(node);
                 return Visit(DelegateFactory.IfNotNullExpression(node));


### PR DESCRIPTION
Have check for nulls on each property but the source was already checked for null before you got to this point, so there's no need to check source every time.  It's the only place it's used right now so it works with the base being parameter expression.

Not big time saver from what I've seen, but the expression is less cluttered.