### PR TITLE
Configuration expression separating

### DIFF
--- a/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
@@ -15,7 +15,6 @@ namespace AutoMapper.Configuration
         {
             _defaultProfile = new NamedProfile(ProfileName);
             _profiles.Add(_defaultProfile);
-
         }
 
         public string ProfileName => "";

--- a/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
@@ -1,0 +1,146 @@
+namespace AutoMapper.Configuration
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using Mappers;
+
+    public class MapperConfigurationExpression : IMapperConfigurationExpression
+    {
+        private readonly Profile _defaultProfile;
+        private readonly IList<Profile> _profiles = new List<Profile>();
+        private readonly List<Action<TypeMap, IMappingExpression>> _allTypeMapActions = new List<Action<TypeMap, IMappingExpression>>();
+
+        public MapperConfigurationExpression()
+        {
+            _defaultProfile = new NamedProfile(ProfileName);
+            _profiles.Add(_defaultProfile);
+
+        }
+
+        public string ProfileName => "";
+        public IEnumerable<Profile> Profiles => _profiles;
+        public IEnumerable<Action<TypeMap, IMappingExpression>> AllTypeMapActions => _allTypeMapActions;
+        public Func<Type, object> ServiceCtor { get; private set; } = ObjectCreator.CreateObject;
+
+        public void CreateProfile(string profileName, Action<Profile> config)
+        {
+            var profile = new NamedProfile(profileName);
+
+            config(profile);
+
+            AddProfile(profile);
+        }
+
+        private class NamedProfile : Profile
+        {
+            public NamedProfile(string profileName) : base(profileName)
+            {
+            }
+        }
+
+        public void AddProfile(Profile profile)
+        {
+            profile.Initialize();
+            _profiles.Add(profile);
+        }
+
+        public void AddProfile<TProfile>() where TProfile : Profile, new() => AddProfile(new TProfile());
+
+        public void AddProfile(Type profileType) => AddProfile((Profile)Activator.CreateInstance(profileType));
+
+        public void ConstructServicesUsing(Func<Type, object> constructor) => ServiceCtor = constructor;
+
+        public Func<PropertyInfo, bool> ShouldMapProperty
+        {
+            get { return _defaultProfile.ShouldMapProperty; }
+            set { _defaultProfile.ShouldMapProperty = value; }
+        }
+
+        public Func<FieldInfo, bool> ShouldMapField
+        {
+            get { return _defaultProfile.ShouldMapField; }
+            set { _defaultProfile.ShouldMapField = value; }
+        }
+
+        public bool CreateMissingTypeMaps
+        {
+            get { return _defaultProfile.CreateMissingTypeMaps; }
+            set { _defaultProfile.CreateMissingTypeMaps = value; }
+        }
+
+        public void IncludeSourceExtensionMethods(Type type) => _defaultProfile.IncludeSourceExtensionMethods(type);
+
+        public INamingConvention SourceMemberNamingConvention
+        {
+            get { return _defaultProfile.SourceMemberNamingConvention; }
+            set { _defaultProfile.SourceMemberNamingConvention = value; }
+        }
+
+        public INamingConvention DestinationMemberNamingConvention
+        {
+            get { return _defaultProfile.DestinationMemberNamingConvention; }
+            set { _defaultProfile.DestinationMemberNamingConvention = value; }
+        }
+
+        public bool AllowNullDestinationValues
+        {
+            get { return _defaultProfile.AllowNullDestinationValues; }
+            set { _defaultProfile.AllowNullDestinationValues = value; }
+        }
+
+        public bool AllowNullCollections
+        {
+            get { return _defaultProfile.AllowNullCollections; }
+            set { _defaultProfile.AllowNullCollections = value; }
+        }
+
+        public void ForAllMaps(Action<TypeMap, IMappingExpression> configuration)
+            => _allTypeMapActions.Add(configuration);
+
+        public Conventions.IMemberConfiguration AddMemberConfiguration()
+            => _defaultProfile.AddMemberConfiguration();
+
+        public IConditionalObjectMapper AddConditionalObjectMapper()
+            => _defaultProfile.AddConditionalObjectMapper();
+
+        public void DisableConstructorMapping() => _defaultProfile.DisableConstructorMapping();
+
+        public IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>()
+            => _defaultProfile.CreateMap<TSource, TDestination>();
+
+        public IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>(
+            MemberList memberList)
+            => _defaultProfile.CreateMap<TSource, TDestination>(memberList);
+
+        public IMappingExpression CreateMap(Type sourceType, Type destinationType)
+            => _defaultProfile.CreateMap(sourceType, destinationType, MemberList.Destination);
+
+        public IMappingExpression CreateMap(Type sourceType, Type destinationType, MemberList memberList)
+            => _defaultProfile.CreateMap(sourceType, destinationType, memberList);
+
+        public void ClearPrefixes() => _defaultProfile.ClearPrefixes();
+
+        public void RecognizeAlias(string original, string alias)
+            => _defaultProfile.RecognizeAlias(original, alias);
+
+        public void ReplaceMemberName(string original, string newValue)
+            => _defaultProfile.ReplaceMemberName(original, newValue);
+
+        public void RecognizePrefixes(params string[] prefixes)
+            => _defaultProfile.RecognizePrefixes(prefixes);
+
+        public void RecognizePostfixes(params string[] postfixes)
+            => _defaultProfile.RecognizePostfixes(postfixes);
+
+        public void RecognizeDestinationPrefixes(params string[] prefixes)
+            => _defaultProfile.RecognizeDestinationPrefixes(prefixes);
+
+        public void RecognizeDestinationPostfixes(params string[] postfixes)
+            => _defaultProfile.RecognizeDestinationPostfixes(postfixes);
+
+        public void AddGlobalIgnore(string startingwith)
+            => _defaultProfile.AddGlobalIgnore(startingwith);
+
+    }
+}

--- a/src/AutoMapper/IConfiguration.cs
+++ b/src/AutoMapper/IConfiguration.cs
@@ -3,7 +3,7 @@ namespace AutoMapper
     using System;
     using System.Collections.Generic;
 
-    public interface IMapperConfiguration : IProfileExpression, IConfiguration
+    public interface IMapperConfigurationExpression : IProfileExpression, IConfiguration
     {
         Func<Type, object> ServiceCtor { get; }
         IEnumerable<Profile> Profiles { get; }

--- a/src/AutoMapper/IConfiguration.cs
+++ b/src/AutoMapper/IConfiguration.cs
@@ -1,10 +1,13 @@
 namespace AutoMapper
 {
     using System;
+    using System.Collections.Generic;
 
     public interface IMapperConfiguration : IProfileExpression, IConfiguration
     {
-        
+        Func<Type, object> ServiceCtor { get; }
+        IEnumerable<Profile> Profiles { get; }
+        IEnumerable<Action<TypeMap, IMappingExpression>> AllTypeMapActions { get; } 
     }
 
     public interface IConfiguration

--- a/src/AutoMapper/IConfigurationProvider.cs
+++ b/src/AutoMapper/IConfigurationProvider.cs
@@ -63,15 +63,6 @@ namespace AutoMapper
         TypeMap ResolveTypeMap(TypePair typePair);
 
         /// <summary>
-        /// Resolve the <see cref="TypeMap"/> for the runtime and declared source types and destination type, checking parent types
-        /// </summary>
-        /// <param name="sourceRuntimeType">The runtime type of the source</param>
-        /// <param name="sourceDeclaredType">The declared type of the source</param>
-        /// <param name="destinationType">Configured destination type</param>
-        /// <returns>Type map configuration</returns>
-        TypeMap ResolveTypeMap(Type sourceRuntimeType, Type sourceDeclaredType, Type destinationType);
-
-        /// <summary>
         /// Dry run all configured type maps and throw <see cref="AutoMapperConfigurationException"/> for each problem
         /// </summary>
         void AssertConfigurationIsValid();

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -47,7 +47,7 @@ namespace AutoMapper
         /// Initialize static configuration instance
         /// </summary>
         /// <param name="config">Configuration action</param>
-        public static void Initialize(Action<IMapperConfiguration> config)
+        public static void Initialize(Action<IMapperConfigurationExpression> config)
         {
             Configuration = new MapperConfiguration(config);
             Instance = new Mapper(Configuration);

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -134,12 +134,6 @@ namespace AutoMapper
                 ?? ResolveTypeMap(sourceType, destinationType);
         }
 
-        public TypeMap ResolveTypeMap(Type sourceRuntimeType, Type sourceDeclaredType, Type destinationType)
-        {
-            return ResolveTypeMap(sourceRuntimeType, destinationType) ??
-                      (sourceDeclaredType != sourceRuntimeType ? ResolveTypeMap(sourceDeclaredType, destinationType) : null);
-        }
-
         public void AssertConfigurationIsValid(TypeMap typeMap)
         {
             _validator.AssertConfigurationIsValid(Enumerable.Repeat(typeMap, 1));

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -130,9 +130,17 @@ namespace AutoMapper
                 set { _defaultProfile.DestinationMemberNamingConvention = value; }
             }
 
-            bool IProfileExpression.AllowNullDestinationValues { get; set; }
+            bool IProfileExpression.AllowNullDestinationValues
+            {
+                get { return _defaultProfile.AllowNullDestinationValues; }
+                set { _defaultProfile.AllowNullDestinationValues = value; }
+            }
 
-            bool IProfileExpression.AllowNullCollections { get; set; }
+            bool IProfileExpression.AllowNullCollections
+            {
+                get { return _defaultProfile.AllowNullCollections; }
+                set { _defaultProfile.AllowNullCollections = value; }
+            }
 
             void IProfileExpression.ForAllMaps(Action<TypeMap, IMappingExpression> configuration)
                 => _allTypeMapActions.Add(configuration);

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -14,19 +14,17 @@ namespace AutoMapper
     using static ExpressionExtensions;
     using UntypedMapperFunc = System.Func<object, object, ResolutionContext, object>;
 
-    public class MapperConfiguration : IConfigurationProvider, IMapperConfiguration
+
+    public class MapperConfiguration : IConfigurationProvider
     {
         private readonly IEnumerable<IObjectMapper> _mappers;
-        private readonly List<Action<TypeMap, IMappingExpression>> _allTypeMapActions = new List<Action<TypeMap, IMappingExpression>>();
-        private readonly Profile _defaultProfile;
         private readonly TypeMapRegistry _typeMapRegistry = new TypeMapRegistry();
         private readonly ConcurrentDictionary<TypePair, TypeMap> _typeMapPlanCache = new ConcurrentDictionary<TypePair, TypeMap>();
         private readonly ConcurrentDictionary<MapRequest, MapperFuncs> _mapPlanCache = new ConcurrentDictionary<MapRequest, MapperFuncs>();
-        private readonly IList<Profile> _profiles = new List<Profile>();
         private readonly ConfigurationValidator _validator;
-        private Func<Type, object> _serviceCtor = ObjectCreator.CreateObject;
         private readonly Func<TypePair, TypeMap> _getTypeMap;
         private readonly Func<MapRequest, MapperFuncs> _createMapperFuncs;
+        private readonly ConfigurationExpression _configurationExpression;
 
         public MapperConfiguration(Action<IMapperConfiguration> configure) : this(configure, MapperRegistry.Mappers)
         {
@@ -38,129 +36,152 @@ namespace AutoMapper
             _getTypeMap = GetTypeMap;
             _createMapperFuncs = CreateMapperFuncs;
 
-            _defaultProfile = new NamedProfile(ProfileName);
-            _profiles.Add(_defaultProfile);
-
             _validator = new ConfigurationValidator(this);
             ExpressionBuilder = new ExpressionBuilder(this);
 
-            configure(this);
+            _configurationExpression = new ConfigurationExpression();
 
-            Seal();
+            configure(_configurationExpression);
+
+            Seal(_configurationExpression);
         }
-
-        public string ProfileName => "";
 
         #region IConfiguration Members
 
-        void IConfiguration.CreateProfile(string profileName, Action<Profile> config)
+        private class ConfigurationExpression : IMapperConfiguration
         {
-            var profile = new NamedProfile(profileName);
+            private readonly Profile _defaultProfile;
+            private readonly IList<Profile> _profiles = new List<Profile>();
+            private readonly List<Action<TypeMap, IMappingExpression>> _allTypeMapActions = new List<Action<TypeMap, IMappingExpression>>();
 
-            config(profile);
+            public ConfigurationExpression()
+            {
+                _defaultProfile = new NamedProfile(ProfileName);
+                _profiles.Add(_defaultProfile);
 
-            ((IConfiguration)this).AddProfile(profile);
+            }
+
+            public string ProfileName => "";
+            public IEnumerable<Profile> Profiles => _profiles;
+            public IEnumerable<Action<TypeMap, IMappingExpression>> AllTypeMapActions => _allTypeMapActions;
+            public Func<Type, object> ServiceCtor { get; private set; } = ObjectCreator.CreateObject;
+
+            void IConfiguration.CreateProfile(string profileName, Action<Profile> config)
+            {
+                var profile = new NamedProfile(profileName);
+
+                config(profile);
+
+                ((IConfiguration)this).AddProfile(profile);
+            }
+
+            private class NamedProfile : Profile
+            {
+                public NamedProfile(string profileName) : base(profileName)
+                {
+                }
+            }
+
+            void IConfiguration.AddProfile(Profile profile)
+            {
+                profile.Initialize();
+                _profiles.Add(profile);
+            }
+
+            void IConfiguration.AddProfile<TProfile>() => ((IConfiguration)this).AddProfile(new TProfile());
+
+            void IConfiguration.AddProfile(Type profileType)
+                => ((IConfiguration)this).AddProfile((Profile)Activator.CreateInstance(profileType));
+
+            void IConfiguration.ConstructServicesUsing(Func<Type, object> constructor) => ServiceCtor = constructor;
+
+            Func<PropertyInfo, bool> IProfileExpression.ShouldMapProperty
+            {
+                get { return _defaultProfile.ShouldMapProperty; }
+                set { _defaultProfile.ShouldMapProperty = value; }
+            }
+
+            Func<FieldInfo, bool> IProfileExpression.ShouldMapField
+            {
+                get { return _defaultProfile.ShouldMapField; }
+                set { _defaultProfile.ShouldMapField = value; }
+            }
+
+            bool IConfiguration.CreateMissingTypeMaps
+            {
+                get { return _defaultProfile.CreateMissingTypeMaps; }
+                set { _defaultProfile.CreateMissingTypeMaps = value; }
+            }
+
+            void IProfileExpression.IncludeSourceExtensionMethods(Type type)
+            {
+                _defaultProfile.IncludeSourceExtensionMethods(type);
+            }
+
+            INamingConvention IProfileExpression.SourceMemberNamingConvention
+            {
+                get { return _defaultProfile.SourceMemberNamingConvention; }
+                set { _defaultProfile.SourceMemberNamingConvention = value; }
+            }
+
+            INamingConvention IProfileExpression.DestinationMemberNamingConvention
+            {
+                get { return _defaultProfile.DestinationMemberNamingConvention; }
+                set { _defaultProfile.DestinationMemberNamingConvention = value; }
+            }
+
+            bool IProfileExpression.AllowNullDestinationValues { get; set; }
+
+            bool IProfileExpression.AllowNullCollections { get; set; }
+
+            void IProfileExpression.ForAllMaps(Action<TypeMap, IMappingExpression> configuration)
+                => _allTypeMapActions.Add(configuration);
+
+            Configuration.Conventions.IMemberConfiguration IProfileExpression.AddMemberConfiguration()
+                => _defaultProfile.AddMemberConfiguration();
+
+            IConditionalObjectMapper IProfileExpression.AddConditionalObjectMapper()
+                => _defaultProfile.AddConditionalObjectMapper();
+
+            void IProfileExpression.DisableConstructorMapping() => _defaultProfile.DisableConstructorMapping();
+
+            IMappingExpression<TSource, TDestination> IProfileExpression.CreateMap<TSource, TDestination>()
+                => _defaultProfile.CreateMap<TSource, TDestination>();
+
+            IMappingExpression<TSource, TDestination> IProfileExpression.CreateMap<TSource, TDestination>(
+                MemberList memberList)
+                => _defaultProfile.CreateMap<TSource, TDestination>(memberList);
+
+            IMappingExpression IProfileExpression.CreateMap(Type sourceType, Type destinationType)
+                => _defaultProfile.CreateMap(sourceType, destinationType, MemberList.Destination);
+
+            IMappingExpression IProfileExpression.CreateMap(Type sourceType, Type destinationType, MemberList memberList)
+                => _defaultProfile.CreateMap(sourceType, destinationType, memberList);
+
+            void IProfileExpression.ClearPrefixes() => _defaultProfile.ClearPrefixes();
+
+            void IProfileExpression.RecognizeAlias(string original, string alias)
+                => _defaultProfile.RecognizeAlias(original, alias);
+
+            void IProfileExpression.ReplaceMemberName(string original, string newValue)
+                => _defaultProfile.ReplaceMemberName(original, newValue);
+
+            void IProfileExpression.RecognizePrefixes(params string[] prefixes)
+                => _defaultProfile.RecognizePrefixes(prefixes);
+
+            void IProfileExpression.RecognizePostfixes(params string[] postfixes)
+                => _defaultProfile.RecognizePostfixes(postfixes);
+
+            void IProfileExpression.RecognizeDestinationPrefixes(params string[] prefixes)
+                => _defaultProfile.RecognizeDestinationPrefixes(prefixes);
+
+            void IProfileExpression.RecognizeDestinationPostfixes(params string[] postfixes)
+                => _defaultProfile.RecognizeDestinationPostfixes(postfixes);
+
+            void IProfileExpression.AddGlobalIgnore(string startingwith)
+                => _defaultProfile.AddGlobalIgnore(startingwith);
+
         }
-
-        private class NamedProfile : Profile
-        {
-            public NamedProfile(string profileName) : base(profileName) { }
-        }
-
-        void IConfiguration.AddProfile(Profile profile)
-        {
-            profile.Initialize();
-            _profiles.Add(profile);
-        }
-
-        void IConfiguration.AddProfile<TProfile>() => ((IConfiguration)this).AddProfile(new TProfile());
-
-        void IConfiguration.AddProfile(Type profileType) => ((IConfiguration)this).AddProfile((Profile)Activator.CreateInstance(profileType));
-
-        void IConfiguration.ConstructServicesUsing(Func<Type, object> constructor) => _serviceCtor = constructor;
-
-        Func<PropertyInfo, bool> IProfileExpression.ShouldMapProperty
-        {
-            get { return _defaultProfile.ShouldMapProperty; }
-            set { _defaultProfile.ShouldMapProperty = value; }
-        }
-
-        Func<FieldInfo, bool> IProfileExpression.ShouldMapField
-        {
-            get { return _defaultProfile.ShouldMapField; }
-            set { _defaultProfile.ShouldMapField = value; }
-        }
-
-        bool IConfiguration.CreateMissingTypeMaps
-        {
-            get { return _defaultProfile.CreateMissingTypeMaps; }
-            set { _defaultProfile.CreateMissingTypeMaps = value; }
-        }
-
-        void IProfileExpression.IncludeSourceExtensionMethods(Type type)
-        {
-            _defaultProfile.IncludeSourceExtensionMethods(type);
-        }
-
-        INamingConvention IProfileExpression.SourceMemberNamingConvention
-        {
-            get { return _defaultProfile.SourceMemberNamingConvention; }
-            set { _defaultProfile.SourceMemberNamingConvention = value; }
-        }
-
-        INamingConvention IProfileExpression.DestinationMemberNamingConvention
-        {
-            get { return _defaultProfile.DestinationMemberNamingConvention; }
-            set { _defaultProfile.DestinationMemberNamingConvention = value; }
-        }
-
-        bool IProfileExpression.AllowNullDestinationValues
-        {
-            get { return AllowNullDestinationValues; }
-            set { AllowNullDestinationValues = value; }
-        }
-
-        bool IProfileExpression.AllowNullCollections
-        {
-            get { return AllowNullCollections; }
-            set { AllowNullCollections = value; }
-        }
-
-        void IProfileExpression.ForAllMaps(Action<TypeMap, IMappingExpression> configuration) => _allTypeMapActions.Add(configuration);
-
-        Configuration.Conventions.IMemberConfiguration IProfileExpression.AddMemberConfiguration() => _defaultProfile.AddMemberConfiguration();
-
-        IConditionalObjectMapper IProfileExpression.AddConditionalObjectMapper() => _defaultProfile.AddConditionalObjectMapper();
-
-        void IProfileExpression.DisableConstructorMapping() => _defaultProfile.DisableConstructorMapping();
-
-        IMappingExpression<TSource, TDestination> IProfileExpression.CreateMap<TSource, TDestination>()
-            => _defaultProfile.CreateMap<TSource, TDestination>();
-
-        IMappingExpression<TSource, TDestination> IProfileExpression.CreateMap<TSource, TDestination>(MemberList memberList)
-            => _defaultProfile.CreateMap<TSource, TDestination>(memberList);
-
-        IMappingExpression IProfileExpression.CreateMap(Type sourceType, Type destinationType)
-            => _defaultProfile.CreateMap(sourceType, destinationType, MemberList.Destination);
-
-        IMappingExpression IProfileExpression.CreateMap(Type sourceType, Type destinationType, MemberList memberList)
-            => _defaultProfile.CreateMap(sourceType, destinationType, memberList);
-
-        void IProfileExpression.ClearPrefixes() => _defaultProfile.ClearPrefixes();
-
-        void IProfileExpression.RecognizeAlias(string original, string alias) => _defaultProfile.RecognizeAlias(original, alias);
-
-        void IProfileExpression.ReplaceMemberName(string original, string newValue) => _defaultProfile.ReplaceMemberName(original, newValue);
-
-        void IProfileExpression.RecognizePrefixes(params string[] prefixes) => _defaultProfile.RecognizePrefixes(prefixes);
-
-        void IProfileExpression.RecognizePostfixes(params string[] postfixes) => _defaultProfile.RecognizePostfixes(postfixes);
-
-        void IProfileExpression.RecognizeDestinationPrefixes(params string[] prefixes) => _defaultProfile.RecognizeDestinationPrefixes(prefixes);
-
-        void IProfileExpression.RecognizeDestinationPostfixes(params string[] postfixes) => _defaultProfile.RecognizeDestinationPostfixes(postfixes);
-
-        void IProfileExpression.AddGlobalIgnore(string startingwith) => _defaultProfile.AddGlobalIgnore(startingwith);
 
         #endregion
 
@@ -168,25 +189,17 @@ namespace AutoMapper
 
         public IExpressionBuilder ExpressionBuilder { get; }
 
-        public Func<Type, object> ServiceCtor => _serviceCtor;
+        public Func<Type, object> ServiceCtor { get; private set; }
 
-        public bool AllowNullDestinationValues
-        {
-            get { return _defaultProfile.AllowNullDestinationValues; }
-            private set { _defaultProfile.AllowNullDestinationValues = value; }
-        }
+        public bool AllowNullDestinationValues { get; private set; }
 
-        public bool AllowNullCollections
-        {
-            get { return _defaultProfile.AllowNullCollections; }
-            private set { _defaultProfile.AllowNullCollections = value; }
-        }
+        public bool AllowNullCollections { get; private set; }
 
         public Func<TSource, TDestination, ResolutionContext, TDestination> GetMapperFunc<TSource, TDestination>(TypePair types)
         {
             var key = new TypePair(typeof(TSource), typeof(TDestination));
             var mapRequest = new MapRequest(key, types);
-            return (Func<TSource, TDestination, ResolutionContext, TDestination>) GetMapperFunc(mapRequest);
+            return (Func<TSource, TDestination, ResolutionContext, TDestination>)GetMapperFunc(mapRequest);
         }
 
         public Delegate GetMapperFunc(MapRequest mapRequest)
@@ -202,47 +215,12 @@ namespace AutoMapper
         private MapperFuncs CreateMapperFuncs(MapRequest mapRequest)
         {
             var typeMap = ResolveTypeMap(mapRequest.RuntimeTypes);
-            if(typeMap != null)
+            if (typeMap != null)
             {
                 return new MapperFuncs(mapRequest, typeMap);
-                //return new Func<TSource, TDestination, ResolutionContext, TDestination>((src, dest, context) =>
-                //{
-                //    try
-                //    {
-                //        return (TDestination) typeMap.Map(src, context);
-                //    }
-                //    catch (AutoMapperMappingException)
-                //    {
-                //        throw;
-                //    }
-                //    catch (Exception ex)
-                //    {
-                //        throw new AutoMapperMappingException(context, ex);
-                //    }
-                //});
             }
             var mapperToUse = _mappers.FirstOrDefault(om => om.IsMatch(mapRequest.RuntimeTypes));
             return new MapperFuncs(mapRequest, mapperToUse);
-            //return new Func<TSource, TDestination, ResolutionContext, TDestination>((src, dest, context) =>
-            //{
-            //    if(mapperToUse == null)
-            //    {
-            //        throw new AutoMapperMappingException(context,
-            //        "Missing type map configuration or unsupported mapping.");
-            //    }
-            //    try
-            //    {
-            //        return mapperToUse.Map(context);
-            //    }
-            //    catch(AutoMapperMappingException)
-            //    {
-            //        throw;
-            //    }
-            //    catch(Exception ex)
-            //    {
-            //        throw new AutoMapperMappingException(context, ex);
-            //    }
-            //});
         }
 
         public TypeMap[] GetAllTypeMaps() => _typeMapRegistry.TypeMaps.ToArray();
@@ -268,14 +246,14 @@ namespace AutoMapper
 
         private TypeMap GetTypeMap(TypePair pair)
         {
-            foreach(var tp in pair.GetRelatedTypePairs())
+            foreach (var tp in pair.GetRelatedTypePairs())
             {
                 var typeMap =
                           _typeMapPlanCache.GetOrDefault(tp) ??
                           FindTypeMapFor(tp) ??
                           (!CoveredByObjectMap(pair) ? FindConventionTypeMapFor(tp) : null) ??
                           FindClosedGenericTypeMapFor(tp, pair);
-                if(typeMap != null)
+                if (typeMap != null)
                 {
                     return typeMap;
                 }
@@ -324,17 +302,21 @@ namespace AutoMapper
 
         #endregion
 
-        private void Seal()
+        private void Seal(IMapperConfiguration configuration)
         {
+            ServiceCtor = configuration.ServiceCtor;
+            AllowNullDestinationValues = configuration.AllowNullDestinationValues;
+            AllowNullCollections = configuration.AllowNullCollections;
+
             var derivedMaps = new List<Tuple<TypePair, TypeMap>>();
             var redirectedTypes = new List<Tuple<TypePair, TypePair>>();
 
-            foreach (var profile in _profiles.Cast<IProfileConfiguration>())
+            foreach (var profile in configuration.Profiles.Cast<IProfileConfiguration>())
             {
                 profile.Register(_typeMapRegistry);
             }
 
-            foreach (var action in _allTypeMapActions)
+            foreach (var action in configuration.AllTypeMapActions)
             {
                 foreach (var typeMap in _typeMapRegistry.TypeMaps)
                 {
@@ -346,7 +328,7 @@ namespace AutoMapper
                 }
             }
 
-            foreach (var profile in _profiles.Cast<IProfileConfiguration>())
+            foreach (var profile in configuration.Profiles.Cast<IProfileConfiguration>())
             {
                 profile.Configure(_typeMapRegistry);
             }
@@ -410,7 +392,7 @@ namespace AutoMapper
 
         private TypeMap FindConventionTypeMapFor(TypePair typePair)
         {
-            var typeMap = _profiles
+            var typeMap = _configurationExpression.Profiles
                 .Cast<IProfileConfiguration>()
                 .Select(p => p.ConfigureConventionTypeMap(_typeMapRegistry, typePair))
                 .FirstOrDefault(t => t != null);
@@ -425,7 +407,7 @@ namespace AutoMapper
             if (typePair.GetOpenGenericTypePair() == null)
                 return null;
 
-            var typeMap = _profiles
+            var typeMap = _configurationExpression.Profiles
                 .Cast<IProfileConfiguration>()
                 .Select(p => p.ConfigureClosedGenericTypeMap(_typeMapRegistry, typePair, requestedTypes))
                 .FirstOrDefault(t => t != null);
@@ -454,7 +436,7 @@ namespace AutoMapper
             public MapperFuncs(MapRequest mapRequest, LambdaExpression typedExpression)
             {
                 Typed = typedExpression.Compile();
-                _untyped = new Lazy<UntypedMapperFunc>(()=>Wrap(mapRequest, typedExpression).Compile());
+                _untyped = new Lazy<UntypedMapperFunc>(() => Wrap(mapRequest, typedExpression).Compile());
             }
 
             private static Expression<UntypedMapperFunc> Wrap(MapRequest mapRequest, LambdaExpression typedExpression)
@@ -465,7 +447,7 @@ namespace AutoMapper
                 var requestedSourceType = mapRequest.RequestedTypes.SourceType;
                 var requestedDestinationType = mapRequest.RequestedTypes.DestinationType;
 
-                var destination = requestedDestinationType.IsValueType() ? Coalesce(destinationParameter, New(requestedDestinationType)) : (Expression) destinationParameter;
+                var destination = requestedDestinationType.IsValueType() ? Coalesce(destinationParameter, New(requestedDestinationType)) : (Expression)destinationParameter;
                 return Lambda<UntypedMapperFunc>(
                             ToType(
                                 Invoke(typedExpression, ToType(sourceParameter, requestedSourceType), ToType(destination, requestedDestinationType), contextParameter)
@@ -481,7 +463,7 @@ namespace AutoMapper
                 var requestedSourceType = mapRequest.RequestedTypes.SourceType;
                 var requestedDestinationType = mapRequest.RequestedTypes.DestinationType;
 
-                if(typeMapSourceParameter.Type != requestedSourceType || typeMapDestinationParameter.Type != requestedDestinationType)
+                if (typeMapSourceParameter.Type != requestedSourceType || typeMapDestinationParameter.Type != requestedDestinationType)
                 {
                     var requestedSourceParameter = Parameter(requestedSourceType, "src");
                     var requestedDestinationParameter = Parameter(requestedDestinationType, "dest");
@@ -512,7 +494,7 @@ namespace AutoMapper
                             select c).Single();
 
                 LambdaExpression fullExpression;
-                if(mapperToUse == null)
+                if (mapperToUse == null)
                 {
                     var message = Constant("Missing type map configuration or unsupported mapping.");
                     fullExpression = Lambda(Block(Throw(New(ctor, context, message)), Default(destinationType)), source, destination, context);

--- a/src/UnitTests/SeparateConfiguration.cs
+++ b/src/UnitTests/SeparateConfiguration.cs
@@ -1,0 +1,39 @@
+﻿namespace AutoMapper.UnitTests
+{
+    using Configuration;
+    using Should;
+    using Xunit;
+
+    public class SeparateConfiguration : NonValidatingSpecBase
+    {
+        public class Source
+        {
+            public int Value { get; set; }
+        }
+        public class Dest
+        {
+            public int Value { get; set; }
+        }
+        public SeparateConfiguration()
+        {
+            var expr = new MapperConfigurationExpression();
+
+            expr.CreateMap<Source, Dest>();
+
+            var configuration = new MapperConfiguration(expr);
+
+            Configuration = configuration;
+        }
+
+        protected override MapperConfiguration Configuration { get; }
+
+        [Fact]
+        public void Should_use_passed_in_configuration()
+        {
+            var source = new Source {Value = 5};
+            var dest = Mapper.Map<Source, Dest>(source);
+
+            dest.Value.ShouldEqual(source.Value);
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -265,6 +265,7 @@
     <Compile Include="PropertyMapContexts.cs" />
     <Compile Include="Regression.cs" />
     <Compile Include="ReverseMapping.cs" />
+    <Compile Include="SeparateConfiguration.cs" />
     <Compile Include="Should\Should.Core\Assertions\Assert.cs" />
     <Compile Include="Should\Should.Core\Assertions\AssertComparer.cs" />
     <Compile Include="Should\Should.Core\Assertions\AssertEqualityComparer.cs" />


### PR DESCRIPTION
This allows you to have the configuration expression passed around and modified, before you then pass it to the MapperConfiguration for consumption.