### PR TITLE
Allow custom resolved values to validate; I didn't try to get the typ…

### DIFF
--- a/src/AutoMapper/AutoMapperConfigurationException.cs
+++ b/src/AutoMapper/AutoMapperConfigurationException.cs
@@ -52,7 +52,7 @@ namespace AutoMapper
                         string.Format(
                             "The following property on {0} cannot be mapped: \n\t{2}\nAdd a custom mapping expression, ignore, add a custom resolver, or modify the destination type {1}.",
                             Context.DestinationType.FullName, Context.DestinationType.FullName,
-                            PropertyMap.DestinationProperty.Name);
+                            PropertyMap?.DestinationProperty.Name);
 
                     message += "\nContext:";
 

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -76,6 +76,10 @@ namespace AutoMapper
                     return CustomExpression.ReturnType;
                 if (CustomResolver != null)
                     return CustomResolver.ReturnType;
+                if(CustomValue != null)
+                    return CustomValue.GetType();
+                if(ValueResolverConfig != null)
+                    return typeof(object);
                 return SourceMember?.GetMemberType();
             }
         }

--- a/src/UnitTests/CustomMapping.cs
+++ b/src/UnitTests/CustomMapping.cs
@@ -5,6 +5,90 @@ using Xunit;
 
 namespace AutoMapper.UnitTests
 {
+    public class When_using_value_with_mismatched_properties : AutoMapperSpecBase
+    {
+        Destination _destination;
+        static Guid _guid = Guid.NewGuid();
+
+        class Source
+        {
+            public int Value { get; set; }
+        }
+
+        class Destination
+        {
+            public Guid Value { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration
+        {
+            get
+            {
+                return new MapperConfiguration(c =>
+                {
+                    c.CreateMap<Source, Destination>().ForMember(d => d.Value, o => o.UseValue(_guid));
+                });
+            }
+        }
+
+        protected override void Because_of()
+        {
+            _destination = Mapper.Map<Destination>(new Source());
+        }
+
+        [Fact]
+        public void Should_map_ok()
+        {
+            _destination.Value.ShouldEqual(_guid);
+        }
+    }
+
+    public class When_custom_resolving_mismatched_properties : AutoMapperSpecBase
+    {
+        Destination _destination;
+        static Guid _guid = Guid.NewGuid();
+
+        class Source
+        {
+            public int Value { get; set; }
+        }
+
+        class Destination
+        {
+            public Guid Value { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration
+        {
+            get
+            {
+                return new MapperConfiguration(c =>
+                {
+                    c.CreateMap<Source, Destination>().ForMember(d => d.Value, o => o.ResolveUsing<Resolver>());//.ForMember(d => d.Value, o => o.ResolveUsing(s=>_guid));
+                });
+            }
+        }
+
+        class Resolver : IValueResolver<Source, Guid>
+        {
+            public Guid Resolve(Source model, ResolutionContext context)
+            {
+                return _guid;
+            }
+        }
+
+        protected override void Because_of()
+        {
+            _destination = Mapper.Map<Destination>(new Source());
+        }
+
+        [Fact]
+        public void Should_map_ok()
+        {
+            _destination.Value.ShouldEqual(_guid);
+        }
+    }
+
     public class When_resolve_throws : NonValidatingSpecBase
     {
         Exception _ex = new Exception();


### PR DESCRIPTION
…e returned by the resolver
I think that's the way it worked at some point. Getting the type seemed difficult.