### PR TITLE
Array mapper improvements

### DIFF
--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -349,7 +349,7 @@
                     var match = configurationProvider.GetMappers().FirstOrDefault(m => m.IsMatch(typePair));
                     var expressionMapper = match as IObjectMapExpression;
                     if (expressionMapper != null)
-                        valueResolverExpr = expressionMapper.MapExpression(valueResolverExpr, destValueExpr,
+                        valueResolverExpr = expressionMapper.MapExpression(typeMapRegistry, configurationProvider, valueResolverExpr, destValueExpr,
                             ctxtParam);
                     else
                         valueResolverExpr = SetMap(propertyMap, valueResolverExpr, destValueExpr, ref propertyContext);

--- a/src/AutoMapper/IObjectMapper.cs
+++ b/src/AutoMapper/IObjectMapper.cs
@@ -30,10 +30,12 @@ namespace AutoMapper
         /// <summary>
         /// Builds a mapping expression equivalent to the base Map method
         /// </summary>
+        /// <param name="typeMapRegistry"></param>
+        /// <param name="configurationProvider"></param>
         /// <param name="sourceExpression">Source parameter</param>
         /// <param name="destExpression">Destination parameter</param>
         /// <param name="contextExpression">ResulotionContext parameter</param>
         /// <returns>Map expression</returns>
-        Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression);
+        Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression);
     }
 }

--- a/src/AutoMapper/Mappers/ArrayMapper.cs
+++ b/src/AutoMapper/Mappers/ArrayMapper.cs
@@ -43,7 +43,7 @@ namespace AutoMapper.Mappers
             return (context.DestinationType.IsArray) && (context.SourceType.IsEnumerableType());
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, TypeHelper.GetElementType(sourceExpression.Type), TypeHelper.GetElementType(destExpression.Type)), sourceExpression, contextExpression );
         }

--- a/src/AutoMapper/Mappers/AssignableMapper.cs
+++ b/src/AutoMapper/Mappers/AssignableMapper.cs
@@ -19,7 +19,7 @@ namespace AutoMapper.Mappers
             return context.DestinationType.IsAssignableFrom(context.SourceType);
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return sourceExpression;
         }

--- a/src/AutoMapper/Mappers/CollectionMapper.cs
+++ b/src/AutoMapper/Mappers/CollectionMapper.cs
@@ -48,7 +48,7 @@ namespace AutoMapper.Mappers
             return isMatch;
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, 
                 MapMethodInfo.MakeGenericMethod(sourceExpression.Type, TypeHelper.GetElementType(sourceExpression.Type), destExpression.Type, TypeHelper.GetElementType(destExpression.Type)),

--- a/src/AutoMapper/Mappers/ConvertMapper.cs
+++ b/src/AutoMapper/Mappers/ConvertMapper.cs
@@ -491,7 +491,7 @@ namespace AutoMapper.Mappers
             : _converterFuncs[context.Types].DynamicInvoke(context.SourceValue);
 
         public bool IsMatch(TypePair types) => _converters.ContainsKey(types);
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             var typeMap = new TypePair(sourceExpression.Type, destExpression.Type);
             return _converters[typeMap].ReplaceParameters(sourceExpression);

--- a/src/AutoMapper/Mappers/DictionaryMapper.cs
+++ b/src/AutoMapper/Mappers/DictionaryMapper.cs
@@ -55,7 +55,7 @@ namespace AutoMapper.Mappers
                     .Invoke(null, new[] { context.SourceValue, context.DestinationValue, context });
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             Type genericSourceDictType = sourceExpression.Type.GetDictionaryType();
             Type sourceKeyType = genericSourceDictType.GetTypeInfo().GenericTypeArguments[0];

--- a/src/AutoMapper/Mappers/DynamicMappers.cs
+++ b/src/AutoMapper/Mappers/DynamicMappers.cs
@@ -59,7 +59,7 @@ namespace AutoMapper.Mappers
             return context.SourceType.IsDynamic() && !context.DestinationType.IsDynamic();
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression, destExpression, contextExpression);
         }
@@ -115,7 +115,7 @@ namespace AutoMapper.Mappers
             return context.DestinationType.IsDynamic() && !context.SourceType.IsDynamic();
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression, destExpression, contextExpression);
         }

--- a/src/AutoMapper/Mappers/EnumMapper.cs
+++ b/src/AutoMapper/Mappers/EnumMapper.cs
@@ -30,7 +30,7 @@ namespace AutoMapper.Mappers
             return destEnumType != null && context.SourceType == typeof(string);
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Call(null, MapMethodInfo.MakeGenericMethod(destExpression.Type), sourceExpression);
         }
@@ -76,7 +76,7 @@ namespace AutoMapper.Mappers
             return sourceEnumType != null && destEnumType != null;
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression);
         }
@@ -172,7 +172,7 @@ namespace AutoMapper.Mappers
             return false;
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression);
         }

--- a/src/AutoMapper/Mappers/EnumerableMapper.cs
+++ b/src/AutoMapper/Mappers/EnumerableMapper.cs
@@ -50,7 +50,7 @@ namespace AutoMapper.Mappers
                    && context.SourceType.IsEnumerableType();
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type, TypeHelper.GetElementType(destExpression.Type)), sourceExpression, destExpression, contextExpression);
         }

--- a/src/AutoMapper/Mappers/EnumerableToDictionaryMapper.cs
+++ b/src/AutoMapper/Mappers/EnumerableToDictionaryMapper.cs
@@ -56,7 +56,7 @@ namespace AutoMapper.Mappers
                     .Invoke(null, new[] { context.SourceValue, context.DestinationValue, context });
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             Type sourceElementType = TypeHelper.GetElementType(sourceExpression.Type);
             Type genericDestDictType = destExpression.Type;

--- a/src/AutoMapper/Mappers/ExplicitConversionOperatorMapper.cs
+++ b/src/AutoMapper/Mappers/ExplicitConversionOperatorMapper.cs
@@ -34,7 +34,7 @@ namespace AutoMapper.Mappers
             return sourceTypeMethod ?? destTypeMethod;
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             var implicitOperator = GetExplicitConversionOperator(new TypePair(sourceExpression.Type, destExpression.Type));
             return Expression.Call(null, implicitOperator, sourceExpression);

--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -59,7 +59,7 @@ namespace AutoMapper.Mappers
                    && context.DestinationType != typeof (LambdaExpression);
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression, contextExpression);
         }

--- a/src/AutoMapper/Mappers/FlagsEnumMapper.cs
+++ b/src/AutoMapper/Mappers/FlagsEnumMapper.cs
@@ -41,7 +41,7 @@ namespace AutoMapper.Mappers
                    && destEnumType.GetCustomAttributes(typeof (FlagsAttribute), false).Any();
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression, contextExpression);
         }

--- a/src/AutoMapper/Mappers/HashSetMapper.cs
+++ b/src/AutoMapper/Mappers/HashSetMapper.cs
@@ -48,7 +48,7 @@ namespace AutoMapper.Mappers
         }
 
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null,
                 MapMethodInfo.MakeGenericMethod(TypeHelper.GetElementType(sourceExpression.Type), TypeHelper.GetElementType(destExpression.Type)),

--- a/src/AutoMapper/Mappers/ImplicitConversionOperatorMapper.cs
+++ b/src/AutoMapper/Mappers/ImplicitConversionOperatorMapper.cs
@@ -37,7 +37,7 @@ namespace AutoMapper.Mappers
         }
 
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             var implicitOperator = GetImplicitConversionOperator(new TypePair(sourceExpression.Type, destExpression.Type));
             return Expression.Call(null, implicitOperator, sourceExpression);

--- a/src/AutoMapper/Mappers/MultidimensionalArrayMapper.cs
+++ b/src/AutoMapper/Mappers/MultidimensionalArrayMapper.cs
@@ -68,7 +68,7 @@ namespace AutoMapper.Mappers
             return context.DestinationType.IsArray && context.DestinationType.GetArrayRank() > 1 && context.SourceType.IsEnumerableType();
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(destExpression.Type, sourceExpression.Type, TypeHelper.GetElementType(sourceExpression.Type)), sourceExpression, contextExpression);
         }

--- a/src/AutoMapper/Mappers/NameValueCollectionMapper.cs
+++ b/src/AutoMapper/Mappers/NameValueCollectionMapper.cs
@@ -36,7 +36,7 @@ namespace AutoMapper.Mappers
                 context.DestinationType == typeof (NameValueCollection);
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo, sourceExpression);
         }

--- a/src/AutoMapper/Mappers/NullableMapper.cs
+++ b/src/AutoMapper/Mappers/NullableMapper.cs
@@ -16,7 +16,7 @@ namespace AutoMapper.Mappers
             return context.DestinationType.IsNullableType();
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return sourceExpression;
         }

--- a/src/AutoMapper/Mappers/NullableSourceMapper.cs
+++ b/src/AutoMapper/Mappers/NullableSourceMapper.cs
@@ -26,7 +26,7 @@ namespace AutoMapper.Mappers
             return context.SourceType.IsNullableType() && !context.DestinationType.IsNullableType() && context.DestinationType == context.SourceType.GetTypeOfNullable();
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(destExpression.Type), sourceExpression);
         }

--- a/src/AutoMapper/Mappers/PrimitiveArrayMapper.cs
+++ b/src/AutoMapper/Mappers/PrimitiveArrayMapper.cs
@@ -61,7 +61,7 @@ namespace AutoMapper.Mappers
                        .Equals(TypeHelper.GetElementType(context.SourceType)));
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             Type sourceElementType = TypeHelper.GetElementType(sourceExpression.Type);
             Type destElementType = TypeHelper.GetElementType(destExpression.Type);

--- a/src/AutoMapper/Mappers/ReadOnlyCollectionMapper.cs
+++ b/src/AutoMapper/Mappers/ReadOnlyCollectionMapper.cs
@@ -47,7 +47,7 @@ namespace AutoMapper.Mappers
             return genericType == typeof (ReadOnlyCollection<>);
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, TypeHelper.GetElementType(sourceExpression.Type), TypeHelper.GetElementType(destExpression.Type)), sourceExpression, contextExpression);
         }

--- a/src/AutoMapper/Mappers/StringDictionaryMapper.cs
+++ b/src/AutoMapper/Mappers/StringDictionaryMapper.cs
@@ -37,7 +37,7 @@ namespace AutoMapper.Mappers
                 .Invoke(null, new[] { membersDictionary, context.DestinationValue, context });
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             var membersDictionaryExpression = Expression.Call(null, MembersDictionaryMethodInfo, contextExpression);
 
@@ -77,7 +77,7 @@ namespace AutoMapper.Mappers
             return MapMethodInfo.MakeGenericMethod(context.DestinationType).Invoke(null, new []{context.SourceValue, context});
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(destExpression.Type), sourceExpression, contextExpression);
         }

--- a/src/AutoMapper/Mappers/StringMapper.cs
+++ b/src/AutoMapper/Mappers/StringMapper.cs
@@ -14,7 +14,7 @@ namespace AutoMapper.Mappers
             return context.DestinationType == typeof(string) && context.SourceType != typeof(string);
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Condition(Expression.Equal(sourceExpression, Expression.Default(sourceExpression.Type)),
                 Expression.Constant(null, typeof (string)),

--- a/src/AutoMapper/Mappers/TypeConverterMapper.cs
+++ b/src/AutoMapper/Mappers/TypeConverterMapper.cs
@@ -56,7 +56,7 @@ namespace AutoMapper.Mappers
                     destTypeConverter.CanConvertFrom(context.SourceType));
         }
 
-        public Expression MapExpression(Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression, contextExpression);
         }

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -8,15 +8,15 @@ namespace Benchmark
 	{
 		public static void Main(string[] args)
 		{
-            //var mappers = new Dictionary<string, IObjectToObjectMapper[]>
-            //    {
-            //        { "Flattening", new IObjectToObjectMapper[] { new FlatteningMapper(), new ManualMapper(), new EquilvalentManualMapper(),  } },
-            //        { "Ctors", new IObjectToObjectMapper[] { new CtorMapper(), new ManualCtorMapper(),  } }
-            //    };
             var mappers = new Dictionary<string, IObjectToObjectMapper[]>
-            {
-                {"Flattening", new IObjectToObjectMapper[] {new FlatteningMapper()}},
-            };
+                {
+                    { "Flattening", new IObjectToObjectMapper[] { new FlatteningMapper(), new ManualMapper(), new EquilvalentManualMapper(),  } },
+                    { "Ctors", new IObjectToObjectMapper[] { new CtorMapper(), new ManualCtorMapper(),  } }
+                };
+            //var mappers = new Dictionary<string, IObjectToObjectMapper[]>
+            //{
+            //    {"Flattening", new IObjectToObjectMapper[] {new FlatteningMapper()}},
+            //};
 
 
             foreach (var pair in mappers)

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -8,15 +8,15 @@ namespace Benchmark
 	{
 		public static void Main(string[] args)
 		{
-            var mappers = new Dictionary<string, IObjectToObjectMapper[]>
-                {
-                    { "Flattening", new IObjectToObjectMapper[] { new FlatteningMapper(), new ManualMapper(), new EquilvalentManualMapper(),  } },
-                    { "Ctors", new IObjectToObjectMapper[] { new CtorMapper(), new ManualCtorMapper(),  } }
-                };
             //var mappers = new Dictionary<string, IObjectToObjectMapper[]>
-            //{
-            //    {"Flattening", new IObjectToObjectMapper[] {new FlatteningMapper()}},
-            //};
+            //    {
+            //        { "Flattening", new IObjectToObjectMapper[] { new FlatteningMapper(), new ManualMapper(), new EquilvalentManualMapper(),  } },
+            //        { "Ctors", new IObjectToObjectMapper[] { new CtorMapper(), new ManualCtorMapper(),  } }
+            //    };
+            var mappers = new Dictionary<string, IObjectToObjectMapper[]>
+            {
+                {"Flattening", new IObjectToObjectMapper[] {new FlatteningMapper()}},
+            };
 
 
             foreach (var pair in mappers)


### PR DESCRIPTION
@TylerCarlson1 thoughts? The idea is to expand the expression mappers to be able to examine config and pre-wire some of the decisions they make. Source value/collection null etc.

Also makes the actual mapping part a little more obvious, it's just a LINQ select/toarray, surrounded by expressions that have the extra juice.