### PR TITLE
Better Array Mappings

### DIFF
--- a/src/AutoMapper/Mappers/ArrayMapper.cs
+++ b/src/AutoMapper/Mappers/ArrayMapper.cs
@@ -18,8 +18,13 @@ namespace AutoMapper.Mappers
         {
             var itemContext = new ResolutionContext(context);
 
-            return source.Select(item => newItemFunc(item, itemContext))
-                .ToArray();
+            var count = source.Count();
+            var array = new TDestination[count];
+
+            int i = 0;
+            foreach (var item in source)
+                array[i++] = newItemFunc(item, itemContext);
+            return array;
         }
 
         public bool IsMatch(TypePair context)


### PR DESCRIPTION
ToArray has to double enumerate.
You could go a bit further and make array mapper pure expression based, and from that you can use source.Length in cases of array instead of relying on source.Count() which will save you time in array to array mappings.  That can be saved for a later PR I guess