### PR TITLE
Remove null checks from map when src allready checked

### DIFF
--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -210,7 +210,7 @@
             {
                 mapperFunc =
                     Condition(Equal(srcParam, Default(typeMap.SourceType)),
-                        Default(typeMap.DestinationType), mapperFunc);
+                        Default(typeMap.DestinationType), mapperFunc.RemoveIfNotNull(srcParam));
                 //mapperFunc = (source, context, destFunc) => source == default(TSource) ? default(TDestination) : inner(source, context, destFunc);
             }
 


### PR DESCRIPTION
This time I think I got it.  Seems to work on all maps including sub property null checks.  Because when the expression is created it takes it out, and when replace parameters it won't have that null check.