### PR TITLE
[Example] Compiled lambda Performance

### DIFF
--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -256,6 +256,7 @@
             ParameterExpression ctxtParam)
         {
             var pmExpression = CreatePropertyMapFunc(pm, configurationProvider, registry, srcParam, destParam, ctxtParam);
+            return pmExpression;
 
             if (pmExpression == null)
                 return null;

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -221,6 +221,18 @@ namespace AutoMapper
 
             return func(source, destination, context);
         }
+        public Func<TSource, TDestination, ResolutionContext, TDestination> Func<TSource, TDestination>(TSource source, out ResolutionContext context)
+        {
+            var types = TypePair.Create(source, null, typeof(TSource), typeof(TDestination));
+
+            var func = _configurationProvider.GetMapperFunc<TSource, TDestination>(types);
+
+            var destination = default(TDestination);
+
+            context = new ResolutionContext(_defaultMappingOptions, this);
+
+            return func;
+        }
 
         TDestination IMapper.Map<TSource, TDestination>(TSource source, Action<IMappingOperationOptions<TSource, TDestination>> opts)
         {

--- a/src/Benchmark/FlatteningMapper.cs
+++ b/src/Benchmark/FlatteningMapper.cs
@@ -369,6 +369,8 @@ namespace Benchmark.Flattening
     {
         private ModelObject _source;
         private IMapper _mapper;
+        private Func<ModelObject, ModelDto, ResolutionContext, ModelDto> _func;
+        private ResolutionContext _resolutionContext;
 
         public string Name
         {
@@ -390,6 +392,7 @@ namespace Benchmark.Flattening
                 cfg.CreateMap<Model9, Dto9>();
                 cfg.CreateMap<Model10, Dto10>();
                 cfg.CreateMap<ModelObject, ModelDto>();
+                cfg.AllowNullDestinationValues = false;
             });
             config.AssertConfigurationIsValid();
             _source = new ModelObject
@@ -413,10 +416,12 @@ namespace Benchmark.Flattening
                 },
             };
             _mapper = config.CreateMapper();
+            _func = (_mapper as Mapper).Func<ModelObject, ModelDto>(_source, out _resolutionContext);
         }
 
         public object Map()
         {
+            return _func(_source, null, _resolutionContext);
             return _mapper.Map<ModelObject, ModelDto>(_source);
         }
     }

--- a/src/Benchmark/FlatteningMapper.cs
+++ b/src/Benchmark/FlatteningMapper.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Linq.Expressions;
 using AutoMapper;
+using AutoMapper.Mappers;
 
 namespace Benchmark.Flattening
 {
@@ -461,14 +463,16 @@ namespace Benchmark.Flattening
 
         public object Map()
         {
-            return new ModelDto
-            {
-                BaseDate = _source.BaseDate,
-                Sub2ProperName = _source.Sub2.ProperName,
-                SubProperName = _source.Sub.ProperName,
-                SubSubSubIAmACoolProperty = _source.Sub.SubSub.IAmACoolProperty,
-                SubWithExtraNameProperName = _source.SubWithExtraName.ProperName
-            };
+            ModelDto dest = null;
+            dest = dest ?? new ModelDto();
+            dest.BaseDate = _source?.BaseDate ?? default(DateTime);
+            dest.Sub2ProperName = _source?.Sub2?.ProperName ?? (string) ObjectCreator.CreateNonNullValue(typeof(string));
+            dest.SubProperName = _source?.Sub?.ProperName ?? (string) ObjectCreator.CreateNonNullValue(typeof(string));
+            dest.SubSubSubIAmACoolProperty = _source?.Sub?.SubSub?.IAmACoolProperty ??
+                                             (string) ObjectCreator.CreateNonNullValue(typeof(string));
+            dest.SubWithExtraNameProperName = _source?.SubWithExtraName?.ProperName ??
+                                              (string) ObjectCreator.CreateNonNullValue(typeof(string));
+            return dest;
         }
     }
 


### PR DESCRIPTION
Shows performance difference between compiled expression and actual code.  I can't compile a lamdba to match code since it's multiple lines but it shows the performance hit.  Code run matches expression.

All other things have been eliminated.  Finding function and resolution context generation.

FlattenMapper's compiled map func (No Sub Invokes just static method calls)
```
(src, dest, ctxt) =>
{
    var dest = dest ?? new ModelDto();
    dest.SubSubSubIAmACoolProperty = (((src == null) ? null : src.Sub == null) ? null : src.Sub.SubSub == null)
        ? null
        : src.Sub.SubSub.IAmACoolProperty ?? ((string)ObjectCreator.CreateNonNullValue(typeof(string)));
    dest.SubWithExtraNameProperName = ((src == null) ? null : src.SubWithExtraName == null) ? null : src.SubWithExtraName.ProperName ?? ((string)ObjectCreator.CreateNonNullValue(typeof(string)));
    dest.Sub2ProperName = ((src == null) ? null : src.Sub2 == null) ? null : src.Sub2.ProperName ?? ((string)ObjectCreator.CreateNonNullValue(typeof(string)));
    dest.SubProperName = ((src == null) ? null : src.Sub == null) ? null : src.Sub.ProperName ?? ((string)ObjectCreator.CreateNonNullValue(typeof(string)));
    dest.BaseDate = (src == null) ? default(DateTime) : src.BaseDate;
    return dest;
}
```

Look at FlatteningMappers as benchmarks

I get 10 time slower execution in Release and 2.4 times slower in Debug just from running the execution of the func.

Using CompileToMethod under the same tests the difference is 2%, basically nothing for Debug and 40% more in Release.  (Probably cause dynamic assembly isn't set to optimize code)