### PR TITLE
Measure only the map calls & remove unneeded attributes

### DIFF
--- a/src/AutoMapper/AssemblyInfo.cs
+++ b/src/AutoMapper/AssemblyInfo.cs
@@ -4,6 +4,6 @@ using System.Security;
 [assembly:CLSCompliant(true)]
 #if NET45
 [assembly: AllowPartiallyTrustedCallers]
-[assembly: SecurityTransparent]
-[assembly: SecurityRules(SecurityRuleSet.Level2, SkipVerificationInFullTrust = true)]
+//[assembly: SecurityTransparent]
+//[assembly: SecurityRules(SecurityRuleSet.Level2, SkipVerificationInFullTrust = true)]
 #endif

--- a/src/Benchmark/BenchEngine.cs
+++ b/src/Benchmark/BenchEngine.cs
@@ -28,7 +28,7 @@ namespace Benchmark
 
 			timer.Stop();
 
-			Console.WriteLine("{0}: - {1} - Mapping time: \t{2}s", _mapper.Name, _mode, timer.ElapsedMilliseconds/1000.0);
+			Console.WriteLine("{0}: - {1} - Mapping time: \t{2}s", _mapper.Name, _mode, timer.Elapsed.TotalSeconds);
 		}
 	}
 }

--- a/src/Benchmark/BenchEngine.cs
+++ b/src/Benchmark/BenchEngine.cs
@@ -16,14 +16,12 @@ namespace Benchmark
 
 		public void Start()
 		{
-			var timer = Stopwatch.StartNew();
-
 			_mapper.Initialize();
 			_mapper.Map();
 
-			timer.Start();
+            var timer = Stopwatch.StartNew();
 
-			for (int i = 0; i < 1000000; i++)
+            for(int i = 0; i < 1000000; i++)
 			{
 				_mapper.Map();
 			}

--- a/src/Benchmark/Program.cs
+++ b/src/Benchmark/Program.cs
@@ -4,8 +4,8 @@ using System.Security;
 using Benchmark.Flattening;
 
 [assembly: AllowPartiallyTrustedCallers]
-[assembly: SecurityTransparent]
-[assembly: SecurityRules(SecurityRuleSet.Level2, SkipVerificationInFullTrust = true)]
+//[assembly: SecurityTransparent]
+//[assembly: SecurityRules(SecurityRuleSet.Level2, SkipVerificationInFullTrust = true)]
 
 namespace Benchmark
 {
@@ -15,19 +15,18 @@ namespace Benchmark
 		{
             var mappers = new Dictionary<string, IObjectToObjectMapper[]>
                 {
-                    { "Flattening", new IObjectToObjectMapper[] { new FlatteningMapper(), new ManualMapper(), } },
+                    { "Flattening", new IObjectToObjectMapper[] { new FlatteningMapper() , new ManualMapper(), } },
                     { "Ctors", new IObjectToObjectMapper[] { new CtorMapper(), new ManualCtorMapper(),  } },
                     { "Complex", new IObjectToObjectMapper[] { new ComplexTypeMapper(), new ManualComplexTypeMapper() } },
                     { "Deep", new IObjectToObjectMapper[] { new DeepTypeMapper(), new ManualDeepTypeMapper() } }
-                };		
-
-			foreach (var pair in mappers)
-			{
-				foreach (var mapper in pair.Value)
-				{
-					new BenchEngine(mapper, pair.Key).Start();
-				}
-			}
+                };
+            foreach(var pair in mappers)
+            {
+                foreach(var mapper in pair.Value)
+                {
+                    new BenchEngine(mapper, pair.Key).Start();
+                }
+            }
 		}
 	}
 }


### PR DESCRIPTION
You wouldn't think this is so complicated. Third time's a charm :)
About @TylerCarlson1's version.
Stopwatch ticks are different from DateTime.Ticks. Each tick in the DateTime.Ticks value represents one 100-nanosecond interval. Each tick in the ElapsedTicks value represents the time interval equal to 1 second divided by the Frequency.
https://msdn.microsoft.com/en-us/library/system.diagnostics.stopwatch.elapsedticks(v=vs.110).aspx