### PR TITLE
[WIP] Fix #1352

### DIFF
--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -97,10 +97,7 @@ namespace AutoMapper.QueryableExtensions
             var visitCount = typePairCount.AddOrUpdate(request, 0, (tp, i) => i + 1);
             if (typeMap.MaxDepth > 0 && visitCount >= typeMap.MaxDepth)
             {
-                if (_configurationProvider.AllowNullDestinationValues)
-                {
-                    return null;
-                }
+                // Don't null it cause problems
             }
             else
             {


### PR DESCRIPTION
At one point in 5.0 development you set AllowNullDestinationValues = true by default.
That caused the null reference exception in #1352.  It seems to fix it by taking that out and allowing the default constructor to work.  As far as I can tell this check needs to go, or you need to tell people to set AllowNullDestinationValues to true if using MaxDepth and Projection.

This is WIP because I don't fully know the effects of this change.  I don't know if you should return a default of return type instead instead of defaulting to a newing up of an object.  Either one is better than exception.