### PR TITLE
[WIP] Transforms property maps based on a profile

### DIFF
--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -74,6 +74,9 @@
 
             var mapperFunc = CreateMapperFunc(typeMap, srcParam, destParam, ctxtParam, assignmentFunc);
 
+            foreach (var expressionVisitor in typeMap.Profile.AfterBuildMapFuncVisitors)
+                mapperFunc = expressionVisitor.Visit(mapperFunc);
+
             var lambdaExpr = Lambda(mapperFunc, srcParam, destParam, ctxtParam);
 
             return lambdaExpr;

--- a/src/AutoMapper/IProfileConfiguration.cs
+++ b/src/AutoMapper/IProfileConfiguration.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using System.Reflection;
 using AutoMapper.Mappers;
 
@@ -20,6 +21,7 @@ namespace AutoMapper
         bool CreateMissingTypeMaps { get; }
         IEnumerable<Action<TypeMap, IMappingExpression>> AllTypeMapActions { get; }
         IEnumerable<Action<PropertyMap, IMemberConfigurationExpression>> AllPropertyMapActions { get; }
+        IList<ExpressionVisitor> AfterBuildMapFuncVisitors { get; }
 
         IMemberConfiguration DefaultMemberConfig { get; }
         /// <summary>

--- a/src/AutoMapper/IProfileExpression.cs
+++ b/src/AutoMapper/IProfileExpression.cs
@@ -1,3 +1,5 @@
+using System.Linq.Expressions;
+
 namespace AutoMapper
 {
     using System;
@@ -51,6 +53,14 @@ namespace AutoMapper
         /// <param name="memberList">Member list to validate</param>
         /// <returns>Mapping expression for more configuration options</returns>
         IMappingExpression CreateMap(Type sourceType, Type destinationType, MemberList memberList);
+
+        /// <summary>
+        /// Transforms PropertyMap with source and destination Type
+        /// </summary>
+        /// <typeparam name="TSource"></typeparam>
+        /// <typeparam name="TDestination"></typeparam>
+        /// <param name="transformExpression"></param>
+        void TransformPropertyMap<TSource>(Expression<Func<TSource, TSource>> transformExpression);
 
         /// <summary>
         /// Clear the list of recognized prefixes.

--- a/src/AutoMapper/IProfileExpression.cs
+++ b/src/AutoMapper/IProfileExpression.cs
@@ -63,6 +63,14 @@ namespace AutoMapper
         void TransformPropertyMap<TSource>(Expression<Func<TSource, TSource>> transformExpression);
 
         /// <summary>
+        /// Transforms PropertyMap with source and destination Type
+        /// </summary>
+        /// <typeparam name="TSource"></typeparam>
+        /// <typeparam name="TDestination"></typeparam>
+        /// <param name="transformExpression"></param>
+        void TransformPropertyMap<TSource>(Expression<Func<TSource, TSource>> transformExpression, Func<PropertyMap, bool> predicateFunc);
+
+        /// <summary>
         /// Clear the list of recognized prefixes.
         /// </summary>
         void ClearPrefixes();

--- a/src/UnitTests/TransformMap.cs
+++ b/src/UnitTests/TransformMap.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Should;
+using Xunit;
+
+namespace AutoMapper.UnitTests
+{
+    public class TransformPropertyMap : AutoMapperSpecBase
+    {
+        DateTime _now = DateTime.Now;
+        private Destination _destination;
+        private Source _source;
+
+        public class Source
+        {
+            public string String { get; set; }
+
+            public DateTime Date { get; set; }
+
+            public DateTime DateToString { get; set; }
+        }
+
+        public class Destination
+        {
+            public string String { get; set; }
+
+            public DateTime Date { get; set; }
+
+            public string DateToString { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMissingTypeMaps = true;
+            cfg.TransformPropertyMap<string>(s => $"Transformed({s})");
+            cfg.TransformPropertyMap<DateTime>(s => s.AddDays(1));
+            cfg.CreateProfile("Profile", p => p.CreateMap<Source, Source>());
+        });
+
+        protected override void Because_of()
+        {
+            _source = new Source
+            {
+                Date = _now,
+                DateToString = _now,
+                String = "Test String"
+            };
+            _destination = Mapper.Map<Destination>(_source);
+        }
+
+        [Fact]
+        public void Sould_TransformPropertyMap_Date_Using_DateTime_Transform()
+        {
+            _destination.Date.ShouldEqual(_now.AddDays(1));
+        }
+
+        [Fact]
+        public void Sould_TransformPropertyMap_String_String_Transform()
+        {
+            _destination.String.ShouldEqual("Transformed(Test String)");
+        }
+
+        [Fact]
+        public void Sould_TransformPropertyMap_DateToString_String_Transform_But_Not_Date_Transform()
+        {
+            _destination.DateToString.ShouldEqual($"Transformed({_now})");
+        }
+
+        [Fact]
+        public void Sould_Not_TransformPropertyMap_In_Different_Profile()
+        {
+            var source = Mapper.Map<Source>(_source);
+            source.ShouldNotEqual(_source);
+            source.Date.ShouldEqual(_source.Date);
+            source.String.ShouldEqual(_source.String);
+            source.DateToString.ShouldEqual(_source.DateToString);
+        }
+    }
+}

--- a/src/UnitTests/TransformMap.cs
+++ b/src/UnitTests/TransformMap.cs
@@ -33,6 +33,7 @@ namespace AutoMapper.UnitTests
             cfg.CreateMissingTypeMaps = true;
             cfg.TransformPropertyMap<string>(s => $"Transformed({s})");
             cfg.TransformPropertyMap<DateTime>(s => s.AddDays(1));
+            cfg.TransformPropertyMap<string>(s => s + "ToString", pm => pm.DestinationProperty.Name.EndsWith("ToString"));
             cfg.CreateProfile("Profile", p => p.CreateMap<Source, Source>());
         });
 
@@ -60,9 +61,9 @@ namespace AutoMapper.UnitTests
         }
 
         [Fact]
-        public void Sould_TransformPropertyMap_DateToString_String_Transform_But_Not_Date_Transform()
+        public void Sould_TransformPropertyMap_Based_On_Conditions_And_Dest_Type_Only()
         {
-            _destination.DateToString.ShouldEqual($"Transformed({_now})");
+            _destination.DateToString.ShouldEqual($"Transformed({_now})ToString");
         }
 
         [Fact]

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -328,6 +328,7 @@
     <Compile Include="Tests\MapperTests.cs" />
     <Compile Include="Tests\TypeInfoSpecs.cs" />
     <Compile Include="Tests\TypeMapFactorySpecs.cs" />
+    <Compile Include="TransformMap.cs" />
     <Compile Include="TypeConverters.cs" />
     <Compile Include="UsingEngineInsideMap.cs" />
     <Compile Include="ValueTypes.cs" />


### PR DESCRIPTION
Possible solution for #1414

Didn't implement version for ForMember because well, MapFrom does the same thing.  Also there's no condition, but I could possibly put one in.  It's kind of hard because it's expression based, but it's possible.

Also there's only one type, the destinationType, so if you use a string converter it will wrap around anything set to string, even if the source type is different.  Also since it's the last thing, it will wrap all possible scenarios of property map, without effecting how they work.

One BIG Issue is making sure these expression visitors only work where they are intended and not break functionality IObjectMapper expressions that are generated.

And later you can make up more functions to do even crazier things.  Even allow people to make quick hacks for issues without having to build a new release that would fix people's problems.
Like have the null checks actually not set the property if any of them are null instead of setting the property to null.  Or taking out the null checks completely if you want the exception to happen or you need the performance boost.
