### PR TITLE
Adding back in destinations for value resolvers; Added new member val…

### DIFF
--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -116,7 +116,7 @@ namespace AutoMapper.Configuration
                 PropertyMapActions.Add(pm => pm.ValueResolverConfig = config);
             }
 
-            public void ResolveUsing<TSource, TSourceMember>(IValueResolver<TSource, TSourceMember> resolver, string memberName)
+            public void ResolveUsing<TSource, TDestination, TSourceMember, TDestMember>(IMemberValueResolver<TSource, TDestination, TSourceMember, TDestMember> resolver, string memberName)
             {
                 var config = new ValueResolverConfiguration(resolver)
                 {

--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -32,7 +32,7 @@ namespace AutoMapper.Configuration
         }
 
         public void ResolveUsing<TValueResolver>() 
-            where TValueResolver : IValueResolver<TSource, TMember>
+            where TValueResolver : IValueResolver<TSource, TDestination, TMember>
         {
             var config = new ValueResolverConfiguration(typeof(TValueResolver));
 
@@ -40,7 +40,7 @@ namespace AutoMapper.Configuration
         }
 
         public void ResolveUsing<TValueResolver, TSourceMember>(Expression<Func<TSource, TSourceMember>> sourceMember)
-            where TValueResolver : IValueResolver<TSourceMember, TMember>
+            where TValueResolver : IMemberValueResolver<TSource, TDestination, TSourceMember, TMember>
         {
             var config = new ValueResolverConfiguration(typeof (TValueResolver))
             {
@@ -51,7 +51,7 @@ namespace AutoMapper.Configuration
         }
 
         public void ResolveUsing<TValueResolver, TSourceMember>(string sourceMemberName)
-            where TValueResolver : IValueResolver<TSourceMember, TMember>
+            where TValueResolver : IMemberValueResolver<TSource, TDestination, TSourceMember, TMember>
         {
             var config = new ValueResolverConfiguration(typeof (TValueResolver))
             {
@@ -61,14 +61,14 @@ namespace AutoMapper.Configuration
             PropertyMapActions.Add(pm => pm.ValueResolverConfig = config);
         }
 
-        public void ResolveUsing(IValueResolver<TSource, TMember> valueResolver)
+        public void ResolveUsing(IValueResolver<TSource, TDestination, TMember> valueResolver)
         {
             var config = new ValueResolverConfiguration(valueResolver);
 
             PropertyMapActions.Add(pm => pm.ValueResolverConfig = config);
         }
 
-        public void ResolveUsing<TSourceMember>(IValueResolver<TSourceMember, TMember> valueResolver, Expression<Func<TSource, TSourceMember>> sourceMember)
+        public void ResolveUsing<TSourceMember>(IMemberValueResolver<TSource, TDestination, TSourceMember, TMember> valueResolver, Expression<Func<TSource, TSourceMember>> sourceMember)
         {
             var config = new ValueResolverConfiguration(valueResolver)
             {
@@ -78,31 +78,41 @@ namespace AutoMapper.Configuration
             PropertyMapActions.Add(pm => pm.ValueResolverConfig = config);
         }
 
-        public void ResolveUsing<TSourceMember>(Func<TSource, TSourceMember> resolver)
+        public void ResolveUsing<TResult>(Func<TSource, TResult> resolver)
         {
             PropertyMapActions.Add(pm =>
             {
-                Expression<Func<TSource, TDestination, ResolutionContext, TSourceMember>> expr = (src, dest, ctxt) => resolver(src);
+                Expression<Func<TSource, TDestination, TMember, ResolutionContext, TResult>> expr = (src, dest, destMember, ctxt) => resolver(src);
 
                 pm.CustomResolver = expr;
             });
         }
 
-        public void ResolveUsing<TSourceMember>(Func<TSource, TMember, TSourceMember> resolver)
+        public void ResolveUsing<TResult>(Func<TSource, TDestination, TResult> resolver)
         {
             PropertyMapActions.Add(pm =>
             {
-                Expression<Func<TSource, TMember, ResolutionContext, TSourceMember>> expr = (src, dest, ctxt) => resolver(src, dest);
+                Expression<Func<TSource, TDestination, TMember, ResolutionContext, TResult>> expr = (src, dest, destMember, ctxt) => resolver(src, dest);
 
                 pm.CustomResolver = expr;
             });
         }
 
-        public void ResolveUsing<TSourceMember>(Func<TSource, TMember, ResolutionContext, TSourceMember> resolver)
+        public void ResolveUsing<TResult>(Func<TSource, TDestination, TMember, TResult> resolver)
         {
             PropertyMapActions.Add(pm =>
             {
-                Expression<Func<TSource, TMember, ResolutionContext, TSourceMember>> expr = (src, dest, ctxt) => resolver(src, dest, ctxt);
+                Expression<Func<TSource, TDestination, TMember, ResolutionContext, TResult>> expr = (src, dest, destMember, ctxt) => resolver(src, dest, destMember);
+
+                pm.CustomResolver = expr;
+            });
+        }
+
+        public void ResolveUsing<TResult>(Func<TSource, TDestination, TMember, ResolutionContext, TResult> resolver)
+        {
+            PropertyMapActions.Add(pm =>
+            {
+                Expression<Func<TSource, TDestination, TMember, ResolutionContext, TResult>> expr = (src, dest, destMember, ctxt) => resolver(src, dest, destMember, ctxt);
 
                 pm.CustomResolver = expr;
             });

--- a/src/AutoMapper/IMemberConfigurationExpression.cs
+++ b/src/AutoMapper/IMemberConfigurationExpression.cs
@@ -23,7 +23,7 @@ namespace AutoMapper
         /// <typeparam name="TValueResolver">Value resolver type</typeparam>
         /// <returns>Value resolver configuration options</returns>
         void ResolveUsing<TValueResolver>() 
-            where TValueResolver : IValueResolver<TSource, TMember>;
+            where TValueResolver : IValueResolver<TSource, TDestination, TMember>;
 
         /// <summary>
         /// Resolve destination member using a custom value resolver from a source member
@@ -32,7 +32,7 @@ namespace AutoMapper
         /// <typeparam name="TSourceMember">Source member to supply</typeparam>
         /// <returns>Value resolver configuration options</returns>
         void ResolveUsing<TValueResolver, TSourceMember>(Expression<Func<TSource, TSourceMember>> sourceMember) 
-            where TValueResolver : IValueResolver<TSourceMember, TMember>;
+            where TValueResolver : IMemberValueResolver<TSource, TDestination, TSourceMember, TMember>;
 
         /// <summary>
         /// Resolve destination member using a custom value resolver from a source member
@@ -42,14 +42,14 @@ namespace AutoMapper
         /// <param name="sourceMemberName">Source member name</param>
         /// <returns>Value resolver configuration options</returns>
         void ResolveUsing<TValueResolver, TSourceMember>(string sourceMemberName) 
-            where TValueResolver : IValueResolver<TSourceMember, TMember>;
+            where TValueResolver : IMemberValueResolver<TSource, TDestination, TSourceMember, TMember>;
 
         /// <summary>
         /// Resolve destination member using a custom value resolver instance
         /// </summary>
         /// <param name="valueResolver">Value resolver instance to use</param>
         /// <returns>Resolution expression</returns>
-        void ResolveUsing(IValueResolver<TSource, TMember> valueResolver);
+        void ResolveUsing(IValueResolver<TSource, TDestination, TMember> valueResolver);
 
         /// <summary>
         /// Resolve destination member using a custom value resolver instance
@@ -57,14 +57,14 @@ namespace AutoMapper
         /// <param name="valueResolver">Value resolver instance to use</param>
         /// <param name="sourceMember">Source member to supply to value resolver</param>
         /// <returns>Resolution expression</returns>
-        void ResolveUsing<TSourceMember>(IValueResolver<TSourceMember, TMember> valueResolver, Expression<Func<TSource, TSourceMember>> sourceMember);
+        void ResolveUsing<TSourceMember>(IMemberValueResolver<TSource, TDestination, TSourceMember, TMember> valueResolver, Expression<Func<TSource, TSourceMember>> sourceMember);
 
         /// <summary>
         /// Resolve destination member using a custom value resolver callback. Used instead of MapFrom when not simply redirecting a source member
         /// This method cannot be used in conjunction with LINQ query projection
         /// </summary>
         /// <param name="resolver">Callback function to resolve against source type</param>
-        void ResolveUsing<TSourceMember>(Func<TSource, TSourceMember> resolver);
+        void ResolveUsing<TResult>(Func<TSource, TResult> resolver);
 
         /// <summary>
         /// Resolve destination member using a custom value resolver callback. Used instead of MapFrom when not simply redirecting a source member
@@ -72,8 +72,15 @@ namespace AutoMapper
         /// This method cannot be used in conjunction with LINQ query projection
         /// </summary>
         /// <param name="resolver">Callback function to resolve against source type</param>
-        void ResolveUsing<TSourceMember>(Func<TSource, TMember, TSourceMember> resolver);
+        void ResolveUsing<TResult>(Func<TSource, TDestination, TResult> resolver);
 
+        /// <summary>
+        /// Resolve destination member using a custom value resolver callback. Used instead of MapFrom when not simply redirecting a source member
+        /// Access both the source object and destination member for additional mapping, context items
+        /// This method cannot be used in conjunction with LINQ query projection
+        /// </summary>
+        /// <param name="resolver">Callback function to resolve against source type</param>
+        void ResolveUsing<TResult>(Func<TSource, TDestination, TMember, TResult> resolver);
 
         /// <summary>
         /// Resolve destination member using a custom value resolver callback. Used instead of MapFrom when not simply redirecting a source member
@@ -81,7 +88,7 @@ namespace AutoMapper
         /// This method cannot be used in conjunction with LINQ query projection
         /// </summary>
         /// <param name="resolver">Callback function to resolve against source type</param>
-        void ResolveUsing<TSourceMember>(Func<TSource, TMember, ResolutionContext, TSourceMember> resolver);
+        void ResolveUsing<TResult>(Func<TSource, TDestination, TMember, ResolutionContext, TResult> resolver);
 
         /// <summary>
         /// Specify the source member to map from. Can only reference a member on the <typeparamref name="TSource"/> type
@@ -202,6 +209,6 @@ namespace AutoMapper
         /// <param name="valueResolver">Value resolver instance to use</param>
         /// <param name="memberName">Source member to supply to value resolver</param>
         /// <returns>Resolution expression</returns>
-        void ResolveUsing<TSource, TSourceMember>(IValueResolver<TSource, TSourceMember> valueResolver, string memberName);
+        void ResolveUsing<TSource, TDestination, TSourceMember, TDestMember>(IMemberValueResolver<TSource, TDestination, TSourceMember, TDestMember> valueResolver, string memberName);
     }
 }

--- a/src/AutoMapper/IValueResolver.cs
+++ b/src/AutoMapper/IValueResolver.cs
@@ -3,15 +3,33 @@ namespace AutoMapper
     /// <summary>
     /// Extension point to provide custom resolution for a destination value
     /// </summary>
-	public interface IValueResolver<in TSource, TMember>
+	public interface IValueResolver<in TSource, in TDestination, TDestMember>
     {
         /// <summary>
         /// Implementors use source object to provide a destination object.
         /// </summary>
         /// <param name="source">Source object</param>
         /// <param name="destination">Destination object, if exists</param>
+        /// <param name="destMember">Destination member</param>
         /// <param name="context">The context of the mapping</param>
         /// <returns>Result, typically build from the source resolution result</returns>
-        TMember Resolve(TSource source, TMember destination, ResolutionContext context);
+        TDestMember Resolve(TSource source, TDestination destination, TDestMember destMember, ResolutionContext context);
+    }
+
+    /// <summary>
+    /// Extension point to provide custom resolution for a destination value
+    /// </summary>
+	public interface IMemberValueResolver<in TSource, in TDestination, in TSourceMember, TDestMember>
+    {
+        /// <summary>
+        /// Implementors use source object to provide a destination object.
+        /// </summary>
+        /// <param name="source">Source object</param>
+        /// <param name="destination">Destination object, if exists</param>
+        /// <param name="sourceMember">Source member</param>
+        /// <param name="destMember">Destination member</param>
+        /// <param name="context">The context of the mapping</param>
+        /// <returns>Result, typically build from the source resolution result</returns>
+        TDestMember Resolve(TSource source, TDestination destination, TSourceMember sourceMember, TDestMember destMember, ResolutionContext context);
     }
 }

--- a/src/AutoMapperSamples/CustomValueResolvers.cs
+++ b/src/AutoMapperSamples/CustomValueResolvers.cs
@@ -20,9 +20,9 @@ namespace AutoMapperSamples
 				public int Total { get; set; }
 			}
 
-			public class CustomResolver : IValueResolver<Source, int>
+			public class CustomResolver : IValueResolver<Source, Destination, int>
 			{
-			    public int Resolve(Source source, int dest, ResolutionContext context)
+			    public int Resolve(Source source, Destination d, int dest, ResolutionContext context)
 				{
 					return source.Value1 + source.Value2;
 				}

--- a/src/UnitTests/Bug/ParentChildResolversBug.cs
+++ b/src/UnitTests/Bug/ParentChildResolversBug.cs
@@ -47,9 +47,9 @@
         }
 
 
-        public class ParentResolver : IValueResolver<Source, ParentDestEnum?>
+        public class ParentResolver : IValueResolver<Source, ParentDest, ParentDestEnum?>
         {
-            public ParentDestEnum? Resolve(Source source, ParentDestEnum? dest, ResolutionContext context)
+            public ParentDestEnum? Resolve(Source source, ParentDest dest, ParentDestEnum? destMember, ResolutionContext context)
             {
                 switch (source.fieldCode)
                 {
@@ -61,9 +61,9 @@
             }
         }
 
-        public class Resolver : IValueResolver<Source, DestEnum?>
+        public class Resolver : IValueResolver<Source, ParentDest, DestEnum?>
         {
-            public DestEnum? Resolve(Source source, DestEnum? dest, ResolutionContext context)
+            public DestEnum? Resolve(Source source, ParentDest dest, DestEnum? destMember, ResolutionContext context)
             {
                 switch (source.fieldCode)
                 {

--- a/src/UnitTests/ContextItems.cs
+++ b/src/UnitTests/ContextItems.cs
@@ -17,9 +17,9 @@
                 public int Value { get; set; }
             }
 
-            public class ContextResolver : IValueResolver<int, int>
+            public class ContextResolver : IMemberValueResolver<Source, Dest, int, int>
             {
-                public int Resolve(int source, int dest, ResolutionContext context)
+                public int Resolve(Source src, Dest d, int source, int dest, ResolutionContext context)
                 {
                     return source + (int)context.Options.Items["Item"];
                 }
@@ -52,21 +52,13 @@
                 public int Value { get; set; }
             }
 
-            public class ContextResolver : IValueResolver<int, int>
-            {
-                public int Resolve(int source, int dest, ResolutionContext context)
-                {
-                    return source + (int)context.Options.Items["Item"];
-                }
-            }
-
             [Fact]
             public void Should_use_value_passed_in()
             {
                 var config = new MapperConfiguration(cfg =>
                 {
                     cfg.CreateMap<Source, Dest>()
-                        .ForMember(d => d.Value, opt => opt.ResolveUsing((src, d, ctxt) => (int)ctxt.Items["Item"] + 5));
+                        .ForMember(d => d.Value, opt => opt.ResolveUsing((src, d, member, ctxt) => (int)ctxt.Items["Item"] + 5));
                 });
 
                 var dest = config.CreateMapper().Map<Source, Dest>(new Source { Value = 5 }, opt => opt.Items["Item"] = 10);
@@ -87,21 +79,13 @@
                 public int Value1 { get; set; }
             }
 
-            public class ContextResolver : IValueResolver<int, int>
-            {
-                public int Resolve(int source, int dest, ResolutionContext context)
-                {
-                    return source + (int)context.Options.Items["Item"];
-                }
-            }
-
             [Fact]
             public void Should_use_value_passed_in()
             {
                 var config = new MapperConfiguration(cfg =>
                 {
                     cfg.CreateMap<Source, Dest>()
-                        .ForMember(d => d.Value1, opt => opt.ResolveUsing((source, d, context) => (int)context.Options.Items["Item"] + source.Value1));
+                        .ForMember(d => d.Value1, opt => opt.ResolveUsing((source, d, dMember, context) => (int)context.Options.Items["Item"] + source.Value1));
                 });
 
                 var dest = config.CreateMapper().Map<Source, Dest>(new Source { Value1 = 5 }, opt => { opt.Items["Item"] = 10; });

--- a/src/UnitTests/CustomMapping.cs
+++ b/src/UnitTests/CustomMapping.cs
@@ -93,9 +93,9 @@ namespace AutoMapper.UnitTests
             }
         }
 
-        class Resolver : IValueResolver<Source, Guid>
+        class Resolver : IValueResolver<Source, Destination, Guid>
         {
-            public Guid Resolve(Source model, Guid dest, ResolutionContext context)
+            public Guid Resolve(Source model, Destination d, Guid dest, ResolutionContext context)
             {
                 return _guid;
             }
@@ -333,17 +333,17 @@ namespace AutoMapper.UnitTests
             public int Value5 { get; set; }
         }
 
-        public class CustomResolver : IValueResolver<ModelObject, int>
+        public class CustomResolver : IValueResolver<ModelObject, ModelDto, int>
         {
-            public int Resolve(ModelObject source, int dest, ResolutionContext context)
+            public int Resolve(ModelObject source, ModelDto d, int dest, ResolutionContext context)
             {
                 return source.Value + 1;
             }
         }
 
-        public class CustomResolver2 : IValueResolver<ModelObject, int>
+        public class CustomResolver2 : IValueResolver<ModelObject, ModelDto, int>
         {
-            public int Resolve(ModelObject source, int dest, ResolutionContext context)
+            public int Resolve(ModelObject source, ModelDto d, int dest, ResolutionContext context)
             {
                 return source.Value2fff + 2;
             }
@@ -408,9 +408,9 @@ namespace AutoMapper.UnitTests
             public int SomeValue { get; set; }
         }
 
-        public class CustomResolver : IValueResolver<ModelSubObject, int>
+        public class CustomResolver : IMemberValueResolver<object, object, ModelSubObject, int>
         {
-            public int Resolve(ModelSubObject source, int ignored, ResolutionContext context)
+            public int Resolve(object s, object d, ModelSubObject source, int ignored, ResolutionContext context)
             {
                 return source.SomeValue + 1;
             }
@@ -453,9 +453,9 @@ namespace AutoMapper.UnitTests
             public int SomeValue { get; set; }
         }
 
-        public class CustomResolver : IValueResolver<int, int>
+        public class CustomResolver : IMemberValueResolver<object, object, int, int>
         {
-            public int Resolve(int source, int dest, ResolutionContext context)
+            public int Resolve(object s, object d, int source, int dest, ResolutionContext context)
             {
                 return source + 5;
             }
@@ -501,14 +501,6 @@ namespace AutoMapper.UnitTests
             public int Type { get; set; }
         }
 
-        public class CustomResolver : IValueResolver<int, int>
-        {
-            public int Resolve(int source, int dest, ResolutionContext context)
-            {
-                return source + 5;
-            }
-        }
-
         protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
         {
             cfg.CreateMap<Source, Dest>()
@@ -548,7 +540,7 @@ namespace AutoMapper.UnitTests
             public int Value { get; set; }
         }
 
-        public class CustomResolver : IValueResolver<int, int>
+        public class CustomResolver : IMemberValueResolver<object, object, int, int>
         {
             private readonly int _toAdd;
 
@@ -562,7 +554,7 @@ namespace AutoMapper.UnitTests
                 _toAdd = 10;
             }
 
-            public int Resolve(int source, int dest, ResolutionContext context)
+            public int Resolve(object s, object d, int source, int dest, ResolutionContext context)
             {
                 return source + _toAdd;
             }
@@ -608,7 +600,7 @@ namespace AutoMapper.UnitTests
             public int Value { get; set; }
         }
 
-        public class CustomResolver : IValueResolver<int, int>
+        public class CustomResolver : IMemberValueResolver<object, object, int, int>
         {
             private readonly int _toAdd;
 
@@ -622,7 +614,7 @@ namespace AutoMapper.UnitTests
                 _toAdd = 10;
             }
 
-            public int Resolve(int source, int dest, ResolutionContext context)
+            public int Resolve(object s, object d, int source, int dest, ResolutionContext context)
             {
                 return source + _toAdd;
             }
@@ -959,7 +951,7 @@ namespace AutoMapper.UnitTests
             public int Value { get; set; }
         }
 
-        public class CustomValueResolver : IValueResolver<int, int>
+        public class CustomValueResolver : IMemberValueResolver<object, object, int, int>
         {
             private readonly int _toAdd;
             public CustomValueResolver() { _toAdd = 11; }
@@ -969,7 +961,7 @@ namespace AutoMapper.UnitTests
                 _toAdd = toAdd;
             }
 
-            public int Resolve(int source, int dest, ResolutionContext context)
+            public int Resolve(object s, object d, int source, int dest, ResolutionContext context)
             {
                 return source + _toAdd;
             }
@@ -1010,9 +1002,9 @@ namespace AutoMapper.UnitTests
             public int Value { get; set; }
         }
 
-        public class CustomValueResolver : IValueResolver<int, int>
+        public class CustomValueResolver : IMemberValueResolver<object, object, int, int>
         {
-            public int Resolve(int source, int dest, ResolutionContext context)
+            public int Resolve(object s, object d, int source, int dest, ResolutionContext context)
             {
                 return dest;
             }
@@ -1051,13 +1043,13 @@ namespace AutoMapper.UnitTests
             public int DestinationValue { get; set; }
         }
 
-        public class CustomValueResolver : IValueResolver<int, object>
+        public class CustomValueResolver : IMemberValueResolver<object, object, int, object>
         {
             public CustomValueResolver()
             {
             }
 
-            public object Resolve(int source, object dest, ResolutionContext context)
+            public object Resolve(object s, object d, int source, object dest, ResolutionContext context)
             {
                 return source + 5;
             }

--- a/src/UnitTests/Enumerations.cs
+++ b/src/UnitTests/Enumerations.cs
@@ -293,17 +293,17 @@ namespace AutoMapper.Tests
 			public StatusForDto? Status { get; set; }
 		}
 
-		public class DtoStatusValueResolver : IValueResolver<Order, StatusForDto>
+		public class DtoStatusValueResolver : IValueResolver<Order, object, StatusForDto>
 		{
-			public StatusForDto Resolve(Order source, StatusForDto dest, ResolutionContext context)
+			public StatusForDto Resolve(Order source, object d, StatusForDto dest, ResolutionContext context)
 			{
 				return context.Mapper.Map<StatusForDto>(source.Status);
 			}
 		}
 
-		public class EnumValueResolver<TInputEnum, TOutputEnum> : IValueResolver<TInputEnum, TOutputEnum>
+		public class EnumValueResolver<TInputEnum, TOutputEnum> : IMemberValueResolver<object, object, TInputEnum, TOutputEnum>
 		{
-			public TOutputEnum Resolve(TInputEnum source, TOutputEnum dest, ResolutionContext context)
+			public TOutputEnum Resolve(object s, object d, TInputEnum source, TOutputEnum dest, ResolutionContext context)
 			{
 				return ((TOutputEnum)Enum.Parse(typeof(TOutputEnum), Enum.GetName(typeof(TInputEnum), source), false));
 			}

--- a/src/UnitTests/ForAllMaps.cs
+++ b/src/UnitTests/ForAllMaps.cs
@@ -37,9 +37,9 @@ namespace AutoMapper.UnitTests.Bug
             public int Number { get; set; }
         }
 
-        public class MinusOneResolver : IValueResolver<object, object>
+        public class MinusOneResolver : IValueResolver<object, object, object>
         {
-            public object Resolve(object source, object dest, ResolutionContext context)
+            public object Resolve(object source, object dest, object destMember, ResolutionContext context)
             {
                 return -1;
             }

--- a/src/UnitTests/ForAllMembers.cs
+++ b/src/UnitTests/ForAllMembers.cs
@@ -28,9 +28,9 @@
                 cfg.CreateMap<Source, Dest>();
             });
 
-            public class ConditionalValueResolver : IValueResolver<DateTime, DateTime>
+            public class ConditionalValueResolver : IMemberValueResolver<object, object, DateTime, DateTime>
             {
-                public DateTime Resolve(DateTime source, DateTime destination, ResolutionContext context)
+                public DateTime Resolve(object s, object d, DateTime source, DateTime destination, ResolutionContext context)
                 {
                     return source.AddDays(1);
                 }

--- a/src/UnitTests/MemberResolution.cs
+++ b/src/UnitTests/MemberResolution.cs
@@ -970,23 +970,23 @@ namespace AutoMapper.UnitTests
                 public string Postal { get; set; }
             }
 
-            public class StringCAPS : IValueResolver<string, string>
+            public class StringCAPS : IMemberValueResolver<object, object, string, string>
             {
-                public string Resolve(string source, string dest, ResolutionContext context)
+                public string Resolve(object s, object d, string source, string dest, ResolutionContext context)
                 {
                     return source.ToUpper();
                 }
             }
 
-            public class StringLower : IValueResolver<string, string>
+            public class StringLower : IMemberValueResolver<object, object, string, string>
             {
-                public string Resolve(string source, string dest, ResolutionContext context)
+                public string Resolve(object s, object d, string source, string dest, ResolutionContext context)
                 {
                     return source.ToLower();
                 }
             }
 
-            public class StringPadder : IValueResolver<string, string>
+            public class StringPadder : IMemberValueResolver<object, object, string, string>
             {
                 private readonly int _desiredLength;
 
@@ -995,7 +995,7 @@ namespace AutoMapper.UnitTests
                     _desiredLength = desiredLength;
                 }
 
-                public string Resolve(string source, string dest, ResolutionContext context)
+                public string Resolve(object s, object d, string source, string dest, ResolutionContext context)
                 {
                     return source.PadLeft(_desiredLength);
                 }

--- a/src/UnitTests/NestedContainers.cs
+++ b/src/UnitTests/NestedContainers.cs
@@ -10,7 +10,7 @@ namespace AutoMapper.UnitTests
         {
             private Dest _dest;
 
-            public class FooResolver : IValueResolver<int, int>
+            public class FooResolver : IMemberValueResolver<Source, Dest, int, int>
             {
                 private readonly int _value;
 
@@ -24,15 +24,15 @@ namespace AutoMapper.UnitTests
                     _value = value;
                 }
 
-                public int Resolve(int source, int dest, ResolutionContext context)
+                public int Resolve(Source s, Dest d, int source, int dest, ResolutionContext context)
                 {
                     return source + _value;
                 }
             }
 
-            public class BarResolver : IValueResolver<int, int>
+            public class BarResolver : IMemberValueResolver<Source, Dest, int, int>
             {
-                public int Resolve(int source, int dest, ResolutionContext context)
+                public int Resolve(Source s, Dest d, int source, int dest, ResolutionContext context)
                 {
                     return source + 1;
                 }

--- a/src/UnitTests/NullBehavior.cs
+++ b/src/UnitTests/NullBehavior.cs
@@ -205,9 +205,9 @@ namespace AutoMapper.UnitTests
 
 		public class When_using_a_custom_resolver_and_the_source_value_is_null : NonValidatingSpecBase
 		{
-			public class NullResolver : IValueResolver<string, string>
+			public class NullResolver : IMemberValueResolver<Source, Destination, string, string>
 			{
-				public string Resolve(string source, string dest, ResolutionContext context)
+				public string Resolve(Source s, Destination d, string source, string dest, ResolutionContext context)
 				{
 					if (source == null)
 						return "jon";

--- a/src/UnitTests/UsingEngineInsideMap.cs
+++ b/src/UnitTests/UsingEngineInsideMap.cs
@@ -29,8 +29,8 @@
                 .ForMember(dest => dest.Child,
                     opt =>
                         opt.ResolveUsing(
-                            (src, dest, context) =>
-                                context.Mapper.Map(src, dest, typeof (Source), typeof (ChildDest), context)));
+                            (src, dest, destMember, context) =>
+                                context.Mapper.Map(src, destMember, typeof (Source), typeof (ChildDest), context)));
             cfg.CreateMap<Source, ChildDest>();
         });
 


### PR DESCRIPTION
…ue resolvers type.

This was necessary to be able to access destination values in a value resolver since they're gone from the resolution context.