### PR TITLE
Enumerators

### DIFF
--- a/src/AutoMapper/Mappers/ArrayMapper.cs
+++ b/src/AutoMapper/Mappers/ArrayMapper.cs
@@ -65,8 +65,8 @@ namespace AutoMapper.Mappers
             //return array;
 
             var countParam = Parameter(typeof(int), "count");
-            var arrayParam = Parameter(destExpression.Type, "array");
-            var indexParam = Parameter(typeof(int), "i");
+            var arrayParam = Parameter(destExpression.Type, "destinationArray");
+            var indexParam = Parameter(typeof(int), "destinationArrayIndex");
 
             var actions = new List<Expression>();
             var parameters = new List<ParameterExpression> { countParam, arrayParam, indexParam };

--- a/src/Benchmark/FlatteningMapper.cs
+++ b/src/Benchmark/FlatteningMapper.cs
@@ -232,13 +232,13 @@ namespace Benchmark.Flattening
 
             public Foo Foo1 { get; set; }
 
-            public IEnumerable<Foo> Foos { get; set; }
+            public List<Foo> Foos { get; set; }
 
             public Foo[] FooArr { get; set; }
 
             public int[] IntArr { get; set; }
 
-            public IEnumerable<int> Ints { get; set; }
+            public int[] Ints { get; set; }
         }
 
     }

--- a/src/Benchmark/FlatteningMapper.cs
+++ b/src/Benchmark/FlatteningMapper.cs
@@ -67,7 +67,7 @@ namespace Benchmark.Flattening
             public Address Address { get; set; }
             public Address HomeAddress { get; set; }
             public Address[] Addresses { get; set; }
-            public ICollection<Address> WorkAddresses { get; set; }
+            public List<Address> WorkAddresses { get; set; }
         }
 
         public class CustomerDTO


### PR DESCRIPTION
Generate better enumeration code for concrete types. Avoid allocations and interface dispatch by using the enumerator pattern for collections and a for loop for arrays.