### PR TITLE
Only doing null fixing on custom member mappings when there are only …

### DIFF
--- a/src/UnitTests/Bug/NullableBytesAndEnums.cs
+++ b/src/UnitTests/Bug/NullableBytesAndEnums.cs
@@ -70,4 +70,43 @@ namespace AutoMapper.UnitTests.Bug
             _destination.Value.ShouldEqual(2);
         }
     }
+
+    public class NullableShortWithCustomMapFrom : AutoMapperSpecBase
+    {
+        private Destination _destination;
+
+        public class Source
+        {
+            public short Value { get; set; }
+        }
+
+        public class Destination
+        {
+            public short? Value { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>()
+                .ForMember(t => t.Value, opts => opts.MapFrom(s => s.Value > 0 ? s.Value : default(short?)));
+        });
+
+        protected override void Because_of()
+        {
+        }
+
+        [Fact]
+        public void Should_map_the_value()
+        {
+            var destination = Mapper.Map<Source, Destination>(new Source { Value = 2 });
+            destination.Value.ShouldEqual((short)2);
+        }
+
+        [Fact]
+        public void Should_map_the_value_with_condition()
+        {
+            var destination = Mapper.Map<Source, Destination>(new Source { Value = 0 });
+            destination.Value.ShouldBeNull();
+        }
+    }
 }

--- a/src/UnitTests/NullBehavior.cs
+++ b/src/UnitTests/NullBehavior.cs
@@ -152,9 +152,15 @@ namespace AutoMapper.UnitTests
             }
 
             [Fact]
-            public void Should_return_not_null_for_nullable_properties_that_are_user_defined()
+            public void Should_return_null_for_nullable_properties_that_are_complex_map_froms()
             {
                 _result.SubExpressionName.ShouldEqual(null);
+            }
+
+            [Fact]
+            public void Should_return_null_for_nullable_properties_that_have_member_access_map_froms()
+            {
+                _result.NullableMapFrom.ShouldEqual(null);
             }
 
             [Fact]


### PR DESCRIPTION
…member accesses, otherwise doing try catches. Fixes #1505