### PR TITLE
Fix #1518

### DIFF
--- a/src/AutoMapper/Mappers/TypeHelper.cs
+++ b/src/AutoMapper/Mappers/TypeHelper.cs
@@ -44,6 +44,12 @@ namespace AutoMapper.Mappers
                 return enumerableType.GetTypeInfo().GenericTypeArguments;
             }
 
+            Type idictionaryType = GetIDictionaryType(enumerableType);
+            if (idictionaryType != null && flags.HasFlag(ElemntTypeFlags.BreakKeyValuePair))
+            {
+                return idictionaryType.GetTypeInfo().GenericTypeArguments;
+            }
+
             Type ienumerableType = GetIEnumerableType(enumerableType);
             if (ienumerableType != null)
             {
@@ -84,6 +90,20 @@ namespace AutoMapper.Mappers
             {
                 if (enumerableType.BaseType() != typeof(object))
                     return GetIEnumerableType(enumerableType.BaseType());
+
+                return null;
+            }
+        }
+        private static Type GetIDictionaryType(Type enumerableType)
+        {
+            try
+            {
+                return enumerableType.GetTypeInfo().ImplementedInterfaces.FirstOrDefault(t => t.Name == "IDictionary`2");
+            }
+            catch (AmbiguousMatchException)
+            {
+                if (enumerableType.BaseType() != typeof(object))
+                    return GetIDictionaryType(enumerableType.BaseType());
 
                 return null;
             }

--- a/src/AutoMapper/Mappers/TypeHelper.cs
+++ b/src/AutoMapper/Mappers/TypeHelper.cs
@@ -44,7 +44,7 @@ namespace AutoMapper.Mappers
                 return enumerableType.GetTypeInfo().GenericTypeArguments;
             }
 
-            Type idictionaryType = GetIDictionaryType(enumerableType);
+            Type idictionaryType = enumerableType.GetDictionaryType();
             if (idictionaryType != null && flags.HasFlag(ElemntTypeFlags.BreakKeyValuePair))
             {
                 return idictionaryType.GetTypeInfo().GenericTypeArguments;
@@ -90,20 +90,6 @@ namespace AutoMapper.Mappers
             {
                 if (enumerableType.BaseType() != typeof(object))
                     return GetIEnumerableType(enumerableType.BaseType());
-
-                return null;
-            }
-        }
-        private static Type GetIDictionaryType(Type enumerableType)
-        {
-            try
-            {
-                return enumerableType.GetTypeInfo().ImplementedInterfaces.FirstOrDefault(t => t.Name == "IDictionary`2");
-            }
-            catch (AmbiguousMatchException)
-            {
-                if (enumerableType.BaseType() != typeof(object))
-                    return GetIDictionaryType(enumerableType.BaseType());
 
                 return null;
             }

--- a/src/UnitTests/Dictionaries.cs
+++ b/src/UnitTests/Dictionaries.cs
@@ -462,5 +462,25 @@ namespace AutoMapper.UnitTests
 				_result.Values["Key2"].ShouldEqual("Value2");
 			}
 		}
-	}
+
+        public class When_mapping_nongeneric_type_inherited_from_dictionary : AutoMapperSpecBase
+        {
+            public class BaseClassWithDictionary
+            {
+                public DataDictionary Data { get; set; }
+            }
+
+            public class DerivedClassWithDictionary : BaseClassWithDictionary { }
+
+            public class DataDictionary : Dictionary<string, object>
+            {
+                public string GetString(string name, string @default)
+                {
+                    return null;
+                }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => cfg.CreateMap<BaseClassWithDictionary, DerivedClassWithDictionary>());
+        }
+    }
 }


### PR DESCRIPTION
Have to check for `IDictionary<TKey,TValue>` explicitly for instances that inherit dictionary but aren't generic.  Before would get `IEnumerable<KeyValuePair<TKey,TValue>>`