### PR TITLE
ExpandoObject is a dictionary and should be mapped as such

### DIFF
--- a/src/AutoMapper/Mappers/DictionaryMapper.cs
+++ b/src/AutoMapper/Mappers/DictionaryMapper.cs
@@ -8,8 +8,7 @@ namespace AutoMapper.Mappers
     
     public class DictionaryMapper : IObjectMapper
     {
-        public bool IsMatch(TypePair context)
-            => (context.SourceType.IsDictionaryType() && context.DestinationType.IsDictionaryType() && !context.SourceType.IsDynamic() && !context.DestinationType.IsDynamic());
+        public bool IsMatch(TypePair context) => context.SourceType.IsDictionaryType() && context.DestinationType.IsDictionaryType();
 
         public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
             => typeMapRegistry.MapCollectionExpression(configurationProvider, propertyMap, sourceExpression, destExpression, contextExpression, CollectionMapperExtensions.IfNotNull, typeof(Dictionary<,>), CollectionMapperExtensions.MapKeyPairValueExpr);


### PR DESCRIPTION
 #1418 and #1518 are the same issue (as the numbers clearly suggest).
#1520 fixes both. 
#1430 is not needed.