### PR TITLE
Make constructor mapping a little more lenient

### DIFF
--- a/src/AutoMapper/ICtorParamConfigurationExpression.cs
+++ b/src/AutoMapper/ICtorParamConfigurationExpression.cs
@@ -4,7 +4,6 @@
     using System.Collections.Generic;
     using System.Linq.Expressions;
     using System.Linq;
-    using Execution;
 
     public interface ICtorParamConfigurationExpression<TSource>
     {
@@ -44,10 +43,10 @@
 
         public void Configure(TypeMap typeMap)
         {
-            var parameter = typeMap.ConstructorMap.CtorParams.Single(p => p.Parameter.Name == _ctorParamName);
-            if(parameter == null)
+            var parameter = typeMap.ConstructorMap?.CtorParams?.SingleOrDefault(p => p.Parameter.Name == _ctorParamName);
+            if (parameter == null)
             {
-                throw new ArgumentOutOfRangeException(nameof(typeMap), $"There is no constructor parameter named {_ctorParamName}");
+                return;
             }
             parameter.CanResolve = true;
 

--- a/src/AutoMapper/ICtorParamConfigurationExpression.cs
+++ b/src/AutoMapper/ICtorParamConfigurationExpression.cs
@@ -43,10 +43,16 @@
 
         public void Configure(TypeMap typeMap)
         {
-            var parameter = typeMap.ConstructorMap?.CtorParams?.SingleOrDefault(p => p.Parameter.Name == _ctorParamName);
+            var ctorParams = typeMap.ConstructorMap?.CtorParams;
+            if (ctorParams == null)
+            {
+                throw new AutoMapperConfigurationException($"The type {typeMap.Types.DestinationType.Name} does not have a constructor.\n{typeMap.Types.DestinationType.FullName}");
+            }
+
+            var parameter = ctorParams.SingleOrDefault(p => p.Parameter.Name == _ctorParamName);
             if (parameter == null)
             {
-                return;
+                throw new AutoMapperConfigurationException($"{typeMap.Types.DestinationType.Name} does not have a constructor with a parameter named '{_ctorParamName}'.\n{typeMap.Types.DestinationType.FullName}");
             }
             parameter.CanResolve = true;
 

--- a/src/UnitTests/IMappingExpression/ForCtorParam.cs
+++ b/src/UnitTests/IMappingExpression/ForCtorParam.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq.Expressions;
 using Xunit;
 using Should;
 
@@ -20,6 +19,11 @@ namespace AutoMapper.UnitTests
             }
 
             public int Value1 { get; }
+        }
+
+        public class DestWithNoConstructor
+        {
+            public int Value1 { get; set; }
         }
 
         protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
@@ -50,6 +54,53 @@ namespace AutoMapper.UnitTests
             var dest = mapper.Map<Source, Dest>(new Source { Value = 5 });
 
             dest.Value1.ShouldEqual(8);
+        }
+
+        [Fact]
+        public void Should_ignore_nonexistent_parameter()
+        {
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Source, Dest>()
+                    .ForCtorParam("thing", opt => opt.MapFrom(src => src.Value))
+                    .ForCtorParam("think", opt => opt.MapFrom(src => src.Value));
+            });
+
+            config.AssertConfigurationIsValid();
+
+            var result = config.CreateMapper().Map<Dest>(new Source { Value = 42 });
+
+            result.Value1.ShouldEqual(42);
+        }
+
+        [Fact]
+        public void Should_ignore_when_no_constructor_is_present()
+        {
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Source, DestWithNoConstructor>()
+                    .ForMember(dest => dest.Value1, opt => opt.MapFrom(src => src.Value))
+                    .ForCtorParam("thing", opt => opt.MapFrom(src => src.Value));
+            });
+
+            config.AssertConfigurationIsValid();
+
+            var result = config.CreateMapper().Map<DestWithNoConstructor>(new Source { Value = 17 });
+
+            result.Value1.ShouldEqual(17);
+        }
+
+        [Fact]
+        public void Should_not_pass_config_validation_when_parameter_is_mispelt()
+        {
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Source, Dest>()
+                    .ForCtorParam("think", opt => opt.MapFrom(src => src.Value));
+            });
+
+            Action configValidation = () => config.AssertConfigurationIsValid();
+            configValidation.ShouldThrow<AutoMapperConfigurationException>();
         }
     }
 }

--- a/src/UnitTests/IMappingExpression/ForCtorParam.cs
+++ b/src/UnitTests/IMappingExpression/ForCtorParam.cs
@@ -91,7 +91,7 @@ namespace AutoMapper.UnitTests
         }
 
         [Fact]
-        public void Should_not_pass_config_validation_when_parameter_is_mispelt()
+        public void Should_not_pass_config_validation_when_parameter_is_misspelt()
         {
             var config = new MapperConfiguration(cfg =>
             {
@@ -100,7 +100,20 @@ namespace AutoMapper.UnitTests
             });
 
             Action configValidation = () => config.AssertConfigurationIsValid();
-            configValidation.ShouldThrow<AutoMapperConfigurationException>();
+            configValidation.ShouldThrow<AutoMapperConfigurationException>(exception =>
+            {
+                Console.WriteLine(exception.Message);
+                exception.Message.ShouldContain("Source -> Dest", StringComparison.InvariantCulture);
+                exception.Message.ShouldContain("No available constructor.", StringComparison.InvariantCulture);
+            });
+
+            var mapper = config.CreateMapper();
+
+            Action mapping = () => mapper.Map<Dest>(new Source { Value = 4711 });
+            mapping.ShouldThrow<ArgumentException>(exception =>
+            {
+                exception.Message.ShouldContain("Dest needs to have a constructor with 0 args or only optional args", StringComparison.InvariantCulture);
+            });
         }
     }
 }


### PR DESCRIPTION
Before, all attempts at mapping constructor parameters for classes that
did not have a constructor defined, or where no defined constructor had
a parameter with that name, would throw an exception with a pretty poor
uninformative exception message.

These scenarios are now considered valid mapping configurations, as long
as the stuff that's needed to actually perform a mapping is also
configured.

Fixes #1528
