### PR TITLE
Break long line in AutoMapperConfigurationException

### DIFF
--- a/src/AutoMapper/AutoMapperConfigurationException.cs
+++ b/src/AutoMapper/AutoMapperConfigurationException.cs
@@ -80,7 +80,7 @@ namespace AutoMapper
                 {
                     var message =
                         new StringBuilder(
-                            "\nUnmapped members were found. Review the types and members below.\nAdd a custom mapping expression, ignore, add a custom resolver, or modify the source/destination type\nFor no matching constructor, add a no-arg ctor, add optional arguments, or map all of the constructor parameters");
+                            "\nUnmapped members were found. Review the types and members below.\nAdd a custom mapping expression, ignore, add a custom resolver, or modify the source/destination type\nFor no matching constructor, add a no-arg ctor, add optional arguments, or map all of the constructor parameters\n");
 
                     foreach (var error in Errors)
                     {


### PR DESCRIPTION
1. Fixes #1547
1. Ran all UnitTests.Net4: all succeeded, apart from 5 skipped
1. IntegrationTests.Net4 not ran: they were somehow hanging in VS2015, right at the beginning
