### PR TITLE
Add a null guard instead of rewriting each node

### DIFF
--- a/src/AutoMapper/Execution/DelegateFactory.cs
+++ b/src/AutoMapper/Execution/DelegateFactory.cs
@@ -51,17 +51,6 @@ namespace AutoMapper.Execution
             return lambda;
         }
 
-        public static Expression IfNotNullExpression(MemberExpression member, Type destinationType)
-        {
-            var returnType = destinationType.IsNullableType() && destinationType.GetTypeOfNullable() == member.Type
-                ? destinationType
-                : member.Type;
-            if (member.Expression != null && !member.Expression.Type.IsValueType())
-                return Condition(Equal(member.Expression, Default(member.Expression.Type)),
-                Default(returnType), ExpressionExtensions.ToType(member, returnType));
-            return member;
-        }
-
         public LateBoundCtor CreateCtor(Type type)
         {
             var ctor = _ctorCache.GetOrAdd(type, _generateConstructor);

--- a/src/UnitTests/Bug/NullableDateTime.cs
+++ b/src/UnitTests/Bug/NullableDateTime.cs
@@ -1,10 +1,73 @@
 ﻿using System;
+using System.Linq;
 using Should;
 using AutoMapper;
 using Xunit;
 
 namespace AutoMapper.UnitTests.Bug
 {
+    public class NullableDateTimeMapFromArray : AutoMapperSpecBase
+    {
+        public class Source
+        {
+            public SourceInner[] Bars { get; set; }
+        }
+
+        public class SourceInner
+        {
+            public DateTime Bar { get; set; }
+        }
+
+        public class Destination
+        {
+            public DateTime? Foo { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>()
+                .ForMember(m => m.Foo, opt =>
+                {
+                    opt.Condition(src => src.Bars != null && src.Bars.Length > 0);
+                    opt.MapFrom(src => src.Bars.Min(b => b.Bar));
+                });
+        });
+    }
+
+    public class FromDateToNullableDateTime : AutoMapperSpecBase
+    {
+        Destination _destination;
+        DateTime _date = new DateTime(1900, 1, 1);
+
+        public class Source
+        {
+            public DateTime? FiredDate { get; set; }
+            public DateTime HiredDate { get; set; }
+        }
+
+        public class Destination
+        {
+            public DateTime? FiredDate { get; set; }
+            public DateTime HiredDate { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>().ForMember(d => d.FiredDate, o => o.MapFrom(s => s.HiredDate.Date));
+        });
+
+        protected override void Because_of()
+        {
+            _destination = Mapper.Map<Destination>(new Source { HiredDate = _date });
+        }
+
+        [Fact]
+        public void Should_map_as_usual()
+        {
+            _destination.FiredDate.ShouldEqual(_date.Date);
+        }
+    }
+
     public class NullableDateTime : AutoMapperSpecBase
     {
         Destination _destination;


### PR DESCRIPTION
Fixes #1552. Closes #1550.
I think the root cause of the nullable issues was the fact that the node type was changed in flight, so to speak, without knowing it's safe to do so. It should be safe for the initial expression.
@jbogard This assumes the member accesses visited are really executed, so when any is null, return null. I think this is correct after the new checks you made recently. Of course it could be made more complicated to detect whether the members were really accessed, but with those checks in place, I see no point. If you want to get rid of the checks, the story changes.