### PR TITLE
Inline the easy cases

### DIFF
--- a/src/AutoMapper/ExpressionExtensions.cs
+++ b/src/AutoMapper/ExpressionExtensions.cs
@@ -207,7 +207,7 @@ namespace AutoMapper
             protected override Expression VisitMethodCall(MethodCallExpression node)
             {
                 return node.Object == _oldParam
-                    ? Call(ToType(_newParam, _oldParam.Type), node.Method)
+                    ? Call(ToType(_newParam, _oldParam.Type), node.Method, node.Arguments)
                     : base.VisitMethodCall(node);
             }
         }

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -387,7 +387,7 @@ namespace AutoMapper
                 var destinationType = mapRequest.RequestedTypes.DestinationType;
 
                 var source = Parameter(mapRequest.RequestedTypes.SourceType, "source");
-                var destination = Parameter(destinationType, "destination");
+                var destination = Parameter(destinationType, "mapperDestination");
                 var context = Parameter(typeof(ResolutionContext), "context");
 
                 var ctor = ((NewExpression)ResolutionContextCtor.Body).Constructor;

--- a/src/AutoMapper/Mappers/CollectionMapper.cs
+++ b/src/AutoMapper/Mappers/CollectionMapper.cs
@@ -160,10 +160,13 @@ namespace AutoMapper.Mappers
         {
             Expression itemExpr;
             var typeMap = configurationProvider.ResolveTypeMap(typePair);
-            if (typeMap != null && (typeMap.TypeConverterType != null || typeMap.CustomMapper != null))
+            if (typeMap != null && !typeMap.HasDerivedTypesToInclude())
             {
                 typeMap.Seal(typeMapRegistry, configurationProvider);
-                return typeMap.MapExpression.ReplaceParameters(itemParam, Default(typePair.DestinationType), contextParam);
+                if(typeMap.MapExpression != null)
+                {
+                    return typeMap.MapExpression.ReplaceParameters(itemParam, Default(typePair.DestinationType), contextParam);
+                }
             }
             var match = configurationProvider.GetMappers().FirstOrDefault(m => m.IsMatch(typePair));
             if (match != null && typeMap == null)

--- a/src/AutoMapper/ResolutionContext.cs
+++ b/src/AutoMapper/ResolutionContext.cs
@@ -25,12 +25,21 @@ namespace AutoMapper
         {
             get
             {
+                CheckDefault();
                 if(_instanceCache != null)
                 {
                     return _instanceCache;
                 }
                 _instanceCache = new Dictionary<object, object>();
                 return _instanceCache;
+            }
+        }
+
+        private void CheckDefault()
+        {
+            if(IsDefault)
+            {
+                throw new InvalidOperationException();
             }
         }
 
@@ -41,6 +50,7 @@ namespace AutoMapper
         {
             get
             {
+                CheckDefault();
                 if(_typeDepth != null)
                 {
                     return _typeDepth;

--- a/src/UnitTests/Bug/DuplicateValuesBug.cs
+++ b/src/UnitTests/Bug/DuplicateValuesBug.cs
@@ -26,7 +26,11 @@ namespace AutoMapper.UnitTests.Bug
 			public int Id;
 			public IList<DestObject> Children;
 
-			public void AddChild(DestObject childObject)
+            public DestObject()
+            {
+            }
+
+            public void AddChild(DestObject childObject)
 			{
 				if (this.Children == null)
 					this.Children = new List<DestObject>();
@@ -59,7 +63,6 @@ namespace AutoMapper.UnitTests.Bug
 
 				source1.AddChild(source2); // This causes the problem
 
-				DestObject dest1 = new DestObject();
 				config.CreateMapper().Map(sourceList, destList);
 
 				destList.Count.ShouldEqual(2);


### PR DESCRIPTION
That thing about initialDestination in CreateMapper lambda was a little too hardcore for me. But what can you do? :)
This doesn't do much. The good news is that the deep types test runs three times faster. The bad new is that the generated code looks pretty bad. Probably one reason I had such a hard time with that bug I mentioned.