### PR TITLE
Profile scanning

### DIFF
--- a/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
@@ -45,6 +45,24 @@ namespace AutoMapper.Configuration
         public void AddProfile(Type profileType) => AddProfile((Profile)Activator.CreateInstance(profileType));
 
         public void AddProfiles(IEnumerable<Assembly> assembliesToScan)
+            => AddProfilesCore(assembliesToScan);
+
+        public void AddProfiles(params Assembly[] assembliesToScan)
+            => AddProfilesCore(assembliesToScan);
+
+        public void AddProfiles(IEnumerable<string> assemblyNamesToScan)
+            => AddProfilesCore(assemblyNamesToScan.Select(name => Assembly.Load(new AssemblyName(name))));
+
+        public void AddProfiles(params string[] assemblyNamesToScan)
+            => AddProfilesCore(assemblyNamesToScan.Select(name => Assembly.Load(new AssemblyName(name))));
+
+        public void AddProfiles(IEnumerable<Type> typesFromAssembliesContainingProfiles)
+            => AddProfilesCore(typesFromAssembliesContainingProfiles.Select(t => t.GetTypeInfo().Assembly));
+
+        public void AddProfiles(params Type[] typesFromAssembliesContainingProfiles)
+            => AddProfilesCore(typesFromAssembliesContainingProfiles.Select(t => t.GetTypeInfo().Assembly));
+
+        private void AddProfilesCore(IEnumerable<Assembly> assembliesToScan)
         {
             var allTypes = assembliesToScan.SelectMany(a => a.ExportedTypes).ToArray();
 
@@ -57,13 +75,9 @@ namespace AutoMapper.Configuration
             {
                 AddProfile(profile);
             }
+
         }
 
-        public void AddProfiles(IEnumerable<string> assemblyNamesToScan)
-            => AddProfiles(assemblyNamesToScan.Select(name => Assembly.Load(new AssemblyName(name))));
-
-        public void AddProfiles(IEnumerable<Type> typesFromAssembliesContainingProfiles) 
-            => AddProfiles(typesFromAssembliesContainingProfiles.Select(t => t.GetTypeInfo().Assembly));
 
         public void ConstructServicesUsing(Func<Type, object> constructor) => ServiceCtor = constructor;
     }

--- a/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
@@ -2,6 +2,7 @@ namespace AutoMapper.Configuration
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Reflection;
     using Mappers;
 
@@ -42,6 +43,27 @@ namespace AutoMapper.Configuration
         public void AddProfile<TProfile>() where TProfile : Profile, new() => AddProfile(new TProfile());
 
         public void AddProfile(Type profileType) => AddProfile((Profile)Activator.CreateInstance(profileType));
+
+        public void AddProfiles(IEnumerable<Assembly> assembliesToScan)
+        {
+            var allTypes = assembliesToScan.SelectMany(a => a.ExportedTypes).ToArray();
+
+            var profiles =
+                allTypes
+                    .Where(t => typeof(Profile).GetTypeInfo().IsAssignableFrom(t.GetTypeInfo()))
+                    .Where(t => !t.GetTypeInfo().IsAbstract);
+
+            foreach (var profile in profiles)
+            {
+                AddProfile(profile);
+            }
+        }
+
+        public void AddProfiles(IEnumerable<string> assemblyNamesToScan)
+            => AddProfiles(assemblyNamesToScan.Select(name => Assembly.Load(new AssemblyName(name))));
+
+        public void AddProfiles(IEnumerable<Type> typesFromAssembliesContainingProfiles) 
+            => AddProfiles(typesFromAssembliesContainingProfiles.Select(t => t.GetTypeInfo().Assembly));
 
         public void ConstructServicesUsing(Func<Type, object> constructor) => ServiceCtor = constructor;
     }

--- a/src/AutoMapper/IConfiguration.cs
+++ b/src/AutoMapper/IConfiguration.cs
@@ -3,45 +3,6 @@ namespace AutoMapper
     using System;
     using System.Collections.Generic;
 
-    public interface IMapperConfigurationExpression : IProfileExpression
-    {
-        /// <summary>
-        /// Create missing type maps during mapping, if necessary
-        /// </summary>
-        bool CreateMissingTypeMaps { get; set; }
-
-        /// <summary>
-        /// Add an existing profile
-        /// </summary>
-        /// <param name="profile">Profile to add</param>
-        void AddProfile(Profile profile);
-
-        /// <summary>
-        /// Add an existing profile type. Profile will be instantiated and added to the configuration.
-        /// </summary>
-        /// <typeparam name="TProfile">Profile type</typeparam>
-        void AddProfile<TProfile>() where TProfile : Profile, new();
-
-        /// <summary>
-        /// Add an existing profile type. Profile will be instantiated and added to the configuration.
-        /// </summary>
-        /// <param name="profileType">Profile type</param>
-        void AddProfile(Type profileType);
-
-        /// <summary>
-        /// Supply a factory method callback for creating resolvers and type converters
-        /// </summary>
-        /// <param name="constructor">Factory method</param>
-        void ConstructServicesUsing(Func<Type, object> constructor);
-
-        /// <summary>
-        /// Create a named profile with the supplied configuration
-        /// </summary>
-        /// <param name="profileName">Profile name, must be unique</param>
-        /// <param name="config">Profile configuration</param>
-        void CreateProfile(string profileName, Action<Profile> config);
-    }
-
     public interface IConfiguration : IProfileConfiguration
     {
         Func<Type, object> ServiceCtor { get; }

--- a/src/AutoMapper/IMapperConfigurationExpression.cs
+++ b/src/AutoMapper/IMapperConfigurationExpression.cs
@@ -1,0 +1,63 @@
+namespace AutoMapper
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+
+    public interface IMapperConfigurationExpression : IProfileExpression
+    {
+        /// <summary>
+        /// Create missing type maps during mapping, if necessary
+        /// </summary>
+        bool CreateMissingTypeMaps { get; set; }
+
+        /// <summary>
+        /// Add an existing profile
+        /// </summary>
+        /// <param name="profile">Profile to add</param>
+        void AddProfile(Profile profile);
+
+        /// <summary>
+        /// Add an existing profile type. Profile will be instantiated and added to the configuration.
+        /// </summary>
+        /// <typeparam name="TProfile">Profile type</typeparam>
+        void AddProfile<TProfile>() where TProfile : Profile, new();
+
+        /// <summary>
+        /// Add an existing profile type. Profile will be instantiated and added to the configuration.
+        /// </summary>
+        /// <param name="profileType">Profile type</param>
+        void AddProfile(Type profileType);
+
+        /// <summary>
+        /// Add profiles contained in assemblies
+        /// </summary>
+        /// <param name="assembliesToScan">Assemblies containing profiles</param>
+        void AddProfiles(IEnumerable<Assembly> assembliesToScan);
+
+        /// <summary>
+        /// Add profiles contained in assemblies
+        /// </summary>
+        /// <param name="assemblyNamesToScan">Assembly names to load and scan containing profiles</param>
+        void AddProfiles(IEnumerable<string> assemblyNamesToScan);
+
+        /// <summary>
+        /// Add profiles contained in assemblies
+        /// </summary>
+        /// <param name="typesFromAssembliesContainingProfiles">Types from assemblies containing profiles</param>
+        void AddProfiles(IEnumerable<Type> typesFromAssembliesContainingProfiles);
+
+        /// <summary>
+        /// Supply a factory method callback for creating resolvers and type converters
+        /// </summary>
+        /// <param name="constructor">Factory method</param>
+        void ConstructServicesUsing(Func<Type, object> constructor);
+
+        /// <summary>
+        /// Create a named profile with the supplied configuration
+        /// </summary>
+        /// <param name="profileName">Profile name, must be unique</param>
+        /// <param name="config">Profile configuration</param>
+        void CreateProfile(string profileName, Action<Profile> config);
+    }
+}

--- a/src/AutoMapper/IMapperConfigurationExpression.cs
+++ b/src/AutoMapper/IMapperConfigurationExpression.cs
@@ -38,14 +38,32 @@ namespace AutoMapper
         /// <summary>
         /// Add profiles contained in assemblies
         /// </summary>
+        /// <param name="assembliesToScan">Assemblies containing profiles</param>
+        void AddProfiles(params Assembly[] assembliesToScan);
+
+        /// <summary>
+        /// Add profiles contained in assemblies
+        /// </summary>
         /// <param name="assemblyNamesToScan">Assembly names to load and scan containing profiles</param>
         void AddProfiles(IEnumerable<string> assemblyNamesToScan);
 
         /// <summary>
         /// Add profiles contained in assemblies
         /// </summary>
+        /// <param name="assemblyNamesToScan">Assembly names to load and scan containing profiles</param>
+        void AddProfiles(params string[] assemblyNamesToScan);
+
+        /// <summary>
+        /// Add profiles contained in assemblies
+        /// </summary>
         /// <param name="typesFromAssembliesContainingProfiles">Types from assemblies containing profiles</param>
         void AddProfiles(IEnumerable<Type> typesFromAssembliesContainingProfiles);
+
+        /// <summary>
+        /// Add profiles contained in assemblies
+        /// </summary>
+        /// <param name="typesFromAssembliesContainingProfiles">Types from assemblies containing profiles</param>
+        void AddProfiles(params Type[] typesFromAssembliesContainingProfiles);
 
         /// <summary>
         /// Supply a factory method callback for creating resolvers and type converters

--- a/src/AutoMapper/IProfileExpression.cs
+++ b/src/AutoMapper/IProfileExpression.cs
@@ -140,6 +140,11 @@ namespace AutoMapper
         string ProfileName { get; }
         IMemberConfiguration AddMemberConfiguration();
         IConditionalObjectMapper AddConditionalObjectMapper();
+
+        /// <summary>
+        /// Include extension methods against source members for matching destination members to. Default source extension methods from <see cref="System.Linq.Enumerable"/>
+        /// </summary>
+        /// <param name="type">Static type that contains extension methods</param>
         void IncludeSourceExtensionMethods(Type type);
     }
 }

--- a/src/UnitTests/AssemblyScanning.cs
+++ b/src/UnitTests/AssemblyScanning.cs
@@ -1,0 +1,50 @@
+﻿namespace AutoMapper.UnitTests
+{
+    namespace AssemblyScanning
+    {
+        using Should;
+        using Xunit;
+
+        public class When_scanning_by_assembly : NonValidatingSpecBase
+        {
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.AddProfiles(new[] { typeof(When_scanning_by_assembly).Assembly });
+            });
+
+            [Fact]
+            public void Should_load_profiles()
+            {
+                Configuration.GetAllTypeMaps().Length.ShouldBeGreaterThan(0);
+            }
+        }
+
+        public class When_scanning_by_type : NonValidatingSpecBase
+        {
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.AddProfiles(new[] { typeof(When_scanning_by_assembly) });
+            });
+
+            [Fact]
+            public void Should_load_profiles()
+            {
+                Configuration.GetAllTypeMaps().Length.ShouldBeGreaterThan(0);
+            }
+        }
+
+        public class When_scanning_by_name : NonValidatingSpecBase
+        {
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.AddProfiles(new[] { "AutoMapper.UnitTests.Net4" });
+            });
+
+            [Fact]
+            public void Should_load_profiles()
+            {
+                Configuration.GetAllTypeMaps().Length.ShouldBeGreaterThan(0);
+            }
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -89,6 +89,7 @@
       <Link>PrimitiveExtensions.cs</Link>
     </Compile>
     <Compile Include="ArraysAndLists.cs" />
+    <Compile Include="AssemblyScanning.cs" />
     <Compile Include="AssertionExtensions.cs" />
     <Compile Include="BasicFlattening.cs" />
     <Compile Include="Bug\ConventionCreateMapsWithCircularReference.cs" />


### PR DESCRIPTION
Allow scanning of assemblies for profiles. Can load via:
- Assembly
- Assembly name (string, using AssemblyName internally)
- Type from assembly containing profiles