### PR TITLE
Proxy generator

### DIFF
--- a/src/AutoMapper/Execution/ProxyGenerator.cs
+++ b/src/AutoMapper/Execution/ProxyGenerator.cs
@@ -33,6 +33,8 @@ namespace AutoMapper.Execution
 
         private static readonly ConcurrentDictionary<Type, Lazy<Type>> proxyTypes = new ConcurrentDictionary<Type, Lazy<Type>>();
 
+        private static readonly Func<Type, Lazy<Type>> _createProxyType = CreateProxyType;
+
         private static ModuleBuilder CreateProxyModule()
         {
             AssemblyName name = new AssemblyName("AutoMapper.Proxies");
@@ -164,7 +166,7 @@ namespace AutoMapper.Execution
             {
                 throw new ArgumentException("Only interfaces can be proxied", nameof(interfaceType));
             }
-            return proxyTypes.GetOrAdd(interfaceType, CreateProxyType).Value;
+            return proxyTypes.GetOrAdd(interfaceType, _createProxyType).Value;
         }
 
         private static byte[] StringToByteArray(string hex)

--- a/src/UnitTests/Internal/CreateProxyThreading.cs
+++ b/src/UnitTests/Internal/CreateProxyThreading.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper.Execution;
+using Xunit;
+
+namespace AutoMapper.UnitTests
+{
+    public class CreateProxyThreading
+    {
+        [Fact]
+        public void Should_create_the_proxy_once()
+        {
+            var generator = new ProxyGenerator();
+            var tasks = Enumerable.Range(0, 5).Select(i => Task.Factory.StartNew(() =>
+            {
+                generator.GetProxyType(typeof(ISomeDto));
+            })).ToArray();
+            Task.WaitAll(tasks);
+        }
+
+        public interface ISomeDto
+        {
+            string Property1 { get; set; }
+            string Property21 { get; set; }
+            string Property3 { get; set; }
+            string Property4 { get; set; }
+            string Property5 { get; set; }
+            string Property6 { get; set; }
+            string Property7 { get; set; }
+            string Property8 { get; set; }
+            string Property9 { get; set; }
+            string Property10 { get; set; }
+            string Property11 { get; set; }
+        }
+
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -212,6 +212,7 @@
     <Compile Include="IMappingExpression\NonGenericConstructorTests.cs" />
     <Compile Include="IMappingExpression\NonGenericReverseMapping.cs" />
     <Compile Include="IMappingExpression\NonGenericProjectEnumTest.cs" />
+    <Compile Include="Internal\CreateProxyThreading.cs" />
     <Compile Include="Internal\DelegateFactoryTests.cs" />
     <Compile Include="Dictionaries.cs" />
     <Compile Include="DynamicMapping.cs" />


### PR DESCRIPTION
Fixes #1562.
It's a threading issue. When multiple threads are in GetOrAdd, the same proxy will be generated twice and fail the unique type name check.