### PR TITLE
Don't fail when the parameter name is null

### DIFF
--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -89,7 +89,7 @@ namespace AutoMapper
 
         public bool ConstructorParameterMatches(string destinationPropertyName)
         {
-            return ConstructorMap?.CtorParams.Any(c => !c.DefaultValue && c.Parameter.Name.Equals(destinationPropertyName, StringComparison.OrdinalIgnoreCase)) == true;
+            return ConstructorMap?.CtorParams.Any(c => !c.DefaultValue && string.Equals(c.Parameter.Name, destinationPropertyName, StringComparison.OrdinalIgnoreCase)) == true;
         }
 
         public void AddPropertyMap(MemberInfo destProperty, IEnumerable<MemberInfo> resolvers)

--- a/src/UnitTests/Internal/NullConstructorParameter.cs
+++ b/src/UnitTests/Internal/NullConstructorParameter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace AutoMapper.UnitTests
+{
+    public class NullConstructorParameter : AutoMapperSpecBase
+    {
+        class Source
+        {
+        }
+        class Destination
+        {
+        }
+
+        class Parameter : ParameterInfo
+        {
+        }
+
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg => cfg.CreateMap<Source, Destination>());
+
+        [Fact]
+        public void Should_work()
+        {
+            var typeMap = Configuration.GetAllTypeMaps().Single();
+            var constructorMap = new ConstructorMap(typeof(Source).GetConstructor(Type.EmptyTypes), typeMap);
+            constructorMap.AddParameter(new Parameter(), new MemberInfo[0], true);
+            typeMap.ConstructorMap = constructorMap;
+            typeMap.ConstructorParameterMatches("");
+        }
+    }
+}

--- a/src/UnitTests/Internal/NullConstructorParameter.cs
+++ b/src/UnitTests/Internal/NullConstructorParameter.cs
@@ -12,6 +12,13 @@ namespace AutoMapper.UnitTests
         }
         class Destination
         {
+            public Destination()
+            {
+            }
+
+            public Destination(int _)
+            {
+            }
         }
 
         class Parameter : ParameterInfo
@@ -24,9 +31,7 @@ namespace AutoMapper.UnitTests
         public void Should_work()
         {
             var typeMap = Configuration.GetAllTypeMaps().Single();
-            var constructorMap = new ConstructorMap(typeof(Source).GetConstructor(Type.EmptyTypes), typeMap);
-            constructorMap.AddParameter(new Parameter(), new MemberInfo[0], true);
-            typeMap.ConstructorMap = constructorMap;
+            typeMap.ConstructorMap.AddParameter(new Parameter(), new MemberInfo[0], true);
             typeMap.ConstructorParameterMatches("");
         }
     }

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -224,6 +224,7 @@
     <Compile Include="General.cs" />
     <Compile Include="Indexers.cs" />
     <Compile Include="InterfaceMapping.cs" />
+    <Compile Include="Internal\NullConstructorParameter.cs" />
     <Compile Include="Internal\PrimitiveExtensionsTester.cs" />
     <Compile Include="Internal\QueryMapperHelperTests.cs" />
     <Compile Include="Internationalization.cs" />


### PR DESCRIPTION
Pedantic? :)
There is no need to explicitly check for null. Fixes #1596. Closes #1597.