### PR TITLE
TypePair ignore EntityFramework proxy types when getting type from source instance

### DIFF
--- a/src/AutoMapper/TypeExtensions.cs
+++ b/src/AutoMapper/TypeExtensions.cs
@@ -253,5 +253,27 @@ namespace AutoMapper
         {
             return type.GetRuntimeField(name);
         }
+
+        public static bool IsEntityFrameworkProxyType(this Type type)
+        {
+            const string entityFrameworkDynamicProxiesNamespace = "System.Data.Entity.DynamicProxies";
+            return type.GetTypeInfo().Namespace == entityFrameworkDynamicProxiesNamespace;
+        }
+
+        public static Type GetBaseTypeIfIsEntityFrameworkProxyType(this Type type)
+        {
+            if (type.IsEntityFrameworkProxyType() == false)
+            {
+                return type;
+            }
+
+            var baseType = type.BaseType();
+            if (baseType == null)
+            {
+                return type;
+            }
+
+            return baseType;
+        }
     }
 }

--- a/src/AutoMapper/TypePair.cs
+++ b/src/AutoMapper/TypePair.cs
@@ -63,7 +63,7 @@ namespace AutoMapper
         {
             if(source != null)
             {
-                sourceType = source.GetType();
+                sourceType = source.GetType().GetBaseTypeIfIsEntityFrameworkProxyType();
             }
             return new TypePair(sourceType, destinationType);
         }
@@ -72,11 +72,11 @@ namespace AutoMapper
         {
             if(source != null)
             {
-                sourceType = source.GetType();
+                sourceType = source.GetType().GetBaseTypeIfIsEntityFrameworkProxyType();
             }
             if(destination != null)
             {
-                destinationType = destination.GetType();
+                destinationType = destination.GetType().GetBaseTypeIfIsEntityFrameworkProxyType();
             }
             return new TypePair(sourceType, destinationType);
         }


### PR DESCRIPTION
When specifying a source instance to be mapped to the IMapper.Map the source.GetType() takes precedence over the specified sourceType. 

If source is an instance of an EntityFramework proxy object, CreateMissingTypeMaps is set to true, and there is a defined map for the POCO the proxy is sub classing; the custom map is not used as the sourceType is the EF proxy not the POCO type.