### PR TITLE
derived maps fix

### DIFF
--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -247,10 +247,13 @@ namespace AutoMapper
             }
             foreach (var redirectedType in redirectedTypes)
             {
-                var derivedMap = FindTypeMapFor(redirectedType.Item2);
-                if (derivedMap != null)
+                if (!_typeMapPlanCache.ContainsKey(redirectedType.Item1))
                 {
-                    _typeMapPlanCache[redirectedType.Item1] = derivedMap;
+                    var derivedMap = FindTypeMapFor(redirectedType.Item2);
+                    if (derivedMap != null)
+                    {
+                        _typeMapPlanCache[redirectedType.Item1] = derivedMap;
+                    }
                 }
             }
             foreach (var derivedMap in derivedMaps.Where(derivedMap => !_typeMapPlanCache.ContainsKey(derivedMap.Item1)))


### PR DESCRIPTION
Also see issue #1664

In the MapperConfiguration.cs, we register the different typemaps.  For nullables there is a derived typemap created.  But it also overwrites an existing typemapping when present. 

This shouldn't happen as when the mapping already exist it is probably the intention of the dev to have it there.  So, I added a check to create the derived map only if it doesn't exist.

Robin



