### PR TITLE
ResolveUsing overload with ResolutionContext for ctor params

### DIFF
--- a/src/AutoMapper/ICtorParamConfigurationExpression.cs
+++ b/src/AutoMapper/ICtorParamConfigurationExpression.cs
@@ -20,6 +20,12 @@
         /// </summary>
         /// <param name="resolver">Custom func</param>
         void ResolveUsing(Func<TSource, object> resolver);
+
+        /// <summary>
+        /// Map constructor parameter from custom func that has access to <see cref="ResolutionContext"/>
+        /// </summary>
+        /// <param name="resolver">Custom func</param>
+        void ResolveUsing(Func<TSource, ResolutionContext, object> resolver);
     }
 
     public class CtorParamConfigurationExpression<TSource> : ICtorParamConfigurationExpression<TSource>
@@ -40,6 +46,11 @@
         public void ResolveUsing(Func<TSource, object> resolver)
         {
             _ctorParamActions.Add(cpm => cpm.CustomValueResolver = (src, ctxt) => resolver((TSource)src));
+        }
+
+        public void ResolveUsing(Func<TSource, ResolutionContext, object> resolver)
+        {
+            _ctorParamActions.Add(cpm => cpm.CustomValueResolver = (src, ctxt) => resolver((TSource)src, ctxt));
         }
 
         public void Configure(TypeMap typeMap)

--- a/src/UnitTests/IMappingExpression/ForCtorParam.cs
+++ b/src/UnitTests/IMappingExpression/ForCtorParam.cs
@@ -51,5 +51,21 @@ namespace AutoMapper.UnitTests
 
             dest.Value1.ShouldEqual(8);
         }
+
+        [Fact]
+        public void Should_resolve_using_custom_func_with_correct_ResolutionContext()
+        {
+            const string itemKey = "key";
+            var mapper = new MapperConfiguration(
+                cfg => cfg.CreateMap<Source, Dest>().ForCtorParam("thing", opt =>
+                    opt.ResolveUsing((src, ctx) => ctx.Items[itemKey])
+                ))
+                .CreateMapper();
+
+            var dest = mapper.Map<Source, Dest>(new Source { Value = 8 },
+                opts => opts.Items[itemKey] = 10);
+
+            dest.Value1.ShouldEqual(10);
+        }
     }
 }


### PR DESCRIPTION
We already have the ability to resolve constructor parameters using `Func<TSource, object>`, but we can't access `ResolutionContext` there (as it is possible with property mappings). There is sufficient infrastructure for this, so the only change that was required was to provide correct overload of `ResolveUsing`.