### PR TITLE
Fixed memory leaks

### DIFF
--- a/src/AutoMapper/Configuration/Conventions/SourceToDestinationNameMapperAttributesMember.cs
+++ b/src/AutoMapper/Configuration/Conventions/SourceToDestinationNameMapperAttributesMember.cs
@@ -8,7 +8,7 @@ namespace AutoMapper.Configuration.Conventions
 
     public class SourceToDestinationNameMapperAttributesMember : ISourceToDestinationNameMapper
     {
-        private static readonly ConcurrentDictionary<TypeDetails, Dictionary<MemberInfo, IEnumerable<SourceToDestinationMapperAttribute>>> Cache = new ConcurrentDictionary<TypeDetails, Dictionary<MemberInfo, IEnumerable<SourceToDestinationMapperAttribute>>>();
+        private readonly ConcurrentDictionary<TypeDetails, Dictionary<MemberInfo, IEnumerable<SourceToDestinationMapperAttribute>>> Cache = new ConcurrentDictionary<TypeDetails, Dictionary<MemberInfo, IEnumerable<SourceToDestinationMapperAttribute>>>();
 
         public MemberInfo GetMatchingMemberInfo(IGetTypeInfoMembers getTypeInfoMembers, TypeDetails typeInfo, Type destType, Type destMemberType, string nameToSearch)
         {

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -2,7 +2,6 @@
 namespace AutoMapper
 {
     using System;
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
@@ -21,8 +20,8 @@ namespace AutoMapper
         private readonly List<LambdaExpression> _beforeMapActions = new List<LambdaExpression>();
         private readonly HashSet<TypePair> _includedDerivedTypes = new HashSet<TypePair>();
         private readonly HashSet<TypePair> _includedBaseTypes = new HashSet<TypePair>();
-        private readonly ConcurrentBag<PropertyMap> _propertyMaps = new ConcurrentBag<PropertyMap>();
-        private readonly ConcurrentBag<SourceMemberConfig> _sourceMemberConfigs = new ConcurrentBag<SourceMemberConfig>();
+        private readonly List<PropertyMap> _propertyMaps = new List<PropertyMap>();
+        private readonly List<SourceMemberConfig> _sourceMemberConfigs = new List<SourceMemberConfig>();
 
         private readonly IList<PropertyMap> _inheritedMaps = new List<PropertyMap>();
         private PropertyMap[] _orderedPropertyMaps;


### PR DESCRIPTION
Fixed memory leaks caused when initializing Automapper multiple times on
the same thread/appdomain.

Made Cache in SourceToDestinationNameMapperAttributesMember non-static.
Removed usage of ConcurrentBag in TypeMap, it now uses List<T>.

Closes #1691