### PR TITLE
When we map a nullable, we should map the underlying type unless an e…

### DIFF
--- a/src/AutoMapper/Mappers/MapperRegistry.cs
+++ b/src/AutoMapper/Mappers/MapperRegistry.cs
@@ -6,6 +6,7 @@ namespace AutoMapper.Mappers
     {
         private static readonly IObjectMapper[] _initialMappers =
         {
+            new NullableSourceMapper(),
             new ExpressionMapper(), 
             new FlagsEnumMapper(),
             new StringToEnumMapper(), 
@@ -23,11 +24,10 @@ namespace AutoMapper.Mappers
             new HashSetMapper(),
             new CollectionMapper(),
             new EnumerableMapper(),
-            new StringMapper(),
             new AssignableMapper(),
             new ConvertMapper(),
+            new StringMapper(),
             new TypeConverterMapper(),
-            new NullableSourceMapper(),
             new ImplicitConversionOperatorMapper(),
             new ExplicitConversionOperatorMapper(),
             new FromStringDictionaryMapper(),

--- a/src/UnitTests/Enumerations.cs
+++ b/src/UnitTests/Enumerations.cs
@@ -5,6 +5,38 @@ using Xunit;
 
 namespace AutoMapper.Tests
 {
+    public class NullableEnumToString : AutoMapperSpecBase
+    {
+        Destination _destination;
+
+        class Source
+        {
+            public ConsoleColor? Color { get; set; }
+        }
+
+        class Destination
+        {
+            public string Color { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>();
+            cfg.CreateMap<Enum, string>().ConvertUsing((Enum src) => "Test");
+        });
+
+        protected override void Because_of()
+        {
+            _destination = Mapper.Map<Destination>(new Source { Color = ConsoleColor.Black });
+        }
+
+        [Fact]
+        public void Should_map_with_underlying_type()
+        {
+            _destination.Color.ShouldEqual("Test");
+        }
+    }
+
 	public class EnumMappingFixture
 	{
         public EnumMappingFixture()


### PR DESCRIPTION
…xplicit map exists
The ConvertMapper can call ToString without boxing.
Fixes #1717.