### PR TITLE
Expose the destination member

### DIFF
--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -13,7 +13,7 @@ namespace AutoMapper.Configuration
         MemberInfo DestinationMember { get; }
     }
 
-    public class MemberConfigurationExpression<TSource, TDestination, TMember> : IMemberConfigurationExpression<TSource, TDestination, TMember>
+    public class MemberConfigurationExpression<TSource, TDestination, TMember> : IMemberConfigurationExpression<TSource, TDestination, TMember>, IMemberConfiguration
     {
         private readonly MemberInfo _destinationMember;
         private readonly Type _sourceType;

--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -13,7 +13,7 @@ namespace AutoMapper.Configuration
         MemberInfo DestinationMember { get; }
     }
 
-    public class MemberConfigurationExpression<TSource, TDestination, TMember> : IMemberConfigurationExpression<TSource, TDestination, TMember>, IMemberConfiguration
+    public class MemberConfigurationExpression<TSource, TDestination, TMember> : IMemberConfigurationExpression<TSource, TDestination, TMember>
     {
         private readonly MemberInfo _destinationMember;
         private readonly Type _sourceType;

--- a/src/AutoMapper/IMemberConfigurationExpression.cs
+++ b/src/AutoMapper/IMemberConfigurationExpression.cs
@@ -2,6 +2,7 @@ namespace AutoMapper
 {
     using System;
     using System.Linq.Expressions;
+    using System.Reflection;
     using Configuration;
 
     /// <summary>
@@ -10,7 +11,7 @@ namespace AutoMapper
     /// <typeparam name="TSource">Source type for this member</typeparam>
     /// <typeparam name="TMember">Type for this member</typeparam>
     /// <typeparam name="TDestination">Destination type for this map</typeparam>
-    public interface IMemberConfigurationExpression<TSource, out TDestination, TMember> : IMemberConfiguration
+    public interface IMemberConfigurationExpression<TSource, out TDestination, TMember>
     {
         /// <summary>
         /// Substitute a custom value when the source member resolves as null
@@ -187,6 +188,11 @@ namespace AutoMapper
         /// Ignore this member for LINQ projections unless explicitly expanded during projection
         /// </summary>
         void ExplicitExpansion();
+
+        /// <summary>
+        /// The destination member being configured.
+        /// </summary>
+        MemberInfo DestinationMember { get; }
     }
 
     /// <summary>

--- a/src/AutoMapper/IMemberConfigurationExpression.cs
+++ b/src/AutoMapper/IMemberConfigurationExpression.cs
@@ -2,6 +2,7 @@ namespace AutoMapper
 {
     using System;
     using System.Linq.Expressions;
+    using Configuration;
 
     /// <summary>
     /// Member configuration options
@@ -9,7 +10,7 @@ namespace AutoMapper
     /// <typeparam name="TSource">Source type for this member</typeparam>
     /// <typeparam name="TMember">Type for this member</typeparam>
     /// <typeparam name="TDestination">Destination type for this map</typeparam>
-    public interface IMemberConfigurationExpression<TSource, out TDestination, TMember>
+    public interface IMemberConfigurationExpression<TSource, out TDestination, TMember> : IMemberConfiguration
     {
         /// <summary>
         /// Substitute a custom value when the source member resolves as null


### PR DESCRIPTION
It was needed a couple of times.