### PR TITLE
Fix #1482

### DIFF
--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -144,6 +144,10 @@ namespace AutoMapper.Mappers
                 var newLeft = base.Visit(node.Left);
                 var newRight = base.Visit(node.Right);
 
+                if(newLeft.Type != newRight.Type && newRight.Type == typeof(string))
+                    newLeft = Expression.Call(newLeft, typeof(object).GetDeclaredMethod("ToString"));
+                if (newRight.Type != newLeft.Type && newLeft.Type == typeof(string))
+                    newRight = Expression.Call(newRight, typeof(object).GetDeclaredMethod("ToString"));
                 CheckNullableToNonNullableChanges(node.Left, node.Right, ref newLeft, ref newRight);
                 CheckNullableToNonNullableChanges(node.Right, node.Left, ref newRight, ref newLeft);
                 return Expression.MakeBinary(node.NodeType, newLeft, newRight);

--- a/src/UnitTests/Query/SourceInjectedQuery.cs
+++ b/src/UnitTests/Query/SourceInjectedQuery.cs
@@ -14,15 +14,16 @@ namespace AutoMapper.UnitTests.Query
     {
         readonly Source[] _source = new[]
                     {
-                        new Source {SrcValue = 5},
-                        new Source {SrcValue = 4},
-                        new Source {SrcValue = 7}
+                        new Source {SrcValue = 5, InttoStringValue = 5},
+                        new Source {SrcValue = 4, InttoStringValue = 4},
+                        new Source {SrcValue = 7, InttoStringValue = 7}
                     };
 
         public class Source
         {
             public int SrcValue { get; set; }
             public string StringValue { get; set; }
+            public int InttoStringValue { get; set; }
             public string[] Strings { get; set; }
         }
 
@@ -30,6 +31,7 @@ namespace AutoMapper.UnitTests.Query
         {
             public int DestValue { get; set; }
             public string StringValue { get; set; }
+            public string InttoStringValue { get; set; }
             public string[] Strings { get; set; }
         }
 
@@ -591,6 +593,19 @@ namespace AutoMapper.UnitTests.Query
             results.Count.ShouldEqual(2);
             results[0].HasEditPermission.ShouldBeFalse();
             results[1].HasEditPermission.ShouldBeTrue();
+        }
+
+
+        [Fact]
+        public void Shoud_convert_type_changes()
+        {
+            IQueryable<Destination> result = _source.AsQueryable()
+                .UseAsDataSource(Configuration).For<Destination>();
+
+            var destItem = result.First(s => s.InttoStringValue == "7");
+            var sourceItem = _source.First(s => s.InttoStringValue == 7);
+
+            destItem.DestValue.ShouldEqual(sourceItem.SrcValue);
         }
 
         private static IMapper SetupAutoMapper()


### PR DESCRIPTION
Just fixed the ToString issue.  I think in the long run IObjectMapper, IExpressionBuilder, and these expression translation classes should all be in a single class or same file since they do the same kinds of things but in different Expression Mapping Scenarios.

Assign, ToString, and possibly Map can be applied to all 3 expression translation scenarios

Slices not Layers I guess?
