### PR TITLE
Replace ConcurrentDictionary

### DIFF
--- a/src/AutoMapper/Configuration/Conventions/SourceToDestinationNameMapperAttributesMember.cs
+++ b/src/AutoMapper/Configuration/Conventions/SourceToDestinationNameMapperAttributesMember.cs
@@ -14,10 +14,10 @@ namespace AutoMapper.Configuration.Conventions
             SourceMember[] sourceMembers;
             if(!allSourceMembers.TryGetValue(typeInfo, out sourceMembers))
             {
-                sourceMembers = getTypeInfoMembers.GetMemberInfos(typeInfo).Select(sourceMember => new SourceMember(sourceMember)).ToArray();
+                sourceMembers = getTypeInfoMembers.GetMemberInfos(typeInfo).Select(sourceMember => new SourceMember(sourceMember)).Where(s=>s.Attribute != null).ToArray();
                 allSourceMembers[typeInfo] = sourceMembers;
             }
-            return sourceMembers.FirstOrDefault(d => d.Attribute != null && d.Attribute.IsMatch(typeInfo, d.Member, destType, destMemberType, nameToSearch)).Member;
+            return sourceMembers.FirstOrDefault(d => d.Attribute.IsMatch(typeInfo, d.Member, destType, destMemberType, nameToSearch)).Member;
         }
 
         struct SourceMember

--- a/src/AutoMapper/Configuration/Conventions/SourceToDestinationNameMapperAttributesMember.cs
+++ b/src/AutoMapper/Configuration/Conventions/SourceToDestinationNameMapperAttributesMember.cs
@@ -1,20 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
 namespace AutoMapper.Configuration.Conventions
 {
-    using System;
-    using System.Collections.Concurrent;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Reflection;
-
     public class SourceToDestinationNameMapperAttributesMember : ISourceToDestinationNameMapper
     {
-        private readonly ConcurrentDictionary<TypeDetails, Dictionary<MemberInfo, IEnumerable<SourceToDestinationMapperAttribute>>> Cache = new ConcurrentDictionary<TypeDetails, Dictionary<MemberInfo, IEnumerable<SourceToDestinationMapperAttribute>>>();
+        private readonly Dictionary<TypeDetails, SourceMember[]> allSourceMembers = new Dictionary<TypeDetails, SourceMember[]>();
 
         public MemberInfo GetMatchingMemberInfo(IGetTypeInfoMembers getTypeInfoMembers, TypeDetails typeInfo, Type destType, Type destMemberType, string nameToSearch)
         {
-            Cache.GetOrAdd(typeInfo, ti => getTypeInfoMembers.GetMemberInfos(ti).ToDictionary(mi => mi, mi => mi.GetCustomAttributes(typeof(SourceToDestinationMapperAttribute), true).OfType<SourceToDestinationMapperAttribute>()));
+            SourceMember[] sourceMembers;
+            if(!allSourceMembers.TryGetValue(typeInfo, out sourceMembers))
+            {
+                sourceMembers = getTypeInfoMembers.GetMemberInfos(typeInfo).Select(sourceMember => new SourceMember(sourceMember)).ToArray();
+                allSourceMembers[typeInfo] = sourceMembers;
+            }
+            return sourceMembers.FirstOrDefault(d => d.Attribute != null && d.Attribute.IsMatch(typeInfo, d.Member, destType, destMemberType, nameToSearch)).Member;
+        }
 
-            return Cache[typeInfo].FirstOrDefault(kp => kp.Value.Any(_ => _.IsMatch(typeInfo, kp.Key, destType, destMemberType, nameToSearch))).Key;
+        struct SourceMember
+        {
+            public SourceMember(MemberInfo sourceMember)
+            {
+                Member = sourceMember;
+                Attribute = sourceMember.GetCustomAttribute<SourceToDestinationMapperAttribute>(inherit:true);
+            }
+
+            public MemberInfo Member { get; }
+            public SourceToDestinationMapperAttribute Attribute { get; }
         }
     }
 }

--- a/src/AutoMapper/Configuration/Conventions/SourceToDestinationNameMapperAttributesMember.cs
+++ b/src/AutoMapper/Configuration/Conventions/SourceToDestinationNameMapperAttributesMember.cs
@@ -7,6 +7,7 @@ namespace AutoMapper.Configuration.Conventions
 {
     public class SourceToDestinationNameMapperAttributesMember : ISourceToDestinationNameMapper
     {
+        private static readonly SourceMember[] Empty = new SourceMember[0];
         private readonly Dictionary<TypeDetails, SourceMember[]> allSourceMembers = new Dictionary<TypeDetails, SourceMember[]>();
 
         public MemberInfo GetMatchingMemberInfo(IGetTypeInfoMembers getTypeInfoMembers, TypeDetails typeInfo, Type destType, Type destMemberType, string nameToSearch)
@@ -15,7 +16,7 @@ namespace AutoMapper.Configuration.Conventions
             if(!allSourceMembers.TryGetValue(typeInfo, out sourceMembers))
             {
                 sourceMembers = getTypeInfoMembers.GetMemberInfos(typeInfo).Select(sourceMember => new SourceMember(sourceMember)).Where(s=>s.Attribute != null).ToArray();
-                allSourceMembers[typeInfo] = sourceMembers;
+                allSourceMembers[typeInfo] = sourceMembers.Length == 0 ? Empty : sourceMembers;
             }
             return sourceMembers.FirstOrDefault(d => d.Attribute.IsMatch(typeInfo, d.Member, destType, destMemberType, nameToSearch)).Member;
         }

--- a/src/AutoMapper/Execution/DelegateFactory.cs
+++ b/src/AutoMapper/Execution/DelegateFactory.cs
@@ -13,15 +13,7 @@ namespace AutoMapper.Execution
 
     public class DelegateFactory
     {
-        private readonly ConcurrentDictionary<Type, LateBoundCtor> _ctorCache =
-            new ConcurrentDictionary<Type, LateBoundCtor>();
-
-        private readonly Func<Type, LateBoundCtor> _generateConstructor;
-
-        public DelegateFactory()
-        {
-            _generateConstructor = GenerateConstructor;
-        }
+        private readonly LockingConcurrentDictionary<Type, LateBoundCtor> _ctorCache = new LockingConcurrentDictionary<Type, LateBoundCtor>(GenerateConstructor);
 
         public Expression<LateBoundMethod<object, TValue>> CreateGet<TValue>(MethodInfo method)
         {
@@ -53,8 +45,7 @@ namespace AutoMapper.Execution
 
         public LateBoundCtor CreateCtor(Type type)
         {
-            var ctor = _ctorCache.GetOrAdd(type, _generateConstructor);
-            return ctor;
+            return _ctorCache.GetOrAdd(type);
         }
 
         private static LateBoundCtor GenerateConstructor(Type type)

--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -137,15 +137,12 @@ namespace AutoMapper.QueryableExtensions
 
         private static int GetDepth(ExpressionRequest request, IDictionary<ExpressionRequest, int> typePairCount)
         {
-            int visitCount;
-            if(!typePairCount.TryGetValue(request, out visitCount))
+            int visitCount = 0;
+            if(typePairCount.TryGetValue(request, out visitCount))
             {
-                typePairCount[request] = 0;
+                visitCount = visitCount + 1;
             }
-            else
-            {
-                typePairCount[request] = visitCount + 1;
-            }
+            typePairCount[request] = visitCount;
             return visitCount;
         }
 

--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -306,8 +306,7 @@ namespace AutoMapper.QueryableExtensions
         /// </remarks>
         internal class NullsafeQueryRewriter : ExpressionVisitor
         {
-            static readonly ConcurrentDictionary<Type, Expression> Cache =
-                new ConcurrentDictionary<Type, Expression>();
+            static readonly LockingConcurrentDictionary<Type, Expression> Cache = new LockingConcurrentDictionary<Type, Expression>(NodeFallback);
 
             /// <inheritdoc />
             protected override Expression VisitMember(MemberExpression node)
@@ -334,7 +333,7 @@ namespace AutoMapper.QueryableExtensions
             Expression MakeNullsafe(Expression node, Expression value)
             {
                 // cache "fallback expression" for performance reasons
-                var fallback = Cache.GetOrAdd(node.Type, NodeFallback);
+                var fallback = Cache.GetOrAdd(node.Type);
 
                 // check value and insert additional coalesce, if fallback is not default
                 return Expression.Condition(

--- a/src/AutoMapper/QueryableExtensions/IExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/IExpressionBinder.cs
@@ -1,12 +1,12 @@
 namespace AutoMapper.QueryableExtensions
 {
+    using System.Collections.Generic;
     using System.Linq.Expressions;
-    using System.Collections.Concurrent;
 
     public interface IExpressionBinder
     {
         bool IsMatch(PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionResolutionResult result);
 
-        MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, ConcurrentDictionary<ExpressionRequest, int> typePairCount);
+        MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, IDictionary<ExpressionRequest, int> typePairCount);
     }
 }

--- a/src/AutoMapper/QueryableExtensions/Impl/AssignableExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/AssignableExpressionBinder.cs
@@ -1,8 +1,7 @@
 namespace AutoMapper.QueryableExtensions.Impl
 {
+    using System.Collections.Generic;
     using System.Linq.Expressions;
-    using System.Collections.Concurrent;
-    using System.Reflection;
 
     public class AssignableExpressionBinder : IExpressionBinder
     {
@@ -11,7 +10,7 @@ namespace AutoMapper.QueryableExtensions.Impl
             return propertyMap.DestinationPropertyType.IsAssignableFrom(result.Type) && propertyTypeMap == null;
         }
 
-        public MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, ConcurrentDictionary<ExpressionRequest, int> typePairCount)
+        public MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, IDictionary<ExpressionRequest, int> typePairCount)
         {
             return BindAssignableExpression(propertyMap, result);
         }

--- a/src/AutoMapper/QueryableExtensions/Impl/CustomProjectionExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/CustomProjectionExpressionBinder.cs
@@ -1,8 +1,6 @@
-using System.Linq;
-
 namespace AutoMapper.QueryableExtensions.Impl
 {
-    using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using System.Linq.Expressions;
 
     public class CustomProjectionExpressionBinder : IExpressionBinder
@@ -12,7 +10,7 @@ namespace AutoMapper.QueryableExtensions.Impl
             return propertyTypeMap?.CustomProjection != null;
         }
 
-        public MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, ConcurrentDictionary<ExpressionRequest, int> typePairCount)
+        public MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, IDictionary<ExpressionRequest, int> typePairCount)
         {
             return BindCustomProjectionExpression(propertyMap, propertyTypeMap, result);
         }

--- a/src/AutoMapper/QueryableExtensions/Impl/EnumerableExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/EnumerableExpressionBinder.cs
@@ -1,9 +1,6 @@
-using System;
 using System.Collections.Generic;
-using System.Reflection;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Collections.Concurrent;
 
 namespace AutoMapper.QueryableExtensions.Impl
 {
@@ -18,12 +15,12 @@ namespace AutoMapper.QueryableExtensions.Impl
                     !(TypeHelper.GetElementType(propertyMap.DestinationPropertyType).IsPrimitive() && TypeHelper.GetElementType(propertyMap.SourceType).IsPrimitive());
         }
 
-        public MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, ConcurrentDictionary<ExpressionRequest, int> typePairCount)
+        public MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, IDictionary<ExpressionRequest, int> typePairCount)
         {
             return BindEnumerableExpression(configuration, propertyMap, request, result, typePairCount);
         }
 
-        private static MemberAssignment BindEnumerableExpression(IConfigurationProvider configuration, PropertyMap propertyMap, ExpressionRequest request, ExpressionResolutionResult result, ConcurrentDictionary<ExpressionRequest, int> typePairCount)
+        private static MemberAssignment BindEnumerableExpression(IConfigurationProvider configuration, PropertyMap propertyMap, ExpressionRequest request, ExpressionResolutionResult result, IDictionary<ExpressionRequest, int> typePairCount)
         {
             var destinationListType = TypeHelper.GetElementType(propertyMap.DestinationPropertyType);
             var sourceListType = TypeHelper.GetElementType(propertyMap.SourceType);

--- a/src/AutoMapper/QueryableExtensions/Impl/MappedTypeExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/MappedTypeExpressionBinder.cs
@@ -1,7 +1,6 @@
-using System.Collections.Concurrent;
-
 namespace AutoMapper.QueryableExtensions.Impl
 {
+    using System.Collections.Generic;
     using System.Linq.Expressions;
 
     public class MappedTypeExpressionBinder : IExpressionBinder
@@ -11,12 +10,12 @@ namespace AutoMapper.QueryableExtensions.Impl
             return propertyTypeMap != null && propertyTypeMap.CustomProjection == null;
         }
 
-        public MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, ConcurrentDictionary<ExpressionRequest, int> typePairCount)
+        public MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, IDictionary<ExpressionRequest, int> typePairCount)
         {
             return BindMappedTypeExpression(configuration, propertyMap, request, result, typePairCount);
         }
 
-        private static MemberAssignment BindMappedTypeExpression(IConfigurationProvider configuration, PropertyMap propertyMap, ExpressionRequest request, ExpressionResolutionResult result, ConcurrentDictionary<ExpressionRequest, int> typePairCount)
+        private static MemberAssignment BindMappedTypeExpression(IConfigurationProvider configuration, PropertyMap propertyMap, ExpressionRequest request, ExpressionResolutionResult result, IDictionary<ExpressionRequest, int> typePairCount)
         {
             var transformedExpression = configuration.ExpressionBuilder.CreateMapExpression(request, result.ResolutionExpression, typePairCount);
             if(transformedExpression == null)

--- a/src/AutoMapper/QueryableExtensions/Impl/NullableExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/NullableExpressionBinder.cs
@@ -1,7 +1,6 @@
-using System.Collections.Concurrent;
-
 namespace AutoMapper.QueryableExtensions.Impl
 {
+    using System.Collections.Generic;
     using System.Linq.Expressions;
     using Configuration;
 
@@ -13,7 +12,7 @@ namespace AutoMapper.QueryableExtensions.Impl
                    && !result.Type.IsNullableType();
         }
 
-        public MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, ConcurrentDictionary<ExpressionRequest, int> typePairCount)
+        public MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, IDictionary<ExpressionRequest, int> typePairCount)
         {
             return BindNullableExpression(propertyMap, result);
         }

--- a/src/AutoMapper/QueryableExtensions/Impl/StringExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/StringExpressionBinder.cs
@@ -1,7 +1,6 @@
-using System.Collections.Concurrent;
-
 namespace AutoMapper.QueryableExtensions.Impl
 {
+    using System.Collections.Generic;
     using System.Linq.Expressions;
 
     public class StringExpressionBinder : IExpressionBinder
@@ -11,7 +10,7 @@ namespace AutoMapper.QueryableExtensions.Impl
             return propertyMap.DestinationPropertyType == typeof(string);
         }
 
-        public MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, ConcurrentDictionary<ExpressionRequest, int> typePairCount)
+        public MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, IDictionary<ExpressionRequest, int> typePairCount)
         {
             return BindStringExpression(propertyMap, result);
         }


### PR DESCRIPTION
I reviewed usage of ConcurrentDictionary and replaced it with LockingConcurrentDictionary or Dictionary.
Did a little more in SourceToDestinationNameMapperAttributesMember. Sorry for the whitespace in Profile.cs VS did it :)