### PR TITLE
Check the destination type override to be a derived type

### DIFF
--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -474,12 +474,19 @@ namespace AutoMapper.Configuration
             return this;
         }
 
-        public void As<T>()
+        public void As<T>() where T : TDestination
         {
             As(typeof(T));
         }
 
-        public void As(Type typeOverride) => TypeMapActions.Add(tm => tm.DestinationTypeOverride = typeOverride);
+        public void As(Type typeOverride)
+        {
+            if(!DestinationType.IsAssignableFrom(typeOverride) && !typeOverride.IsGenericTypeDefinition() && !DestinationType.IsGenericTypeDefinition())
+            {
+                throw new ArgumentOutOfRangeException(nameof(typeOverride), $"{typeOverride} is not derived from {DestinationType}.");
+            }
+            TypeMapActions.Add(tm => tm.DestinationTypeOverride = typeOverride);
+        }
 
         public IMappingExpression<TSource, TDestination> ForCtorParam(string ctorParamName, Action<ICtorParamConfigurationExpression<TSource>> paramOptions)
         {

--- a/src/AutoMapper/IMappingExpression.cs
+++ b/src/AutoMapper/IMappingExpression.cs
@@ -370,7 +370,7 @@ namespace AutoMapper
         /// Override the destination type mapping for looking up configuration and instantiation
         /// </summary>
         /// <typeparam name="T">Destination type to use</typeparam>
-        void As<T>();
+        void As<T>() where T : TDestination;
 
         /// <summary>
         /// For self-referential types, limit recurse depth.

--- a/src/UnitTests/MappingInheritance/ShouldSupportOnlyDestinationTypeBeingDerived.cs
+++ b/src/UnitTests/MappingInheritance/ShouldSupportOnlyDestinationTypeBeingDerived.cs
@@ -8,6 +8,44 @@ using Xunit;
 
 namespace AutoMapper.UnitTests.MappingInheritance
 {
+    public class AsShouldWorkOnlyWithDerivedTypesWithGenerics : AutoMapperSpecBase
+    {
+        class Source<T>
+        {
+        }
+
+        class Destination<T>
+        {
+        }
+
+        class Override<T> : Destination<T>
+        {
+        }
+
+        protected override MapperConfiguration Configuration => new MapperConfiguration(c => c.CreateMap(typeof(Source<>), typeof(Destination<>)).As(typeof(Override<>)));
+    }
+
+    public class AsShouldWorkOnlyWithDerivedTypes
+    {
+        class Source
+        {
+        }
+
+        class Destination
+        {
+        }
+
+        [Fact]
+        public void Should_detect_unrelated_override()
+        {
+            new Action(() => new MapperConfiguration(c => c.CreateMap(typeof(Source), typeof(Destination)).As(typeof(Source)))).ShouldThrow<ArgumentOutOfRangeException>(ex =>
+            {
+                ex.ParamName.ShouldEqual("typeOverride");
+                ex.Message.ShouldStartWith($"{typeof(Source)} is not derived from {typeof(Destination)}.");
+            });
+        }
+    }
+
     public class DestinationTypePolymorphismTest
     {
         public class Customer


### PR DESCRIPTION
Skipped generics for simplicity. From #1776.