### PR TITLE
Match on requested types if runtime types don't match; fixes #1865

### DIFF
--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -101,7 +101,7 @@ namespace AutoMapper
 
         public LambdaExpression BuildExecutionPlan(MapRequest mapRequest)
         {
-            var typeMap = ResolveTypeMap(mapRequest.RuntimeTypes);
+            var typeMap = ResolveTypeMap(mapRequest.RuntimeTypes) ?? ResolveTypeMap(mapRequest.RequestedTypes);
             if(typeMap != null)
             {
                 return GenerateTypeMapExpression(mapRequest, typeMap);

--- a/src/UnitTests/TypeConverters.cs
+++ b/src/UnitTests/TypeConverters.cs
@@ -7,6 +7,28 @@ using Xunit;
 
 namespace AutoMapper.UnitTests.CustomMapping
 {
+    public class NullableConverter : AutoMapperSpecBase
+    {
+        public enum GreekLetters
+        {
+            Alpha = 11,
+            Beta = 12,
+            Gamma = 13
+        }
+
+        protected override MapperConfiguration Configuration => new MapperConfiguration(c =>
+        {
+            c.CreateMap<int?, GreekLetters>().ConvertUsing(n => n == null ? GreekLetters.Beta : GreekLetters.Gamma);
+        });
+
+        [Fact]
+        public void Should_map_nullable()
+        {
+            Mapper.Map<int?, GreekLetters>(null).ShouldEqual(GreekLetters.Beta);
+            Mapper.Map<int?, GreekLetters>(42).ShouldEqual(GreekLetters.Gamma);
+        }
+    }
+
     public class MissingConverter : AutoMapperSpecBase
     {
         protected override MapperConfiguration Configuration => new MapperConfiguration(c =>


### PR DESCRIPTION
Maybe this would make sense in other places too, but the cases I saw before were similar.