### PR TITLE
Correct order of ExpressionBinders

### DIFF
--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -31,11 +31,11 @@ namespace AutoMapper.QueryableExtensions
 
         private static readonly IExpressionBinder[] Binders =
         {
+            new CustomProjectionExpressionBinder(),
             new NullableExpressionBinder(),
             new AssignableExpressionBinder(),
             new EnumerableExpressionBinder(),
             new MappedTypeExpressionBinder(),
-            new CustomProjectionExpressionBinder(),
             new StringExpressionBinder()
         };
 

--- a/src/UnitTests/Bug/CannotProjectStringToNullableEnum.cs
+++ b/src/UnitTests/Bug/CannotProjectStringToNullableEnum.cs
@@ -1,0 +1,45 @@
+﻿using Should;
+using Xunit;
+using System.Linq;
+using AutoMapper;
+using AutoMapper.QueryableExtensions;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public class CannotProjectStringToNullableEnum
+    {
+        public enum DummyTypes : int
+        {
+            Foo = 1,
+            Bar = 2
+        }
+
+        public class DummySource
+        {
+            public string Dummy { get; set; }
+        }
+
+        public class DummyDestination
+        {
+            public DummyTypes? Dummy { get; set; }
+        }
+
+        [Fact]
+        public void Should_project_string_to_nullable_enum()
+        {
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<string, DummyTypes?>().ProjectUsing(s => (DummyTypes)System.Enum.Parse(typeof(DummyTypes),s));
+                cfg.CreateMap<DummySource, DummyDestination>();
+            });
+
+            config.AssertConfigurationIsValid();
+
+            var src = new DummySource[] { new DummySource { Dummy = "Foo" } };
+
+            var destination = src.AsQueryable().ProjectTo<DummyDestination>(config).First();
+
+            destination.Dummy.ShouldEqual(DummyTypes.Foo);
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -92,6 +92,7 @@
     <Compile Include="AssemblyScanning.cs" />
     <Compile Include="AssertionExtensions.cs" />
     <Compile Include="BasicFlattening.cs" />
+    <Compile Include="Bug\CannotProjectStringToNullableEnum.cs" />
     <Compile Include="Bug\ConventionCreateMapsWithCircularReference.cs" />
     <Compile Include="Bug\ConvertMapperThreading.cs" />
     <Compile Include="Bug\DeepCloningBug.cs" />


### PR DESCRIPTION
The order of the list of `IExpressionBinders` in `ExpressionBuilder.cs` is important because the first matching `ExpressionBinder` is selected.  When a custom expression binder is provided in the user's configuration, this should be used in preference to any of the built-in binders.  Prior to this fix the NullableExpresisonBinder would indicate a match if the destination type was of type `System.Nullable<>`  Fixes #1879 

Also added a unit test to demonstrate the bug.