### PR TITLE
Use ReverseTypeMaps when configuring closed generic TypeMaps

### DIFF
--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -187,6 +187,7 @@ namespace AutoMapper
         public TypeMap ConfigureClosedGenericTypeMap(TypeMapRegistry typeMapRegistry, TypePair closedTypes, TypePair requestedTypes)
         {
             var openMapConfig = _openTypeMapConfigs
+                .SelectMany(tm => tm.ReverseTypeMap == null ? new[] { tm } : new[] { tm, tm.ReverseTypeMap })
                 //.Where(tm => tm.IsOpenGeneric)
                 .Where(tm =>
                     tm.Types.SourceType.GetGenericTypeDefinitionIfGeneric() == closedTypes.SourceType.GetGenericTypeDefinitionIfGeneric() &&

--- a/src/UnitTests/ReverseMapping.cs
+++ b/src/UnitTests/ReverseMapping.cs
@@ -284,5 +284,40 @@ namespace AutoMapper.UnitTests
                 unmappedPropertyNames[0].ShouldEqual("Boo");
             }
         }
+
+        public class When_reverse_mapping_open_generics : AutoMapperSpecBase
+        {
+            private Source<int> _source;
+
+            public class Source<T>
+            {
+                public T Value { get; set; }
+            }
+            public class Destination<T>
+            {
+                public T Value { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap(typeof(Source<>), typeof(Destination<>))
+                    .ReverseMap();
+            });
+
+            protected override void Because_of()
+            {
+                var dest = new Destination<int>
+                {
+                    Value = 10
+                };
+                _source = Mapper.Map<Destination<int>, Source<int>>(dest);
+            }
+
+            [Fact]
+            public void Should_create_a_map_with_the_reverse_items()
+            {
+                _source.Value.ShouldEqual(10);
+            }
+        }
     }
 }


### PR DESCRIPTION
Currently, `ReverseMap` and open generics don't work together - the new test in this commit would fail with a 'Missing type map configuration' exception. This fixes that by including reverse maps when configuring closed generic maps.