### PR TITLE
Preserve references

### DIFF
--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -201,18 +201,15 @@ namespace AutoMapper.Execution
             if(_typeMap.PreserveReferences)
             {
                 var cache = Variable(_typeMap.DestinationTypeToUse, "cachedDestination");
-                var hasDestination = _context.Type.GetDeclaredMethod("HasDestination");
                 var getDestination = _context.Type.GetDeclaredMethod("GetDestination");
+                var assignCache =
+                    Assign(cache, ToType(Call(_context, getDestination, _source, Constant(_destination.Type)), _destination.Type));
                 var condition = Condition(
-                    AndAlso(
-                        NotEqual(_source, Constant(null)),
-                        Call(_context, hasDestination, _source, Constant(_destination.Type))),
-                    Assign(cache,
-                        ToType(Call(_context, getDestination, _source, Constant(_destination.Type)), _destination.Type)),
-                    Assign(cache, mapperFunc)
-                    );
+                    AndAlso(NotEqual(_source, Constant(null)), NotEqual(assignCache, Constant(null))),
+                    cache,
+                    mapperFunc);
 
-                mapperFunc = Block(new[] { cache }, condition, cache);
+                mapperFunc = Block(new[] { cache }, condition);
             }
             return mapperFunc;
         }

--- a/src/AutoMapper/ResolutionContext.cs
+++ b/src/AutoMapper/ResolutionContext.cs
@@ -131,15 +131,10 @@ namespace AutoMapper
         public static bool operator ==(ContextCacheKey left, ContextCacheKey right) => left.Equals(right);
         public static bool operator !=(ContextCacheKey left, ContextCacheKey right) => !left.Equals(right);
 
-        private static int CombineHashCodes(object obj1, object obj2)
-        {
-            return CombineHashCodes(obj1.GetHashCode(), obj2.GetHashCode());
-        }
+        private static int CombineHashCodes(object obj1, object obj2) =>
+            CombineHashCodes(obj1.GetHashCode(), obj2.GetHashCode());
 
-        private static int CombineHashCodes(int h1, int h2)
-        {
-            return (h1 << 5) + h1 ^ h2;
-        }
+        private static int CombineHashCodes(int h1, int h2) => (h1 << 5) + h1 ^ h2;
 
         private readonly int _hashCode;
         private readonly object _source;

--- a/src/AutoMapper/ResolutionContext.cs
+++ b/src/AutoMapper/ResolutionContext.cs
@@ -134,7 +134,7 @@ namespace AutoMapper
         private static int CombineHashCodes(object obj1, object obj2) =>
             CombineHashCodes(obj1.GetHashCode(), obj2.GetHashCode());
 
-        private static int CombineHashCodes(int h1, int h2) => (h1 << 5) + h1 ^ h2;
+        private static int CombineHashCodes(int h1, int h2) => ((h1 << 5) + h1) ^ h2;
 
         private readonly int _hashCode;
         private readonly object _source;

--- a/src/AutoMapper/ResolutionContext.cs
+++ b/src/AutoMapper/ResolutionContext.cs
@@ -131,6 +131,9 @@ namespace AutoMapper
 
     public struct SourceDestinationType : IEquatable<SourceDestinationType>
     {
+        public static bool operator ==(SourceDestinationType left, SourceDestinationType right) => Equals(left, right);
+        public static bool operator !=(SourceDestinationType left, SourceDestinationType right) => !Equals(left, right);
+
         private readonly int _hashCode;
         private readonly object _source;
         private readonly Type _destinationType;
@@ -142,14 +145,12 @@ namespace AutoMapper
             _hashCode = (_source.GetHashCode() * 397) ^ _destinationType.GetHashCode();
         }
 
-        public override int GetHashCode()
-        {
-            return _hashCode;
-        }
+        public override int GetHashCode() => _hashCode;
 
-        public bool Equals(SourceDestinationType other)
-        {
-            return ReferenceEquals(_source, other._source) && _destinationType == other._destinationType;
-        }
+        public bool Equals(SourceDestinationType other) =>
+            _source == other._source && _destinationType == other._destinationType;
+
+        public override bool Equals(object other) => 
+            other is SourceDestinationType && Equals((SourceDestinationType)other);
     }
 }

--- a/src/AutoMapper/ResolutionContext.cs
+++ b/src/AutoMapper/ResolutionContext.cs
@@ -18,14 +18,14 @@ namespace AutoMapper
         /// </summary>
         public IMappingOperationOptions Options { get; }
 
-        internal bool HasDestination(object source, Type destinationType)
-        {
-            return InstanceCache.ContainsKey(new SourceDestinationType(source, destinationType));
-        }
-
         internal object GetDestination(object source, Type destinationType)
         {
-            return InstanceCache[new SourceDestinationType(source, destinationType)];
+            object destination;
+            if(InstanceCache.TryGetValue(new SourceDestinationType(source, destinationType), out destination))
+            {
+                return destination;
+            }
+            return null;
         }
 
         internal void CacheDestination(object source, Type destinationType, object destination)

--- a/src/AutoMapper/ResolutionContext.cs
+++ b/src/AutoMapper/ResolutionContext.cs
@@ -131,8 +131,8 @@ namespace AutoMapper
 
     public struct SourceDestinationType : IEquatable<SourceDestinationType>
     {
-        public static bool operator ==(SourceDestinationType left, SourceDestinationType right) => Equals(left, right);
-        public static bool operator !=(SourceDestinationType left, SourceDestinationType right) => !Equals(left, right);
+        public static bool operator ==(SourceDestinationType left, SourceDestinationType right) => left.Equals(right);
+        public static bool operator !=(SourceDestinationType left, SourceDestinationType right) => !left.Equals(right);
 
         private readonly int _hashCode;
         private readonly object _source;

--- a/src/AutoMapper/ResolutionContext.cs
+++ b/src/AutoMapper/ResolutionContext.cs
@@ -21,11 +21,8 @@ namespace AutoMapper
         internal object GetDestination(object source, Type destinationType)
         {
             object destination;
-            if(InstanceCache.TryGetValue(new SourceDestinationType(source, destinationType), out destination))
-            {
-                return destination;
-            }
-            return null;
+            InstanceCache.TryGetValue(new SourceDestinationType(source, destinationType), out destination);
+            return destination;
         }
 
         internal void CacheDestination(object source, Type destinationType, object destination)

--- a/src/AutoMapper/ResolutionContext.cs
+++ b/src/AutoMapper/ResolutionContext.cs
@@ -134,6 +134,16 @@ namespace AutoMapper
         public static bool operator ==(SourceDestinationType left, SourceDestinationType right) => left.Equals(right);
         public static bool operator !=(SourceDestinationType left, SourceDestinationType right) => !left.Equals(right);
 
+        private static int CombineHashCodes(object obj1, object obj2)
+        {
+            return CombineHashCodes(obj1.GetHashCode(), obj2.GetHashCode());
+        }
+
+        private static int CombineHashCodes(int h1, int h2)
+        {
+            return (h1 << 5) + h1 ^ h2;
+        }
+
         private readonly int _hashCode;
         private readonly object _source;
         private readonly Type _destinationType;
@@ -142,7 +152,7 @@ namespace AutoMapper
         {
             _source = source;
             _destinationType = destinationType;
-            _hashCode = (_source.GetHashCode() * 397) ^ _destinationType.GetHashCode();
+            _hashCode = CombineHashCodes(_source, _destinationType);
         }
 
         public override int GetHashCode() => _hashCode;

--- a/src/AutoMapper/ResolutionContext.cs
+++ b/src/AutoMapper/ResolutionContext.cs
@@ -136,7 +136,6 @@ namespace AutoMapper
 
         private static int CombineHashCodes(int h1, int h2) => ((h1 << 5) + h1) ^ h2;
 
-        private readonly int _hashCode;
         private readonly object _source;
         private readonly Type _destinationType;
 
@@ -144,10 +143,9 @@ namespace AutoMapper
         {
             _source = source;
             _destinationType = destinationType;
-            _hashCode = CombineHashCodes(_source, _destinationType);
         }
 
-        public override int GetHashCode() => _hashCode;
+        public override int GetHashCode() => CombineHashCodes(_source, _destinationType);
 
         public bool Equals(ContextCacheKey other) =>
             _source == other._source && _destinationType == other._destinationType;

--- a/src/AutoMapper/ResolutionContext.cs
+++ b/src/AutoMapper/ResolutionContext.cs
@@ -10,7 +10,7 @@ namespace AutoMapper
     /// </summary>
     public class ResolutionContext
     {
-        private Dictionary<SourceDestinationType, object> _instanceCache;
+        private Dictionary<ContextCacheKey, object> _instanceCache;
         private Dictionary<TypePair, int> _typeDepth;
 
         /// <summary>
@@ -21,19 +21,19 @@ namespace AutoMapper
         internal object GetDestination(object source, Type destinationType)
         {
             object destination;
-            InstanceCache.TryGetValue(new SourceDestinationType(source, destinationType), out destination);
+            InstanceCache.TryGetValue(new ContextCacheKey(source, destinationType), out destination);
             return destination;
         }
 
         internal void CacheDestination(object source, Type destinationType, object destination)
         {
-            InstanceCache.Add(new SourceDestinationType(source, destinationType), destination);
+            InstanceCache.Add(new ContextCacheKey(source, destinationType), destination);
         }
 
         /// <summary>
         /// Instance cache for resolving circular references
         /// </summary>
-        public Dictionary<SourceDestinationType, object> InstanceCache
+        public Dictionary<ContextCacheKey, object> InstanceCache
         {
             get
             {
@@ -42,7 +42,7 @@ namespace AutoMapper
                 {
                     return _instanceCache;
                 }
-                _instanceCache = new Dictionary<SourceDestinationType, object>();
+                _instanceCache = new Dictionary<ContextCacheKey, object>();
                 return _instanceCache;
             }
         }
@@ -126,10 +126,10 @@ namespace AutoMapper
         }
     }
 
-    public struct SourceDestinationType : IEquatable<SourceDestinationType>
+    public struct ContextCacheKey : IEquatable<ContextCacheKey>
     {
-        public static bool operator ==(SourceDestinationType left, SourceDestinationType right) => left.Equals(right);
-        public static bool operator !=(SourceDestinationType left, SourceDestinationType right) => !left.Equals(right);
+        public static bool operator ==(ContextCacheKey left, ContextCacheKey right) => left.Equals(right);
+        public static bool operator !=(ContextCacheKey left, ContextCacheKey right) => !left.Equals(right);
 
         private static int CombineHashCodes(object obj1, object obj2)
         {
@@ -145,7 +145,7 @@ namespace AutoMapper
         private readonly object _source;
         private readonly Type _destinationType;
 
-        public SourceDestinationType(object source, Type destinationType)
+        public ContextCacheKey(object source, Type destinationType)
         {
             _source = source;
             _destinationType = destinationType;
@@ -154,10 +154,10 @@ namespace AutoMapper
 
         public override int GetHashCode() => _hashCode;
 
-        public bool Equals(SourceDestinationType other) =>
+        public bool Equals(ContextCacheKey other) =>
             _source == other._source && _destinationType == other._destinationType;
 
         public override bool Equals(object other) => 
-            other is SourceDestinationType && Equals((SourceDestinationType)other);
+            other is ContextCacheKey && Equals((ContextCacheKey)other);
     }
 }

--- a/src/UnitTests/Bug/OneSourceWithMultipleDestinationsAndPreserveReferences.cs
+++ b/src/UnitTests/Bug/OneSourceWithMultipleDestinationsAndPreserveReferences.cs
@@ -1,0 +1,43 @@
+﻿using Xunit;
+using Should;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public class OneSourceWithMultipleDestinationsAndPreserveReferences : AutoMapperSpecBase
+    {
+        ClientModel _destination;
+
+        public partial class Client
+        {
+            public string Address1 { get; set; }
+        }
+        public class AddressModel
+        {
+            public string Address1 { get; set; }
+        }
+        public class ClientModel
+        {
+            public AddressModel Address { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(mapConfig =>
+        {
+            mapConfig.CreateMap<Client, ClientModel>()
+                .ForMember(m => m.Address, opt => opt.MapFrom(x => x))
+                .PreserveReferences();
+            mapConfig.CreateMap<Client, AddressModel>()
+                .PreserveReferences();
+        });
+
+        protected override void Because_of()
+        {
+            _destination = Mapper.Map<ClientModel>(new Client { Address1 = "abc" });
+        }
+
+        [Fact]
+        public void Should_map_ok()
+        {
+            _destination.Address.Address1.ShouldEqual("abc");
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -93,6 +93,7 @@
     <Compile Include="AssertionExtensions.cs" />
     <Compile Include="BasicFlattening.cs" />
     <Compile Include="Bug\CannotProjectStringToNullableEnum.cs" />
+    <Compile Include="Bug\OneSourceWithMultipleDestinationsAndPreserveReferences.cs" />
     <Compile Include="Bug\ConventionCreateMapsWithCircularReference.cs" />
     <Compile Include="Bug\ConvertMapperThreading.cs" />
     <Compile Include="Bug\DeepCloningBug.cs" />


### PR DESCRIPTION
Fixes #1892. Closes #1894.
I guess it's a breaking change, but nobody should be using InstanceCache anyway. We could make it internal, or even private (private seems best). Funny enough, I wasn't able to make out parameters work, and not for lack of trying. It worked in a simple test, but not in AM.
I took GetHashCode from System.Tuple. I guess it's close to the idea you used in TypePair. We should have a helper to be used everywhere. It's not in the framework yet I believe. I don't think we need to cache the hash code when the fields are read-only. Tuple doesn't. That saves the field and avoids computing it when it's not needed (granted, that's just a few instructions).