### PR TITLE
UseDestinationValue is now false by default

### DIFF
--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -233,11 +233,6 @@ namespace AutoMapper.Configuration
             PropertyMapActions.Add(pm => pm.UseDestinationValue = true);
         }
 
-        public void DoNotUseDestinationValue()
-        {
-            PropertyMapActions.Add(pm => pm.UseDestinationValue = false);
-        }
-
         public void SetMappingOrder(int mappingOrder)
         {
             PropertyMapActions.Add(pm => pm.MappingOrder = mappingOrder);

--- a/src/AutoMapper/IMemberConfigurationExpression.cs
+++ b/src/AutoMapper/IMemberConfigurationExpression.cs
@@ -134,11 +134,6 @@ namespace AutoMapper
         /// Use the destination value instead of mapping from the source value or creating a new instance
         /// </summary>
         void UseDestinationValue();
-
-        /// <summary>
-        /// Do not use the destination value instead of mapping from the source value or creating a new instance
-        /// </summary>        
-        void DoNotUseDestinationValue();
         
         /// <summary>
         /// Use a custom value

--- a/src/UnitTests/Bug/ForAllMembersAndDoNotUseDestinationValue.cs
+++ b/src/UnitTests/Bug/ForAllMembersAndDoNotUseDestinationValue.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace AutoMapper.UnitTests.Bug
 {
-    public class ForAllMembersAndDoNotUseDestinationValue : AutoMapperSpecBase
+    public class ForAllMembersAndResolveUsing : AutoMapperSpecBase
     {
         private Destination _destination;
 
@@ -19,7 +19,7 @@ namespace AutoMapper.UnitTests.Bug
 
         protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
         {
-            cfg.CreateMap<Source, Destination>().ForAllMembers(opt => opt.DoNotUseDestinationValue());
+            cfg.CreateMap<Source, Destination>().ForAllMembers(opt => opt.ResolveUsing(s=>12));
         });
 
         protected override void Because_of()
@@ -34,7 +34,7 @@ namespace AutoMapper.UnitTests.Bug
         [Fact]
         public void Should_work_together()
         {
-            _destination.Number.ShouldEqual(23);
+            _destination.Number.ShouldEqual(12);
         }
     }
 }


### PR DESCRIPTION
I think this should have been removed when we changed the default. I was tempted to use it for #1918. But of course, it doesn't do anything.