### PR TITLE
Concurrency

### DIFF
--- a/src/UnitTests/Bug/MultiThreadingIssues.cs
+++ b/src/UnitTests/Bug/MultiThreadingIssues.cs
@@ -135,62 +135,62 @@ namespace AutoMapper.UnitTests.Bug
     {
         public class SomeDtoA
         {
-            private string Property1 { get; set; }
-            private string Property21 { get; set; }
-            private string Property3 { get; set; }
-            private string Property4 { get; set; }
-            private string Property5 { get; set; }
-            private string Property6 { get; set; }
-            private string Property7 { get; set; }
-            private string Property8 { get; set; }
-            private string Property9 { get; set; }
-            private string Property10 { get; set; }
-            private string Property11 { get; set; }
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
         }
 
         public class SomeDtoB
         {
-            private string Property1 { get; set; }
-            private string Property21 { get; set; }
-            private string Property3 { get; set; }
-            private string Property4 { get; set; }
-            private string Property5 { get; set; }
-            private string Property6 { get; set; }
-            private string Property7 { get; set; }
-            private string Property8 { get; set; }
-            private string Property9 { get; set; }
-            private string Property10 { get; set; }
-            private string Property11 { get; set; }
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
         }
 
         public class SomeDtoC
         {
-            private string Property1 { get; set; }
-            private string Property21 { get; set; }
-            private string Property3 { get; set; }
-            private string Property4 { get; set; }
-            private string Property5 { get; set; }
-            private string Property6 { get; set; }
-            private string Property7 { get; set; }
-            private string Property8 { get; set; }
-            private string Property9 { get; set; }
-            private string Property10 { get; set; }
-            private string Property11 { get; set; }
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
         }
 
         public class SomeDtoD
         {
-            private string Property1 { get; set; }
-            private string Property21 { get; set; }
-            private string Property3 { get; set; }
-            private string Property4 { get; set; }
-            private string Property5 { get; set; }
-            private string Property6 { get; set; }
-            private string Property7 { get; set; }
-            private string Property8 { get; set; }
-            private string Property9 { get; set; }
-            private string Property10 { get; set; }
-            private string Property11 { get; set; }
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
         }
 
         [Fact]
@@ -224,92 +224,3 @@ namespace AutoMapper.UnitTests.Bug
         }
     }
 }
-
-// The three exceptions I saw while running the multithreading tests for DynamicMap (lbargaoanu)
-
-//Unhandled Exception: System.AggregateException: One or more errors occurred. ---> AutoMapper.AutoMapperMappingException:
-
-//Mapping types:
-//SomeDtoB -> SomeDtoA
-//TestConsole.Program+SomeDtoB -> TestConsole.Program+SomeDtoA
-
-//Destination path:
-//SomeDtoA
-
-//Source value:
-//TestConsole.Program+SomeDtoB ---> System.NullReferenceException: Object reference not set to an instance of an object.
-//   at AutoMapper.MappingEngine.AutoMapper.IMappingEngineRunner.Map(ResolutionContext context) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine.c
-//s:line 256
-//   --- End of inner exception stack trace ---
-//   at AutoMapper.MappingEngine.AutoMapper.IMappingEngineRunner.Map(ResolutionContext context) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine.c
-//s:line 264
-//   at AutoMapper.MappingEngine.DynamicMap(Object source, Type sourceType, Type destinationType) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine
-//.cs:line 199
-//   at AutoMapper.MappingEngine.DynamicMap[TSource, TDestination](TSource source) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine.cs:line 170
-//   at AutoMapper.Mapper.DynamicMap[TSource, TDestination](TSource source) in D:\Projects\AutoMapper\src\AutoMapper\Mapper.cs:line 174
-//   at TestConsole.Program.<>c.<Main>b__6_1() in D:\Projects\TestConsole\TestConsole\Program.cs:line 141
-//   at System.Threading.Tasks.Task.Execute()
-//   --- End of inner exception stack trace ---
-//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout, CancellationToken cancellationToken)
-//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout)
-//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks)
-//   at TestConsole.Program.Main(String[] args) in D:\Projects\TestConsole\TestConsole\Program.cs:line 146
-
-//Unhandled Exception: System.AggregateException: One or more errors occurred. ---> AutoMapper.AutoMapperMappingException:
-
-//Mapping types:
-//SomeDtoB -> SomeDtoA
-//TestConsole.Program+SomeDtoB -> TestConsole.Program+SomeDtoA
-
-//Destination path:
-//SomeDtoA
-
-//Source value:
-//TestConsole.Program+SomeDtoB ---> System.NullReferenceException: Object reference not set to an instance of an object.
-//   at AutoMapper.Mappers.TypeMapMapper.Map(ResolutionContext context, IMappingEngineRunner mapper) in D:\Projects\AutoMapper\src\AutoMapper\Mappers\Ty
-//peMapMapper.cs:line 17
-//   at AutoMapper.MappingEngine.AutoMapper.IMappingEngineRunner.Map(ResolutionContext context) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine.c
-//s:line 260
-//   --- End of inner exception stack trace ---
-//   at AutoMapper.MappingEngine.AutoMapper.IMappingEngineRunner.Map(ResolutionContext context) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine.c
-//s:line 268
-//   at AutoMapper.MappingEngine.DynamicMap(Object source, Type sourceType, Type destinationType) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine
-//.cs:line 199
-//   at AutoMapper.MappingEngine.DynamicMap[TSource, TDestination](TSource source) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine.cs:line 170
-//   at AutoMapper.Mapper.DynamicMap[TSource, TDestination](TSource source) in D:\Projects\AutoMapper\src\AutoMapper\Mapper.cs:line 174
-//   at TestConsole.Program.<>c.<Main>b__6_1() in D:\Projects\TestConsole\TestConsole\Program.cs:line 141
-//   at System.Threading.Tasks.Task.Execute()
-//   --- End of inner exception stack trace ---
-//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout, CancellationToken cancellationToken)
-//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout)
-//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks)
-//   at TestConsole.Program.Main(String[] args) in D:\Projects\TestConsole\TestConsole\Program.cs:line 145
-
-//Unhandled Exception: System.AggregateException: One or more errors occurred. ---> System.Collections.Generic.KeyNotFoundException: The given key was n
-//ot present in the dictionary.
-//   at System.Collections.Concurrent.ConcurrentDictionary`2.get_Item(TKey key)
-//   at AutoMapper.Internal.DictionaryFactoryOverride.ConcurrentDictionaryImpl`2.get_Item(TKey key) in D:\Projects\AutoMapper\src\AutoMapper\Internal\Co
-//ncurrentDictionaryFactory.cs:line 42
-//   at AutoMapper.ConfigurationStore.<ResolveTypeMap>b__87_1(TypePair tp) in D:\Projects\AutoMapper\src\AutoMapper\ConfigurationStore.cs:line 356
-//   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
-//   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
-//   at AutoMapper.ConfigurationStore.<ResolveTypeMap>b__87_0(TypePair _) in D:\Projects\AutoMapper\src\AutoMapper\ConfigurationStore.cs:line 353
-//   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(TKey key, Func`2 valueFactory)
-//   at AutoMapper.Internal.DictionaryFactoryOverride.ConcurrentDictionaryImpl`2.GetOrAdd(TKey key, Func`2 valueFactory) in D:\Projects\AutoMapper\src\A
-//utoMapper\Internal\ConcurrentDictionaryFactory.cs:line 37
-//   at AutoMapper.ConfigurationStore.ResolveTypeMap(TypePair typePair) in D:\Projects\AutoMapper\src\AutoMapper\ConfigurationStore.cs:line 351
-//   at AutoMapper.ConfigurationStore.ResolveTypeMap(Type sourceType, Type destinationType) in D:\Projects\AutoMapper\src\AutoMapper\ConfigurationStore.
-//cs:line 346
-//   at AutoMapper.ConfigurationStore.ResolveTypeMap(Object source, Object destination, Type sourceType, Type destinationType) in D:\Projects\AutoMapper
-//\src\AutoMapper\ConfigurationStore.cs:line 364
-//   at AutoMapper.MappingEngine.DynamicMap(Object source, Type sourceType, Type destinationType) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine
-//.cs:line 191
-//   at AutoMapper.MappingEngine.DynamicMap[TSource, TDestination](TSource source) in D:\Projects\AutoMapper\src\AutoMapper\MappingEngine.cs:line 170
-//   at AutoMapper.Mapper.DynamicMap[TSource, TDestination](TSource source) in D:\Projects\AutoMapper\src\AutoMapper\Mapper.cs:line 174
-//   at TestConsole.Program.<>c.<Main>b__6_1() in D:\Projects\TestConsole\TestConsole\Program.cs:line 143
-//   at System.Threading.Tasks.Task.Execute()
-//   --- End of inner exception stack trace ---
-//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout, CancellationToken cancellationToken)
-//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks, Int32 millisecondsTimeout)
-//   at System.Threading.Tasks.Task.WaitAll(Task[] tasks)
-//   at TestConsole.Program.Main(String[] args) in D:\Projects\TestConsole\TestConsole\Program.cs:line 145

--- a/src/UnitTests/Bug/MultiThreadingIssues.cs
+++ b/src/UnitTests/Bug/MultiThreadingIssues.cs
@@ -1,9 +1,9 @@
-﻿using System ;
+﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics ;
+using System.Diagnostics;
 using System.Linq;
-using System.Threading ;
-using System.Threading.Tasks ;
+using System.Threading;
+using System.Threading.Tasks;
 using AutoMapper.Mappers;
 using Xunit;
 
@@ -15,118 +15,118 @@ namespace AutoMapper.UnitTests.Bug
     {
         public class Type1
         {
-            public string FirstName ;
-            public string MiddleName ;
-            public string LastName ;
-            public int Age ;
+            public string FirstName;
+            public string MiddleName;
+            public string LastName;
+            public int Age;
         }
 
         public class Type1Point3
         {
-            public string FirstName ;
-            public string MiddleName ;
-            public string LastName ;
+            public string FirstName;
+            public string MiddleName;
+            public string LastName;
         }
 
         public class Type1Point2
         {
-            public string FirstName ;
-            public string MiddleName ;
+            public string FirstName;
+            public string MiddleName;
         }
 
         public class Type1Point1
         {
-            public string FirstName ;
+            public string FirstName;
         }
 
         public class DestType
         {
-            public string FirstName ;
-            public string MiddleName ;
-            public string LastName ;
-            public int Age ;
+            public string FirstName;
+            public string MiddleName;
+            public string LastName;
+            public int Age;
         }
 
-        static int _done ;
-        readonly ManualResetEvent _allDone = new ManualResetEvent( false );
+        static int _done;
+        readonly ManualResetEvent _allDone = new ManualResetEvent(false);
 
         [Fact]
         public void ShouldMapToNewISet()
         {
-            const int threadCount = 130 ;
+            const int threadCount = 130;
 
-            for (int i = 0; i < threadCount; i++)
+            for(int i = 0; i < threadCount; i++)
             {
-                Task.Factory.StartNew( doMapping ).ContinueWith(
+                Task.Factory.StartNew(doMapping).ContinueWith(
                     a =>
+                    {
+                        if(Interlocked.Increment(ref _done) == threadCount)
                         {
-                            if (Interlocked.Increment(ref _done) == threadCount)
-                            {
-                                _allDone.Set( ) ;
-                            }
+                            _allDone.Set();
+                        }
 
-                        } ) ;
+                    });
             }
 
-            _allDone.WaitOne( TimeSpan.FromSeconds( 10 ) ) ;
+            _allDone.WaitOne(TimeSpan.FromSeconds(10));
         }
 
-        static void doMapping( )
+        static void doMapping()
         {
-            var source = createSource( ) ;
+            var source = createSource();
 
-            Console.WriteLine( @"Mapping {0} on thread {1}", source.GetType( ), Thread.CurrentThread.ManagedThreadId ) ;
+            Console.WriteLine(@"Mapping {0} on thread {1}", source.GetType(), Thread.CurrentThread.ManagedThreadId);
 
-            var config = new MapperConfiguration(cfg => cfg.CreateMap(source.GetType(), typeof (DestType)));
+            var config = new MapperConfiguration(cfg => cfg.CreateMap(source.GetType(), typeof(DestType)));
 
-            DestType t2 = (DestType)config.CreateMapper().Map(source, source.GetType(  ), typeof( DestType ) )  ;
+            DestType t2 = (DestType)config.CreateMapper().Map(source, source.GetType(), typeof(DestType));
         }
-        
+
         static readonly Random _random = new Random();
 
-        static object createSource( )
+        static object createSource()
         {
-            
-            int n = _random.Next( 0, 4 ) ;
-            
-            if( n == 0 )
+
+            int n = _random.Next(0, 4);
+
+            if(n == 0)
             {
                 return new Type1
-                    {
-                        Age = 12,
-                        FirstName = @"Fred",
-                        LastName = @"Smith",
-                        MiddleName = @"G"
-                    } ;
+                {
+                    Age = 12,
+                    FirstName = @"Fred",
+                    LastName = @"Smith",
+                    MiddleName = @"G"
+                };
             }
-            if( n == 1 )
+            if(n == 1)
             {
-                return new Type1Point1( ) 
-                    {
-                        FirstName = @"Fred",
-                    } ;
+                return new Type1Point1()
+                {
+                    FirstName = @"Fred",
+                };
 
             }
-            if( n == 2 )
+            if(n == 2)
             {
-                return new Type1Point2( ) 
-                    {
-                        FirstName = @"Fred",
-                        MiddleName = @"G"
-                    } ;
+                return new Type1Point2()
+                {
+                    FirstName = @"Fred",
+                    MiddleName = @"G"
+                };
 
             }
-            if( n == 3 )
+            if(n == 3)
             {
-                return new Type1Point3( ) 
-                    {
-                        FirstName = @"Fred",
-                        LastName = @"Smith",
-                        MiddleName = @"G"
-                    } ;
+                return new Type1Point3()
+                {
+                    FirstName = @"Fred",
+                    LastName = @"Smith",
+                    MiddleName = @"G"
+                };
 
             }
-            
+
             throw new Exception();
         }
     }
@@ -199,28 +199,21 @@ namespace AutoMapper.UnitTests.Bug
             var config = new MapperConfiguration(cfg => cfg.CreateMissingTypeMaps = true);
             var mapper = config.CreateMapper();
 
-            var tasks = Enumerable.Range(0, 5).Select(
-          i =>
-              Task.Factory.StartNew(
-                  () =>
+            var tasks = Enumerable.Range(0, 5).Select(index =>
+              Task.Factory.StartNew(() =>
                   {
-                      mapper.Map<SomeDtoA, SomeDtoB>(new SomeDtoA());
-                      mapper.Map<SomeDtoB, SomeDtoA>(new SomeDtoB());
-                      mapper.Map<SomeDtoC, SomeDtoD>(new SomeDtoC());
-                      mapper.Map<SomeDtoD, SomeDtoC>(new SomeDtoD());
-                  }))
-          .ToArray();
-            Exception exception = null;
-            try
-            {
-                Task.WaitAll(tasks);
-            }
-            catch (Exception e)
-            {
-                exception = e;
-            }
-            exception.ShouldBeNull();
-            //typeof(Exception).ShouldNotBeThrownBy(() => Task.WaitAll(tasks));
+                      if(index % 2 == 0)
+                      {
+                          mapper.Map<SomeDtoA, SomeDtoB>(new SomeDtoA());
+                          mapper.Map<SomeDtoC, SomeDtoD>(new SomeDtoC());
+                      }
+                      else
+                      {
+                          mapper.Map<SomeDtoB, SomeDtoA>(new SomeDtoB());
+                          mapper.Map<SomeDtoD, SomeDtoC>(new SomeDtoD());
+                      }
+                  })).ToArray();
+            Task.WaitAll(tasks);
         }
     }
 }


### PR DESCRIPTION
I guess we cannot have a single global lock. The right granularity seems to be per type pair. But this can be tricky. Hopefully it doesn't matter much in the usual case because everything is already in the cache. Creating maps on the fly is more complicated.