### PR TITLE
Exclude more system base types

### DIFF
--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -9,6 +9,10 @@ namespace AutoMapper
     using Configuration.Conventions;
     using Mappers;
 
+#if NETSTANDARD1_1
+    struct IConvertible{}
+#endif
+
     [DebuggerDisplay("{Name}")]
     public class ProfileMap
     {

--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -12,6 +12,7 @@ namespace AutoMapper
     [DebuggerDisplay("{Name}")]
     public class ProfileMap
     {
+        private static readonly Type[] ExcludedTypes = new[]{ typeof(object), typeof(ValueType), typeof(Enum), typeof(IComparable), typeof(IFormattable), typeof(IConvertible) };
         private readonly TypeMapFactory _typeMapFactory = new TypeMapFactory();
         private readonly IEnumerable<ITypeMapConfiguration> _typeMapConfigs;
         private readonly IEnumerable<ITypeMapConfiguration> _openTypeMapConfigs;
@@ -38,7 +39,7 @@ namespace AutoMapper
             TypeConfigurations = profile.TypeConfigurations
                 .Concat(configuration?.TypeConfigurations ?? Enumerable.Empty<IConditionalObjectMapper>())
                 .Concat(CreateMissingTypeMaps
-                    ? Enumerable.Repeat(new ConditionalObjectMapper { Conventions = { tp => tp.SourceType != typeof(object) && tp.DestinationType != typeof(object) } }, 1)
+                    ? Enumerable.Repeat(new ConditionalObjectMapper { Conventions = { tp => !ExcludedTypes.Contains(tp.SourceType) && !ExcludedTypes.Contains(tp.DestinationType)} }, 1)
                     : Enumerable.Empty<IConditionalObjectMapper>())
                 .ToArray();
 

--- a/src/UnitTests/DynamicMapping.cs
+++ b/src/UnitTests/DynamicMapping.cs
@@ -6,6 +6,29 @@ using System.Collections.Generic;
 
 namespace AutoMapper.UnitTests.DynamicMapping
 {
+    public class When_mapping_from_untyped_enum_to_typed_enum : NonValidatingSpecBase
+    {
+        private Destination _result;
+
+        public class Destination
+        {
+            public ConsoleColor Value { get; set; }
+        }
+
+        protected override void Because_of()
+        {
+            _result = Mapper.Map<Destination>(new { Value = (Enum) ConsoleColor.DarkGreen });
+        }
+
+        [Fact]
+        public void Should_map_ok()
+        {
+            _result.Value.ShouldEqual(ConsoleColor.DarkGreen);
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => cfg.CreateMissingTypeMaps = true);
+    }
+
     public class When_mapping_nested_types : NonValidatingSpecBase
     {
         List<ParentTestDto> _destination;


### PR DESCRIPTION
Fixes #1931. I guess primitive types, string, decimal would make sense too. It might break some people, but I think we should exclude them.