### PR TITLE
Fix to static method TypePair.Create() pulling type from instance of source (always) instead

### DIFF
--- a/src/AutoMapper/TypePair.cs
+++ b/src/AutoMapper/TypePair.cs
@@ -57,23 +57,11 @@ namespace AutoMapper
 
         public static TypePair Create<TSource>(TSource source, Type sourceType, Type destinationType)
         {
-            if(source != null)
-            {
-                sourceType = source.GetType();
-            }
             return new TypePair(sourceType, destinationType);
         }
 
         public static TypePair Create<TSource, TDestination>(TSource source, TDestination destination, Type sourceType, Type destinationType)
         {
-            if(source != null)
-            {
-                sourceType = source.GetType();
-            }
-            if(destination != null)
-            {
-                destinationType = destination.GetType();
-            }
             return new TypePair(sourceType, destinationType);
         }
 

--- a/src/UnitTests/Bug/TypePairWithInterfacesBugTests.cs
+++ b/src/UnitTests/Bug/TypePairWithInterfacesBugTests.cs
@@ -1,0 +1,63 @@
+﻿using Should;
+using Xunit;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    /// <summary>
+    /// The purpose of these tests is to highlight unexpected behavior.
+    /// The unexpected behavior is that if one explicitly declares a source type
+    /// that that is the typemap which should be used.  
+    /// 
+    /// The current behavior uses the type returned from the .GetType() method of the instance of the source.
+    /// 
+    /// This behavior inhibits polymorphic behavior of classes.  
+    /// Sometimes we may want to map things in different ways, and interfaces nicely allow us 
+    /// to operate on an object as the interface and not on the object as a whole.
+    /// </summary>
+    public class TypePairWithInterfacesBugTests : AutoMapperSpecBase
+    {
+        interface IFoo
+        {
+            string Name { get; set; }
+        }
+
+        class Source : IFoo
+        {
+            public string Name { get; set; }
+        }
+        class Destination
+        {
+            public string Name { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>();
+            cfg.CreateMap<IFoo, Destination>().AfterMap((s,d)=>d.Name = "IFooMack");
+        });
+
+        [Fact]
+        public void Should_work_ClassTypeToClassType()
+        {
+            var source = new Source
+            {
+                Name = "BlackjacketMack"
+            };
+            var destination = Mapper.Map<Source, Destination>(source);
+
+            destination.Name.ShouldEqual("BlackjacketMack");
+        }
+
+        [Fact]
+        public void Should_workButDoesnt_AfterMapShouldBeCalledHere()
+        {
+            var source = new Source
+            {
+                Name = "BlackjacketMack"
+            };
+            var destination = Mapper.Map<IFoo, Destination>(source);
+
+            destination.Name.ShouldEqual("IFooMack");
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -229,6 +229,7 @@
     <Compile Include="Bug\NullSubstituteInnerClass.cs" />
     <Compile Include="Bug\MapExpandoObjectProperty.cs" />
     <Compile Include="Bug\PreserveReferencesSameDestination.cs" />
+    <Compile Include="Bug\TypePairWithInterfacesBugTests.cs" />
     <Compile Include="BuildExecutionPlan.cs" />
     <Compile Include="ConfigCompilation.cs" />
     <Compile Include="CustomCollectionTester.cs" />


### PR DESCRIPTION
of trusint inbound types.  Specifically, if someone wanted to map a source in different forms (e.g. via interfaces)
to a destination they would be unable to do so.