### PR TITLE
We usually want ResolveTypeMap, not TypeMapRegistry.GetTypeMap

### DIFF
--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -21,7 +21,6 @@ namespace AutoMapper.Execution
 
         private readonly IConfigurationProvider _configurationProvider;
         private readonly TypeMap _typeMap;
-        private readonly TypeMapRegistry _typeMapRegistry;
         private readonly ParameterExpression _source;
         private readonly ParameterExpression _initialDestination;
         private readonly ParameterExpression _context;
@@ -30,10 +29,9 @@ namespace AutoMapper.Execution
         public ParameterExpression Source => _source;
         public ParameterExpression Context => _context;
 
-        public TypeMapPlanBuilder(IConfigurationProvider configurationProvider, TypeMapRegistry typeMapRegistry, TypeMap typeMap)
+        public TypeMapPlanBuilder(IConfigurationProvider configurationProvider, TypeMap typeMap)
         {
             _configurationProvider = configurationProvider;
-            _typeMapRegistry = typeMapRegistry;
             _typeMap = typeMap;
             _source = Parameter(typeMap.SourceType, "src");
             _initialDestination = Parameter(typeMap.DestinationTypeToUse, "dest");
@@ -472,10 +470,10 @@ namespace AutoMapper.Execution
 
         public Expression MapExpression(TypePair typePair, Expression sourceParameter, PropertyMap propertyMap = null, Expression destinationParameter = null)
         {
-            return MapExpression(_typeMapRegistry, _configurationProvider, typePair, sourceParameter, _context, propertyMap, destinationParameter);
+            return MapExpression(_configurationProvider, typePair, sourceParameter, _context, propertyMap, destinationParameter);
         }
 
-        public static Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider,
+        public static Expression MapExpression(IConfigurationProvider configurationProvider,
             TypePair typePair, Expression sourceParameter, Expression contextParameter, PropertyMap propertyMap = null, Expression destinationParameter = null)
         {
             if(destinationParameter == null)
@@ -487,7 +485,7 @@ namespace AutoMapper.Execution
             {
                 if(!typeMap.HasDerivedTypesToInclude())
                 {
-                    typeMap.Seal(typeMapRegistry, configurationProvider);
+                    typeMap.Seal(configurationProvider);
                     if(typeMap.MapExpression != null)
                     {
                         return typeMap.MapExpression.ConvertReplaceParameters(sourceParameter, destinationParameter, contextParameter);
@@ -505,7 +503,7 @@ namespace AutoMapper.Execution
             var match = configurationProvider.GetMappers().FirstOrDefault(m => m.IsMatch(typePair));
             if(match != null)
             {
-                var mapperExpression = match.MapExpression(typeMapRegistry, configurationProvider, propertyMap, sourceParameter, destinationParameter, contextParameter);
+                var mapperExpression = match.MapExpression(configurationProvider, propertyMap, sourceParameter, destinationParameter, contextParameter);
                 return ToType(mapperExpression, typePair.DestinationType);
             }
             return ContextMap(typePair, sourceParameter, contextParameter, destinationParameter);

--- a/src/AutoMapper/IObjectMapper.cs
+++ b/src/AutoMapper/IObjectMapper.cs
@@ -22,14 +22,14 @@ namespace AutoMapper
         /// <summary>
         /// Builds a mapping expression equivalent to the base Map method
         /// </summary>
-        /// <param name="typeMapRegistry"></param>
         /// <param name="configurationProvider"></param>
         /// <param name="propertyMap"></param>
         /// <param name="sourceExpression">Source parameter</param>
         /// <param name="destExpression">Destination parameter</param>
         /// <param name="contextExpression">ResulotionContext parameter</param>
+        /// 
         /// <returns>Map expression</returns>
-        Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression);
+        Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression);
     }
 
     /// <summary>
@@ -57,7 +57,7 @@ namespace AutoMapper
         /// <returns>Destination object</returns>
         public abstract TDestination Map(TSource source, TDestination destination, ResolutionContext context);
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Call(Constant(this), MapMethod, ToType(sourceExpression, typeof(TSource)), ToType(destExpression, typeof(TDestination)), contextExpression);
         }

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -166,7 +166,7 @@ namespace AutoMapper
             }
             else
             {
-                var map = mapperToUse.MapExpression(mapperConfiguration._typeMapRegistry, mapperConfiguration, null, ToType(source, mapRequest.RuntimeTypes.SourceType), destination, context);
+                var map = mapperToUse.MapExpression(mapperConfiguration, null, ToType(source, mapRequest.RuntimeTypes.SourceType), destination, context);
                 var mapToDestination = Lambda(ToType(map, destinationType), source, destination, context);
                 fullExpression = TryCatch(mapToDestination, source, destination, context, mapRequest.RequestedTypes);
             }
@@ -206,7 +206,7 @@ namespace AutoMapper
             {
                 lock(typeMap)
                 {
-                    typeMap.Seal(_typeMapRegistry, this);
+                    typeMap.Seal(this);
                 }
             }
             return typeMap;
@@ -317,7 +317,7 @@ namespace AutoMapper
 
             foreach (var typeMap in _typeMapRegistry.TypeMaps)
             {
-                typeMap.Seal(_typeMapRegistry, this);
+                typeMap.Seal(this);
             }
         }
 
@@ -351,7 +351,7 @@ namespace AutoMapper
 
             if(!Configuration.CreateMissingTypeMaps)
             {
-                typeMap?.Seal(_typeMapRegistry, this);
+                typeMap?.Seal(this);
             }
 
             return typeMap;
@@ -366,7 +366,7 @@ namespace AutoMapper
                 .Select(p => p.ConfigureClosedGenericTypeMap(_typeMapRegistry, typePair, requestedTypes))
                 .FirstOrDefault(t => t != null);
 
-            typeMap?.Seal(_typeMapRegistry, this);
+            typeMap?.Seal(this);
 
             return typeMap;
         }

--- a/src/AutoMapper/Mappers/ArrayMapper.cs
+++ b/src/AutoMapper/Mappers/ArrayMapper.cs
@@ -31,7 +31,7 @@ namespace AutoMapper.Mappers
             return (context.DestinationType.IsArray) && (context.SourceType.IsEnumerableType());
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             var sourceElementType = TypeHelper.GetElementType(sourceExpression.Type);
             var destElementType = TypeHelper.GetElementType(destExpression.Type);
@@ -43,7 +43,7 @@ namespace AutoMapper.Mappers
                                  : NewArrayBounds(destElementType, Constant(0));
 
             ParameterExpression itemParam;
-            var itemExpr = typeMapRegistry.MapItemExpr(configurationProvider, propertyMap, sourceExpression.Type, destExpression.Type, contextExpression, out itemParam);
+            var itemExpr = configurationProvider.MapItemExpr(propertyMap, sourceExpression.Type, destExpression.Type, contextExpression, out itemParam);
 
             //var count = source.Count();
             //var array = new TDestination[count];

--- a/src/AutoMapper/Mappers/AssignableMapper.cs
+++ b/src/AutoMapper/Mappers/AssignableMapper.cs
@@ -9,7 +9,7 @@ namespace AutoMapper.Mappers
             return context.DestinationType.IsAssignableFrom(context.SourceType);
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return sourceExpression;
         }

--- a/src/AutoMapper/Mappers/ConvertMapper.cs
+++ b/src/AutoMapper/Mappers/ConvertMapper.cs
@@ -61,7 +61,7 @@ namespace AutoMapper.Mappers
 
         public bool IsMatch(TypePair types) => _converters.ContainsKey(types);
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             var typeMap = new TypePair(sourceExpression.Type, destExpression.Type);
             return _converters[typeMap].Value.ReplaceParameters(sourceExpression);

--- a/src/AutoMapper/Mappers/DictionaryMapper.cs
+++ b/src/AutoMapper/Mappers/DictionaryMapper.cs
@@ -10,7 +10,7 @@ namespace AutoMapper.Mappers
     {
         public bool IsMatch(TypePair context) => context.SourceType.IsDictionaryType() && context.DestinationType.IsDictionaryType();
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
-            => typeMapRegistry.MapCollectionExpression(configurationProvider, propertyMap, sourceExpression, destExpression, contextExpression, CollectionMapperExtensions.IfNotNull, typeof(Dictionary<,>), CollectionMapperExtensions.MapKeyPairValueExpr);
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+            => configurationProvider.MapCollectionExpression(propertyMap, sourceExpression, destExpression, contextExpression, CollectionMapperExtensions.IfNotNull, typeof(Dictionary<,>), CollectionMapperExtensions.MapKeyPairValueExpr);
     }
 }

--- a/src/AutoMapper/Mappers/DynamicMappers.cs
+++ b/src/AutoMapper/Mappers/DynamicMappers.cs
@@ -54,7 +54,7 @@ namespace AutoMapper.Mappers
             return context.SourceType.IsDynamic() && !context.DestinationType.IsDynamic();
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression, destExpression, contextExpression, Expression.Constant(CollectionMapperExtensions.Constructor(destExpression.Type)));
         }
@@ -108,7 +108,7 @@ namespace AutoMapper.Mappers
             return context.DestinationType.IsDynamic() && !context.SourceType.IsDynamic();
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression, destExpression, contextExpression, Expression.Constant(CollectionMapperExtensions.Constructor(destExpression.Type)));
         }

--- a/src/AutoMapper/Mappers/EnumMapper.cs
+++ b/src/AutoMapper/Mappers/EnumMapper.cs
@@ -17,7 +17,7 @@ namespace AutoMapper.Mappers
             return destEnumType != null && context.SourceType == typeof(string);
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             var destinationType = destExpression.Type;
             var destinationEnumType = TypeHelper.GetEnumerationType(destinationType);
@@ -62,7 +62,7 @@ namespace AutoMapper.Mappers
             return sourceEnumType != null && destEnumType != null;
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression);
         }
@@ -139,7 +139,7 @@ namespace AutoMapper.Mappers
             return false;
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression);
         }

--- a/src/AutoMapper/Mappers/EnumerableMapper.cs
+++ b/src/AutoMapper/Mappers/EnumerableMapper.cs
@@ -18,16 +18,15 @@ namespace AutoMapper.Mappers
                    && context.SourceType.IsEnumerableType();
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider,
-            PropertyMap propertyMap, Expression sourceExpression, Expression destExpression,
-            Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap,
+            Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             if(destExpression.Type.IsInterface())
             {
                 var listType = typeof(List<>).MakeGenericType(TypeHelper.GetElementType(destExpression.Type));
                 destExpression = Default(listType);
             }
-            return typeMapRegistry.MapCollectionExpression(configurationProvider, propertyMap, sourceExpression,
+            return configurationProvider.MapCollectionExpression(propertyMap, sourceExpression,
                 destExpression, contextExpression, IfEditableList, typeof(List<>),
                 CollectionMapperExtensions.MapItemExpr);
         }

--- a/src/AutoMapper/Mappers/EnumerableToDictionaryMapper.cs
+++ b/src/AutoMapper/Mappers/EnumerableToDictionaryMapper.cs
@@ -13,11 +13,10 @@ namespace AutoMapper.Mappers
                    && !context.SourceType.IsDictionaryType();
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider,
-                PropertyMap propertyMap, Expression sourceExpression, Expression destExpression,
-                Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap,
+            Expression sourceExpression, Expression destExpression, Expression contextExpression)
             =>
-            typeMapRegistry.MapCollectionExpression(configurationProvider, propertyMap, sourceExpression, destExpression,
+            configurationProvider.MapCollectionExpression(propertyMap, sourceExpression, destExpression,
                 contextExpression, CollectionMapperExtensions.IfNotNull, typeof(Dictionary<,>),
                 CollectionMapperExtensions.MapItemExpr);
     }

--- a/src/AutoMapper/Mappers/ExplicitConversionOperatorMapper.cs
+++ b/src/AutoMapper/Mappers/ExplicitConversionOperatorMapper.cs
@@ -27,7 +27,7 @@ namespace AutoMapper.Mappers
             return sourceTypeMethod ?? destTypeMethod;
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             var implicitOperator = GetExplicitConversionOperator(new TypePair(sourceExpression.Type, destExpression.Type));
             return Expression.Call(null, implicitOperator, sourceExpression);

--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -54,7 +54,7 @@ namespace AutoMapper.Mappers
                    && context.DestinationType != typeof (LambdaExpression);
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression, contextExpression);
         }

--- a/src/AutoMapper/Mappers/FlagsEnumMapper.cs
+++ b/src/AutoMapper/Mappers/FlagsEnumMapper.cs
@@ -31,7 +31,7 @@ namespace AutoMapper.Mappers
                    && destEnumType.GetCustomAttributes(typeof (FlagsAttribute), false).Any();
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression, Expression.Constant(CollectionMapperExtensions.Constructor(destExpression.Type)));
         }

--- a/src/AutoMapper/Mappers/HashSetMapper.cs
+++ b/src/AutoMapper/Mappers/HashSetMapper.cs
@@ -13,8 +13,8 @@ namespace AutoMapper.Mappers
         public bool IsMatch(TypePair context)
             => context.SourceType.IsEnumerableType() && IsSetType(context.DestinationType);
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
-            => typeMapRegistry.MapCollectionExpression(configurationProvider, propertyMap, sourceExpression, destExpression, contextExpression, CollectionMapperExtensions.IfNotNull, typeof(HashSet<>), CollectionMapperExtensions.MapItemExpr);
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+            => configurationProvider.MapCollectionExpression(propertyMap, sourceExpression, destExpression, contextExpression, CollectionMapperExtensions.IfNotNull, typeof(HashSet<>), CollectionMapperExtensions.MapItemExpr);
 
         private static bool IsSetType(Type type)
         {

--- a/src/AutoMapper/Mappers/ImplicitConversionOperatorMapper.cs
+++ b/src/AutoMapper/Mappers/ImplicitConversionOperatorMapper.cs
@@ -30,7 +30,7 @@ namespace AutoMapper.Mappers
         }
 
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             var implicitOperator = GetImplicitConversionOperator(new TypePair(sourceExpression.Type, destExpression.Type));
             return Expression.Call(null, implicitOperator, sourceExpression);

--- a/src/AutoMapper/Mappers/MultidimensionalArrayMapper.cs
+++ b/src/AutoMapper/Mappers/MultidimensionalArrayMapper.cs
@@ -62,7 +62,7 @@ namespace AutoMapper.Mappers
             return context.DestinationType.IsArray && context.DestinationType.GetArrayRank() > 1 && context.SourceType.IsEnumerableType();
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, 
                 MapMethodInfo.MakeGenericMethod(destExpression.Type, sourceExpression.Type, TypeHelper.GetElementType(sourceExpression.Type)), 

--- a/src/AutoMapper/Mappers/NameValueCollectionMapper.cs
+++ b/src/AutoMapper/Mappers/NameValueCollectionMapper.cs
@@ -29,7 +29,7 @@ namespace AutoMapper.Mappers
                 context.DestinationType == typeof (NameValueCollection);
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo, sourceExpression);
         }

--- a/src/AutoMapper/Mappers/NullableSourceMapper.cs
+++ b/src/AutoMapper/Mappers/NullableSourceMapper.cs
@@ -19,7 +19,7 @@ namespace AutoMapper.Mappers
             return context.SourceType.IsNullableType();
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(Nullable.GetUnderlyingType(sourceExpression.Type), destExpression.Type), sourceExpression, destExpression, contextExpression);
         }

--- a/src/AutoMapper/Mappers/ReadOnlyCollectionMapper.cs
+++ b/src/AutoMapper/Mappers/ReadOnlyCollectionMapper.cs
@@ -20,10 +20,10 @@ namespace AutoMapper.Mappers
             return genericType == typeof (ReadOnlyCollection<>);
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             var listType = typeof(List<>).MakeGenericType(TypeHelper.GetElementType(destExpression.Type));
-            var list = typeMapRegistry.MapCollectionExpression(configurationProvider, propertyMap, sourceExpression, Default(listType), contextExpression, _ => Constant(false), typeof(List<>), CollectionMapperExtensions.MapItemExpr);
+            var list = configurationProvider.MapCollectionExpression(propertyMap, sourceExpression, Default(listType), contextExpression, _ => Constant(false), typeof(List<>), CollectionMapperExtensions.MapItemExpr);
             var dest = Variable(listType, "dest");
 
             return Block(new[] { dest }, Assign(dest, list), Condition(NotEqual(dest, Default(listType)), New(destExpression.Type.GetConstructors().First(), dest), Default(destExpression.Type)));

--- a/src/AutoMapper/Mappers/StringDictionaryMapper.cs
+++ b/src/AutoMapper/Mappers/StringDictionaryMapper.cs
@@ -19,11 +19,10 @@ namespace AutoMapper.Mappers
             return typeof(StringDictionary).IsAssignableFrom(context.DestinationType);
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider,
-                PropertyMap propertyMap, Expression sourceExpression, Expression destExpression,
-                Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap,
+            Expression sourceExpression, Expression destExpression, Expression contextExpression)
             =>
-            typeMapRegistry.MapCollectionExpression(configurationProvider, propertyMap,
+            configurationProvider.MapCollectionExpression(propertyMap,
                 Call(MembersDictionaryMethodInfo, sourceExpression, contextExpression), destExpression, contextExpression, _ => null,
                 typeof(Dictionary<,>), CollectionMapperExtensions.MapKeyPairValueExpr);
 
@@ -46,9 +45,8 @@ namespace AutoMapper.Mappers
             return typeof(StringDictionary).IsAssignableFrom(context.SourceType);
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider,
-            PropertyMap propertyMap, Expression sourceExpression, Expression destExpression,
-            Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap,
+            Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Call(null, MapMethodInfo.MakeGenericMethod(destExpression.Type), sourceExpression, destExpression, contextExpression);
         }

--- a/src/AutoMapper/Mappers/StringMapper.cs
+++ b/src/AutoMapper/Mappers/StringMapper.cs
@@ -11,9 +11,8 @@ namespace AutoMapper.Mappers
             return context.DestinationType == typeof(string) && context.SourceType != typeof(string);
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider,
-            PropertyMap propertyMap, Expression sourceExpression, Expression destExpression,
-            Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap,
+            Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             var toStringCall = Call(sourceExpression, typeof(object).GetDeclaredMethod("ToString"));
             if(sourceExpression.Type.IsValueType())

--- a/src/AutoMapper/Mappers/TypeConverterMapper.cs
+++ b/src/AutoMapper/Mappers/TypeConverterMapper.cs
@@ -46,7 +46,7 @@ namespace AutoMapper.Mappers
                     destTypeConverter.CanConvertFrom(context.SourceType));
         }
 
-        public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
         {
             return Expression.Call(null, MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type), sourceExpression, Expression.Constant(CollectionMapperExtensions.Constructor(destExpression.Type)));
         }

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -248,7 +248,7 @@ namespace AutoMapper
             }
         }
 
-        public void Seal(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider)
+        public void Seal(IConfigurationProvider configurationProvider)
         {
             if(_sealed)
             {
@@ -266,7 +266,7 @@ namespace AutoMapper
                     .Union(_inheritedMaps)
                     .OrderBy(map => map.MappingOrder).ToArray();
 
-            MapExpression = new TypeMapPlanBuilder(configurationProvider, typeMapRegistry, this).CreateMapperLambda();
+            MapExpression = new TypeMapPlanBuilder(configurationProvider, this).CreateMapperLambda();
         }
 
         public PropertyMap GetExistingPropertyMapFor(MemberInfo destinationProperty)

--- a/src/UnitTests/Mappers/CustomMapperTests.cs
+++ b/src/UnitTests/Mappers/CustomMapperTests.cs
@@ -36,8 +36,8 @@ namespace AutoMapper.UnitTests.Mappers
                 return context.SourceType == typeof(SourceType) && context.DestinationType == typeof(DestinationType);
             }
 
-            public Expression MapExpression(TypeMapRegistry typeMapRegistry, IConfigurationProvider configurationProvider,
-                PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+            public Expression MapExpression(IConfigurationProvider configurationProvider, PropertyMap propertyMap,
+                Expression sourceExpression, Expression destExpression, Expression contextExpression)
             {
                 Expression<Func<DestinationType>> expr = () => new DestinationType();
 


### PR DESCRIPTION
I think we fixed a few issues around TypeMapRegistry.GetTypeMap and now it's not used much.