### PR TITLE
Support for EnumMemberAttribute

### DIFF
--- a/src/AutoMapper/AutoMapper.csproj
+++ b/src/AutoMapper/AutoMapper.csproj
@@ -39,6 +39,7 @@
         <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
 		<PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
+		<PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />		
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
@@ -60,11 +61,13 @@
         <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
         <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
         <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+		<PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />		
     </ItemGroup>
 
     <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
         <Reference Include="System" />
         <Reference Include="Microsoft.CSharp" />
+		<PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     </ItemGroup>
 
 </Project>

--- a/src/AutoMapper/Mappers/EnumToStringMapper.cs
+++ b/src/AutoMapper/Mappers/EnumToStringMapper.cs
@@ -10,49 +10,32 @@ using AutoMapper.Mappers.Internal;
 namespace AutoMapper.Mappers
 {
     public class EnumToStringMapper : IObjectMapper
-    {    
-        public bool IsMatch(TypePair context) => context.DestinationType == typeof(string) && ElementTypeHelper.GetEnumerationType(context.SourceType) != null;
+    {
+        public bool IsMatch(TypePair context) => context.DestinationType == typeof(string) &&
+                                                 ElementTypeHelper.GetEnumerationType(context.SourceType) != null;
 
-        public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap,
+            PropertyMap propertyMap, Expression sourceExpression, Expression destExpression,
+            Expression contextExpression)
         {
             var sourceType = sourceExpression.Type;
             var sourceTypeEnum = ElementTypeHelper.GetEnumerationType(sourceType);
             var toStringCall = Expression.Call(sourceExpression, typeof(object).GetDeclaredMethod("ToString"));
-            return BuildEnumMemberSwitchTable(sourceTypeEnum, sourceExpression, toStringCall);
-        }
-
-        private static Expression BuildEnumMemberSwitchTable(Type destinationEnumType, Expression sourceExpression, Expression toStringCall)
-        {
             var switchCases = new List<SwitchCase>();
-            var enumNames = destinationEnumType.GetDeclaredMembers();
-            var resultVariable = Expression.Variable(typeof(string));
-            Expression resultExpression;
+            var enumNames = sourceTypeEnum.GetDeclaredMembers();
             foreach (var memberInfo in enumNames.Where(x => x.IsStatic()))
             {
                 var attribute = memberInfo.GetCustomAttribute(typeof(EnumMemberAttribute)) as EnumMemberAttribute;
                 if (attribute?.Value != null)
                 {
-                    var switchCase = Expression.SwitchCase(
-                        Expression.Assign(resultVariable, Expression.Constant(attribute.Value)),
-                        Expression.Constant(Enum.ToObject(destinationEnumType, memberInfo.GetMemberValue(null))));
+                    var switchCase = Expression.SwitchCase(Expression.Constant(attribute.Value),
+                        Expression.Constant(Enum.ToObject(sourceTypeEnum, memberInfo.GetMemberValue(null))));
                     switchCases.Add(switchCase);
                 }
             }
-            if (switchCases.Count > 0)
-            {
-                var returnTarget = Expression.Label(typeof(string));
-                var blockExpressions = new List<Expression>
-                {
-                    Expression.Switch(sourceExpression, Expression.Assign(resultVariable, toStringCall), switchCases.ToArray()),
-                    Expression.Label(returnTarget, resultVariable)
-                };
-                resultExpression = Expression.Block(new[] { resultVariable }, blockExpressions);
-            }
-            else
-            {
-                resultExpression = toStringCall;
-            }
-            return resultExpression;
+            return switchCases.Count > 0
+                ? (Expression) Expression.Switch(sourceExpression, toStringCall, switchCases.ToArray())
+                : toStringCall;
         }
     }
 }

--- a/src/AutoMapper/Mappers/EnumToStringMapper.cs
+++ b/src/AutoMapper/Mappers/EnumToStringMapper.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.Serialization;
+using AutoMapper.Internal;
+using AutoMapper.Mappers.Internal;
+
+namespace AutoMapper.Mappers
+{
+    public class EnumToStringMapper : IObjectMapper
+    {    
+        public bool IsMatch(TypePair context) => context.DestinationType == typeof(string) && ElementTypeHelper.GetEnumerationType(context.SourceType) != null;
+
+        public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        {
+            var sourceType = sourceExpression.Type;
+            var sourceTypeEnum = ElementTypeHelper.GetEnumerationType(sourceType);
+            var toStringCall = Expression.Call(sourceExpression, typeof(object).GetDeclaredMethod("ToString"));
+            return BuildEnumMemberSwitchTable(sourceTypeEnum, sourceExpression, toStringCall);
+        }
+
+        private static Expression BuildEnumMemberSwitchTable(Type destinationEnumType, Expression sourceExpression, Expression toStringCall)
+        {
+            var switchCases = new List<SwitchCase>();
+            var enumNames = destinationEnumType.GetDeclaredMembers();
+            var resultVariable = Expression.Variable(typeof(string));
+            Expression resultExpression;
+            foreach (var memberInfo in enumNames.Where(x => x.IsStatic()))
+            {
+                var attribute = memberInfo.GetCustomAttribute(typeof(EnumMemberAttribute)) as EnumMemberAttribute;
+                if (attribute?.Value != null)
+                {
+                    var switchCase = Expression.SwitchCase(
+                        Expression.Assign(resultVariable, Expression.Constant(attribute.Value)),
+                        Expression.Constant(Enum.ToObject(destinationEnumType, memberInfo.GetMemberValue(null))));
+                    switchCases.Add(switchCase);
+                }
+            }
+            if (switchCases.Count > 0)
+            {
+                var returnTarget = Expression.Label(typeof(string));
+                var blockExpressions = new List<Expression>
+                {
+                    Expression.Switch(sourceExpression, Expression.Assign(resultVariable, toStringCall), switchCases.ToArray()),
+                    Expression.Label(returnTarget, resultVariable)
+                };
+                resultExpression = Expression.Block(new[] { resultVariable }, blockExpressions);
+            }
+            else
+            {
+                resultExpression = toStringCall;
+            }
+            return resultExpression;
+        }
+    }
+}

--- a/src/AutoMapper/Mappers/MapperRegistry.cs
+++ b/src/AutoMapper/Mappers/MapperRegistry.cs
@@ -10,6 +10,7 @@ namespace AutoMapper.Mappers
             new ExpressionMapper(), 
             new FlagsEnumMapper(),
             new StringToEnumMapper(), 
+            new EnumToStringMapper(),
             new EnumToEnumMapper(), 
             new EnumToUnderlyingTypeMapper(),
             new UnderlyingTypeToEnumMapper(),

--- a/src/AutoMapper/Mappers/StringToEnumMapper.cs
+++ b/src/AutoMapper/Mappers/StringToEnumMapper.cs
@@ -23,7 +23,7 @@ namespace AutoMapper.Mappers
         {
             var destinationType = destExpression.Type;
             var destinationEnumType = ElementTypeHelper.GetEnumerationType(destinationType);
-            Expression enumParse = Expression.Call(typeof(Enum), "Parse", null, Expression.Constant(destinationEnumType), sourceExpression, Expression.Constant(true));
+            var enumParse = Expression.Call(typeof(Enum), "Parse", null, Expression.Constant(destinationEnumType), sourceExpression, Expression.Constant(true));
             var switchTable = BuildEnumMemberSwitchTable(destinationEnumType, destinationType, sourceExpression, enumParse);
             var isNullOrEmpty = Expression.Call(typeof(string), "IsNullOrEmpty", null, sourceExpression);
             return Expression.Condition(isNullOrEmpty, Expression.Default(destinationType), switchTable);

--- a/src/AutoMapper/Mappers/StringToEnumMapper.cs
+++ b/src/AutoMapper/Mappers/StringToEnumMapper.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Linq.Expressions;
+using System.Reflection;
+using System.Runtime.Serialization;
 using AutoMapper.Internal;
 using AutoMapper.Mappers.Internal;
 
@@ -19,9 +23,45 @@ namespace AutoMapper.Mappers
         {
             var destinationType = destExpression.Type;
             var destinationEnumType = ElementTypeHelper.GetEnumerationType(destinationType);
-            var enumParse = Expression.Call(typeof(Enum), "Parse", null, Expression.Constant(destinationEnumType), sourceExpression, Expression.Constant(true));
+            Expression enumParse = Expression.Call(typeof(Enum), "Parse", null, Expression.Constant(destinationEnumType), sourceExpression, Expression.Constant(true));
+            var switchTable = BuildEnumMemberSwitchTable(destinationEnumType, destinationType, sourceExpression, enumParse);
             var isNullOrEmpty = Expression.Call(typeof(string), "IsNullOrEmpty", null, sourceExpression);
-            return Expression.Condition(isNullOrEmpty, Expression.Default(destinationType), ToType(enumParse, destinationType));
+            return Expression.Condition(isNullOrEmpty, Expression.Default(destinationType), switchTable);
+        }
+
+        private static Expression BuildEnumMemberSwitchTable(Type destinationEnumType, Type destinationType, Expression sourceExpression, Expression enumParse)
+        {
+            var switchCases = new List<SwitchCase>();
+            var enumNames = destinationEnumType.GetDeclaredMembers();
+            var resultVariable = Expression.Variable(destinationEnumType);
+            sourceExpression = Expression.Call(sourceExpression, "ToUpperInvariant", null, null);
+            Expression resultExpression;
+            foreach (var memberInfo in enumNames.Where(x => x.IsStatic()))
+            {
+                var attribute = memberInfo.GetCustomAttribute(typeof(EnumMemberAttribute)) as EnumMemberAttribute;
+                if (attribute?.Value != null)
+                {
+                    var switchCase = Expression.SwitchCase(
+                        Expression.Assign(resultVariable, Expression.Constant(Enum.ToObject(destinationEnumType, memberInfo.GetMemberValue(null)))),
+                        Expression.Constant(attribute.Value.ToUpperInvariant()));
+                    switchCases.Add(switchCase);
+                }
+            }
+            if (switchCases.Count > 0)
+            {
+                var returnTarget = Expression.Label(destinationType);
+                var blockExpressions = new List<Expression>
+                {
+                    Expression.Switch(sourceExpression, Expression.Assign(resultVariable, ToType(enumParse, destinationEnumType)), switchCases.ToArray()),
+                    Expression.Label(returnTarget, ToType(resultVariable, destinationType))
+                };
+                resultExpression = Expression.Block(new[] {resultVariable}, blockExpressions);
+            }
+            else
+            {
+                resultExpression = ToType(enumParse, destinationType);
+            }
+            return resultExpression;
         }
     }
 }

--- a/src/AutoMapper/Mappers/StringToEnumMapper.cs
+++ b/src/AutoMapper/Mappers/StringToEnumMapper.cs
@@ -13,55 +13,36 @@ namespace AutoMapper.Mappers
 
     public class StringToEnumMapper : IObjectMapper
     {
-        public bool IsMatch(TypePair context)
-        {
-            var destEnumType = ElementTypeHelper.GetEnumerationType(context.DestinationType);
-            return destEnumType != null && context.SourceType == typeof(string);
-        }
+        public bool IsMatch(TypePair context) => context.SourceType == typeof(string) &&
+                                                 ElementTypeHelper.GetEnumerationType(context.DestinationType) != null;
 
-        public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap, PropertyMap propertyMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap,
+            PropertyMap propertyMap, Expression sourceExpression, Expression destExpression,
+            Expression contextExpression)
         {
             var destinationType = destExpression.Type;
             var destinationEnumType = ElementTypeHelper.GetEnumerationType(destinationType);
-            var enumParse = Expression.Call(typeof(Enum), "Parse", null, Expression.Constant(destinationEnumType), sourceExpression, Expression.Constant(true));
-            var switchTable = BuildEnumMemberSwitchTable(destinationEnumType, destinationType, sourceExpression, enumParse);
-            var isNullOrEmpty = Expression.Call(typeof(string), "IsNullOrEmpty", null, sourceExpression);
-            return Expression.Condition(isNullOrEmpty, Expression.Default(destinationType), switchTable);
-        }
-
-        private static Expression BuildEnumMemberSwitchTable(Type destinationEnumType, Type destinationType, Expression sourceExpression, Expression enumParse)
-        {
+            var enumParse = Expression.Call(typeof(Enum), "Parse", null, Expression.Constant(destinationEnumType),
+                sourceExpression, Expression.Constant(true));
             var switchCases = new List<SwitchCase>();
             var enumNames = destinationEnumType.GetDeclaredMembers();
-            var resultVariable = Expression.Variable(destinationEnumType);
-            sourceExpression = Expression.Call(sourceExpression, "ToUpperInvariant", null, null);
-            Expression resultExpression;
+            var upperCaseSourceExpression = Expression.Call(sourceExpression, "ToUpperInvariant", null, null);
             foreach (var memberInfo in enumNames.Where(x => x.IsStatic()))
             {
                 var attribute = memberInfo.GetCustomAttribute(typeof(EnumMemberAttribute)) as EnumMemberAttribute;
                 if (attribute?.Value != null)
                 {
                     var switchCase = Expression.SwitchCase(
-                        Expression.Assign(resultVariable, Expression.Constant(Enum.ToObject(destinationEnumType, memberInfo.GetMemberValue(null)))),
-                        Expression.Constant(attribute.Value.ToUpperInvariant()));
+                        ToType(Expression.Constant(Enum.ToObject(destinationEnumType, memberInfo.GetMemberValue(null))),
+                            destinationType), Expression.Constant(attribute.Value.ToUpperInvariant()));
                     switchCases.Add(switchCase);
                 }
             }
-            if (switchCases.Count > 0)
-            {
-                var returnTarget = Expression.Label(destinationType);
-                var blockExpressions = new List<Expression>
-                {
-                    Expression.Switch(sourceExpression, Expression.Assign(resultVariable, ToType(enumParse, destinationEnumType)), switchCases.ToArray()),
-                    Expression.Label(returnTarget, ToType(resultVariable, destinationType))
-                };
-                resultExpression = Expression.Block(new[] {resultVariable}, blockExpressions);
-            }
-            else
-            {
-                resultExpression = ToType(enumParse, destinationType);
-            }
-            return resultExpression;
+            var switchTable = switchCases.Count > 0
+                ? Expression.Switch(upperCaseSourceExpression, ToType(enumParse, destinationType), switchCases.ToArray())
+                : ToType(enumParse, destinationType);
+            var isNullOrEmpty = Expression.Call(typeof(string), "IsNullOrEmpty", null, sourceExpression);
+            return Expression.Condition(isNullOrEmpty, Expression.Default(destinationType), switchTable);
         }
     }
 }

--- a/src/UnitTests/Enumerations.cs
+++ b/src/UnitTests/Enumerations.cs
@@ -592,7 +592,7 @@ namespace AutoMapper.Tests
         }
     }
 
-    public class When_the_source_has_an_enummemberattribute_value : AutoMapperSpecBase
+    public class When_the_target_has_an_enummemberattribute_value : AutoMapperSpecBase
     {
         public enum EnumWithEnumMemberAttribute
         {
@@ -653,4 +653,51 @@ namespace AutoMapper.Tests
         }
     }
 
+
+    public class When_the_source_has_an_enummemberattribute_value : AutoMapperSpecBase
+    {
+        public enum EnumWithEnumMemberAttribute
+        {
+            Null,
+            [EnumMember(Value = "Eins")]
+            One
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => { });
+
+        [Fact]
+        public void Should_return_the_defined_enummemberattribute_value()
+        {
+            var dest = Mapper.Map<EnumWithEnumMemberAttribute, string>(EnumWithEnumMemberAttribute.One);
+            dest.ShouldEqual("Eins");
+        }
+
+        [Fact]
+        public void Should_return_the_enum_value()
+        {
+            var dest = Mapper.Map<EnumWithEnumMemberAttribute, string>(EnumWithEnumMemberAttribute.Null);
+            dest.ShouldEqual("Null");
+        }
+
+        [Fact]
+        public void Should_return_the_defined_enummemberattribute_value_nullable()
+        {
+            var dest = Mapper.Map<EnumWithEnumMemberAttribute?, string>(EnumWithEnumMemberAttribute.One);
+            dest.ShouldEqual("Eins");
+        }
+
+        [Fact]
+        public void Should_return_the_enum_value_nullable()
+        {
+            var dest = Mapper.Map<EnumWithEnumMemberAttribute?, string>(EnumWithEnumMemberAttribute.Null);
+            dest.ShouldEqual("Null");
+        }
+
+        [Fact]
+        public void Should_return_null()
+        {
+            var dest = Mapper.Map<EnumWithEnumMemberAttribute?, string>(null);
+            dest.ShouldEqual(null);
+        }
+    }
 }

--- a/src/UnitTests/Enumerations.cs
+++ b/src/UnitTests/Enumerations.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 using AutoMapper.UnitTests;
 using Should;
 using Xunit;
@@ -588,6 +589,67 @@ namespace AutoMapper.Tests
         public void Should_include_all_source_enum_values()
         {
             _result.ShouldEqual(DestinationFlags.One | DestinationFlags.Four | DestinationFlags.Eight);
+        }
+    }
+
+    public class When_the_source_has_an_enummemberattribute_value : AutoMapperSpecBase
+    {
+        public enum EnumWithEnumMemberAttribute
+        {
+            Null,
+            [EnumMember(Value = "Eins")]
+            One
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => { });
+
+        [Fact]
+        public void Should_return_the_enum_from_defined_enummemberattribute_value()
+        {
+            var dest = Mapper.Map<string, EnumWithEnumMemberAttribute>("Eins");
+            dest.ShouldEqual(EnumWithEnumMemberAttribute.One);
+        }
+
+        [Fact]
+        public void Should_return_the_enum_from_undefined_enummemberattribute_value()
+        {
+            var dest = Mapper.Map<string, EnumWithEnumMemberAttribute>("Null");
+            dest.ShouldEqual(EnumWithEnumMemberAttribute.Null);
+        }
+
+        [Fact]
+        public void Should_return_the_nullable_enum_from_defined_enummemberattribute_value()
+        {
+            var dest = Mapper.Map<string, EnumWithEnumMemberAttribute?>("Eins");
+            dest.ShouldEqual(EnumWithEnumMemberAttribute.One);
+        }
+
+        [Fact]
+        public void Should_return_the_enum_from_undefined_enummemberattribute_value_mixedcase()
+        {
+            var dest = Mapper.Map<string, EnumWithEnumMemberAttribute>("NuLl");
+            dest.ShouldEqual(EnumWithEnumMemberAttribute.Null);
+        }
+
+        [Fact]
+        public void Should_return_the_enum_from_defined_enummemberattribute_value_mixedcase()
+        {
+            var dest = Mapper.Map<string, EnumWithEnumMemberAttribute?>("eInS");
+            dest.ShouldEqual(EnumWithEnumMemberAttribute.One);
+        }
+
+        [Fact]
+        public void Should_return_the_nullable_enum_from_null_value()
+        {
+            var dest = Mapper.Map<string, EnumWithEnumMemberAttribute?>(null);
+            dest.ShouldEqual(null);
+        }
+
+        [Fact]
+        public void Should_return_the_nullable_enum_from_undefined_enummemberattribute_value()
+        {
+            var dest = Mapper.Map<string, EnumWithEnumMemberAttribute?>("Null");
+            dest.ShouldEqual(EnumWithEnumMemberAttribute.Null);
         }
     }
 

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -75,6 +75,7 @@
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Data" />
+    <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
@@ -468,7 +469,9 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="ClassDiagram1.cd" />
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -469,9 +469,7 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="ClassDiagram1.cd" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/src/UnitTests/packages.config
+++ b/src/UnitTests/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="Fixie" version="1.0.0.41" targetFramework="net45" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />
+  <package id="System.Runtime.Serialization.Primitives" version="4.3.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
As suggested by  @lbargaoanu in #1741 this is a Pull Request to add EnumMemberAttribute support.

- Changed existing StringToEnumMapper.cs to support a switch table with enum member attribute values, iff EnumMemberAttribute exists for the parsing of strings to enums, it is done case-insensitive (using UpperCaseInvariant
- Added a EnumToStringMapper.cs to do the same the other way round
- Added References to System.Runtime.Serialization.Primitives
- Added Tests for both sides

Fixes #1741.