### PR TITLE
Use the runtime type for the destination too

### DIFF
--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -149,7 +149,10 @@ namespace AutoMapper
             }
             else
             {
-                var map = mapperToUse.MapExpression(mapperConfiguration, Configuration, null, ToType(source, mapRequest.RuntimeTypes.SourceType), destination, context);
+                var map = mapperToUse.MapExpression(mapperConfiguration, Configuration, null, 
+                                                                        ToType(source, mapRequest.RuntimeTypes.SourceType), 
+                                                                        ToType(destination, mapRequest.RuntimeTypes.DestinationType), 
+                                                                        context);
                 var mapToDestination = Lambda(ToType(map, destinationType), source, destination, context);
                 fullExpression = TryCatch(mapToDestination, source, destination, context, mapRequest.RequestedTypes);
             }

--- a/src/UnitTests/CollectionMapping.cs
+++ b/src/UnitTests/CollectionMapping.cs
@@ -9,6 +9,20 @@ using System.Collections;
 
 namespace AutoMapper.UnitTests
 {
+    public class When_mapping_to_existing_collection_typed_as_IEnumerable : AutoMapperSpecBase
+    {
+        protected override MapperConfiguration Configuration => new MapperConfiguration(_=>{ });
+
+        [Fact]
+        public void Should_map_ok()
+        {
+            IEnumerable<int> destination = new List<int>();
+            var source = Enumerable.Range(1, 10).ToArray();
+            Mapper.Map(source, destination);
+            destination.SequenceEqual(source).ShouldBeTrue();
+        }
+    }
+
     public class When_mapping_to_readonly_property_as_IEnumerable_and_existing_destination : AutoMapperSpecBase
     {
         public class Source


### PR DESCRIPTION
Fixes #2096.