### PR TITLE
AddProfiles() includes internal types when scanning assemblies

### DIFF
--- a/src/AutoMapper/AdvancedConfiguration.cs
+++ b/src/AutoMapper/AdvancedConfiguration.cs
@@ -22,6 +22,12 @@ namespace AutoMapper
         /// <param name="validator">the validation callback</param>
         public void Validator(Validator validator) => _validators.Add(validator);
 
+        /// <summary>
+        /// Gets or sets a value indicating that internal profiles should be included when scanning assemblies.
+        /// </summary>
+        public bool ScanForInternalProfiles { get; set; }
+
+
         internal Validator[] GetValidators() => _validators.ToArray();
     }
 }

--- a/src/AutoMapper/AdvancedConfiguration.cs
+++ b/src/AutoMapper/AdvancedConfiguration.cs
@@ -22,12 +22,6 @@ namespace AutoMapper
         /// <param name="validator">the validation callback</param>
         public void Validator(Validator validator) => _validators.Add(validator);
 
-        /// <summary>
-        /// Gets or sets a value indicating that internal profiles should be included when scanning assemblies.
-        /// </summary>
-        public bool ScanForInternalProfiles { get; set; }
-
-
         internal Validator[] GetValidators() => _validators.ToArray();
     }
 }

--- a/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
@@ -63,12 +63,13 @@ namespace AutoMapper.Configuration
 
         private void AddProfilesCore(IEnumerable<Assembly> assembliesToScan)
         {
-            var allTypes = assembliesToScan.Where(a => !a.IsDynamic).SelectMany(a => a.ExportedTypes).ToArray();
+            var allTypes = assembliesToScan.Where(a => !a.IsDynamic).SelectMany(a => a.DefinedTypes).ToArray();
 
             var profiles =
                 allTypes
-                    .Where(t => typeof(Profile).GetTypeInfo().IsAssignableFrom(t.GetTypeInfo()))
-                    .Where(t => !t.GetTypeInfo().IsAbstract);
+                    .Where(t => typeof(Profile).GetTypeInfo().IsAssignableFrom(t))
+                    .Where(t => !t.IsAbstract)
+                    .Select(t => t.AsType());
 
             foreach (var profile in profiles)
             {

--- a/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -9,7 +8,7 @@ namespace AutoMapper.Configuration
 {
     public class MapperConfigurationExpression : Profile, IMapperConfigurationExpression, IConfiguration
     {
-        private IEnumerable<Profile> _profiles = Enumerable.Empty<Profile>();
+        private readonly IList<Profile> _profiles = new List<Profile>();
 
         public MapperConfigurationExpression() : base("")
         {
@@ -21,7 +20,7 @@ namespace AutoMapper.Configuration
         public IEnumerable<IProfileConfiguration> Profiles => _profiles;
         public Func<Type, object> ServiceCtor { get; private set; } = Activator.CreateInstance;
 
-        public void CreateProfile(string profileName, Action<IProfileExpression> config)
+        public void CreateProfile(string profileName, Action<IProfileExpression> config) 
             => AddProfile(new NamedProfile(profileName, config));
 
         public IList<IObjectMapper> Mappers { get; }
@@ -36,13 +35,13 @@ namespace AutoMapper.Configuration
         }
 
         public void AddProfile(Profile profile)
-            => _profiles = _profiles.Concat(new[] { profile });
+        {
+            _profiles.Add(profile);
+        }
 
-        public void AddProfile<TProfile>() where TProfile : Profile, new()
-            => _profiles = _profiles.Concat(new[] {new TProfile()});
+        public void AddProfile<TProfile>() where TProfile : Profile, new() => AddProfile(new TProfile());
 
-        public void AddProfile(Type profileType)
-            => _profiles = _profiles.Concat(new[] {(Profile) Activator.CreateInstance(profileType)});
+        public void AddProfile(Type profileType) => AddProfile((Profile)Activator.CreateInstance(profileType));
 
         public void AddProfiles(IEnumerable<Assembly> assembliesToScan)
             => AddProfilesCore(assembliesToScan);
@@ -63,51 +62,22 @@ namespace AutoMapper.Configuration
             => AddProfilesCore(typesFromAssembliesContainingProfiles.Select(t => t.GetTypeInfo().Assembly));
 
         private void AddProfilesCore(IEnumerable<Assembly> assembliesToScan)
-            => _profiles = _profiles.Concat(new ProfileScannerIterator(assembliesToScan, Advanced));
+        {
+            var allTypes = assembliesToScan.Where(a => !a.IsDynamic).SelectMany(a => a.ExportedTypes).ToArray();
+
+            var profiles =
+                allTypes
+                    .Where(t => typeof(Profile).GetTypeInfo().IsAssignableFrom(t.GetTypeInfo()))
+                    .Where(t => !t.GetTypeInfo().IsAbstract);
+
+            foreach (var profile in profiles)
+            {
+                AddProfile(profile);
+            }
+
+        }
+
 
         public void ConstructServicesUsing(Func<Type, object> constructor) => ServiceCtor = constructor;
-
-        private class ProfileScannerIterator : IEnumerable<Profile>
-        {
-            private readonly IEnumerable<Assembly> _assembliesToScan;
-            private readonly AdvancedConfiguration _config;
-
-            public ProfileScannerIterator(IEnumerable<Assembly> assembliesToScan, AdvancedConfiguration config)
-            {
-                _assembliesToScan = assembliesToScan;
-                _config = config;
-            }
-
-            private IEnumerable<Profile> GetEnumerableProfilesIncludingInternals()
-            {
-                return from assembly in _assembliesToScan
-                       where !assembly.IsDynamic
-                       from typeInfo in assembly.DefinedTypes
-                       where typeof(Profile).GetTypeInfo().IsAssignableFrom(typeInfo) && !typeInfo.IsAbstract
-                       select (Profile) Activator.CreateInstance(typeInfo.AsType());
-            }
-            private IEnumerable<Profile> GetEnumerableProfiles()
-            {
-                return from assembly in _assembliesToScan
-                       where !assembly.IsDynamic
-                       from type in assembly.ExportedTypes.Select(t => t.GetTypeInfo())
-                       where typeof(Profile).GetTypeInfo().IsAssignableFrom(type) && !type.IsAbstract
-                       select(Profile) Activator.CreateInstance(type.AsType());
-            }
-
-            public IEnumerator<Profile> GetEnumerator()
-            {
-                var profiles = _config.ScanForInternalProfiles
-                    ? GetEnumerableProfilesIncludingInternals()
-                    : GetEnumerableProfiles();
-
-                return profiles.GetEnumerator();
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return GetEnumerator();
-            }
-        }
     }
 }

--- a/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -8,7 +9,7 @@ namespace AutoMapper.Configuration
 {
     public class MapperConfigurationExpression : Profile, IMapperConfigurationExpression, IConfiguration
     {
-        private readonly IList<Profile> _profiles = new List<Profile>();
+        private IEnumerable<Profile> _profiles = Enumerable.Empty<Profile>();
 
         public MapperConfigurationExpression() : base("")
         {
@@ -20,7 +21,7 @@ namespace AutoMapper.Configuration
         public IEnumerable<IProfileConfiguration> Profiles => _profiles;
         public Func<Type, object> ServiceCtor { get; private set; } = Activator.CreateInstance;
 
-        public void CreateProfile(string profileName, Action<IProfileExpression> config) 
+        public void CreateProfile(string profileName, Action<IProfileExpression> config)
             => AddProfile(new NamedProfile(profileName, config));
 
         public IList<IObjectMapper> Mappers { get; }
@@ -35,13 +36,13 @@ namespace AutoMapper.Configuration
         }
 
         public void AddProfile(Profile profile)
-        {
-            _profiles.Add(profile);
-        }
+            => _profiles = _profiles.Concat(new[] { profile });
 
-        public void AddProfile<TProfile>() where TProfile : Profile, new() => AddProfile(new TProfile());
+        public void AddProfile<TProfile>() where TProfile : Profile, new()
+            => _profiles = _profiles.Concat(new[] {new TProfile()});
 
-        public void AddProfile(Type profileType) => AddProfile((Profile)Activator.CreateInstance(profileType));
+        public void AddProfile(Type profileType)
+            => _profiles = _profiles.Concat(new[] {(Profile) Activator.CreateInstance(profileType)});
 
         public void AddProfiles(IEnumerable<Assembly> assembliesToScan)
             => AddProfilesCore(assembliesToScan);
@@ -62,22 +63,51 @@ namespace AutoMapper.Configuration
             => AddProfilesCore(typesFromAssembliesContainingProfiles.Select(t => t.GetTypeInfo().Assembly));
 
         private void AddProfilesCore(IEnumerable<Assembly> assembliesToScan)
-        {
-            var allTypes = assembliesToScan.Where(a => !a.IsDynamic).SelectMany(a => a.ExportedTypes).ToArray();
-
-            var profiles =
-                allTypes
-                    .Where(t => typeof(Profile).GetTypeInfo().IsAssignableFrom(t.GetTypeInfo()))
-                    .Where(t => !t.GetTypeInfo().IsAbstract);
-
-            foreach (var profile in profiles)
-            {
-                AddProfile(profile);
-            }
-
-        }
-
+            => _profiles = _profiles.Concat(new ProfileScannerIterator(assembliesToScan, Advanced));
 
         public void ConstructServicesUsing(Func<Type, object> constructor) => ServiceCtor = constructor;
+
+        private class ProfileScannerIterator : IEnumerable<Profile>
+        {
+            private readonly IEnumerable<Assembly> _assembliesToScan;
+            private readonly AdvancedConfiguration _config;
+
+            public ProfileScannerIterator(IEnumerable<Assembly> assembliesToScan, AdvancedConfiguration config)
+            {
+                _assembliesToScan = assembliesToScan;
+                _config = config;
+            }
+
+            private IEnumerable<Profile> GetEnumerableProfilesIncludingInternals()
+            {
+                return from assembly in _assembliesToScan
+                       where !assembly.IsDynamic
+                       from typeInfo in assembly.DefinedTypes
+                       where typeof(Profile).GetTypeInfo().IsAssignableFrom(typeInfo) && !typeInfo.IsAbstract
+                       select (Profile) Activator.CreateInstance(typeInfo.AsType());
+            }
+            private IEnumerable<Profile> GetEnumerableProfiles()
+            {
+                return from assembly in _assembliesToScan
+                       where !assembly.IsDynamic
+                       from type in assembly.ExportedTypes.Select(t => t.GetTypeInfo())
+                       where typeof(Profile).GetTypeInfo().IsAssignableFrom(type) && !type.IsAbstract
+                       select(Profile) Activator.CreateInstance(type.AsType());
+            }
+
+            public IEnumerator<Profile> GetEnumerator()
+            {
+                var profiles = _config.ScanForInternalProfiles
+                    ? GetEnumerableProfilesIncludingInternals()
+                    : GetEnumerableProfiles();
+
+                return profiles.GetEnumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return GetEnumerator();
+            }
+        }
     }
 }

--- a/src/UnitTests/AssemblyScanning.cs
+++ b/src/UnitTests/AssemblyScanning.cs
@@ -1,4 +1,6 @@
-﻿namespace AutoMapper.UnitTests
+﻿using System.Linq;
+
+namespace AutoMapper.UnitTests
 {
     namespace AssemblyScanning
     {
@@ -16,6 +18,51 @@
             public void Should_load_profiles()
             {
                 Configuration.GetAllTypeMaps().Length.ShouldBeGreaterThan(0);
+            }
+
+            [Fact]
+            public void Should_not_load_internal_profile()
+            {
+                Configuration.Profiles.Where(t => t.Name == InternalProfile.Name).ShouldBeEmpty();
+            }
+        }
+
+        internal class InternalProfile : Profile
+        {
+            public const string Name = "InternalProfile";
+
+            public InternalProfile() : base(Name)
+            {
+            }
+        }
+
+        public class When_scanning_by_assembly_after_setting_internal_profiles_inclusion : NonValidatingSpecBase
+        {
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.Advanced.ScanForInternalProfiles = true;
+                cfg.AddProfiles(new[] { typeof(When_scanning_by_assembly_after_setting_internal_profiles_inclusion).Assembly });
+            });
+
+            [Fact]
+            public void Should_contain_internal_profile()
+            {
+                Configuration.Profiles.Where(t => t.Name == InternalProfile.Name).ShouldBeOfLength(1);
+            }
+        }
+
+        public class When_scanning_by_assembly_befor_setting_internal_profiles_inclusion : NonValidatingSpecBase
+        {
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.AddProfiles(new[] { typeof(When_scanning_by_assembly_befor_setting_internal_profiles_inclusion).Assembly });
+                cfg.Advanced.ScanForInternalProfiles = true;
+            });
+
+            [Fact]
+            public void Should_contain_internal_profile()
+            {
+                Configuration.Profiles.Where(t => t.Name == InternalProfile.Name).ShouldBeOfLength(1);
             }
         }
 

--- a/src/UnitTests/AssemblyScanning.cs
+++ b/src/UnitTests/AssemblyScanning.cs
@@ -1,4 +1,6 @@
-﻿namespace AutoMapper.UnitTests
+﻿using System.Linq;
+
+namespace AutoMapper.UnitTests
 {
     namespace AssemblyScanning
     {
@@ -16,6 +18,21 @@
             public void Should_load_profiles()
             {
                 Configuration.GetAllTypeMaps().Length.ShouldBeGreaterThan(0);
+            }
+
+            [Fact]
+            public void Should_load_internal_profiles()
+            {
+                Configuration.Profiles.Where(t => t.Name == InternalProfile.Name).ShouldNotBeEmpty();
+            }
+        }
+
+        internal class InternalProfile : Profile
+        {
+            public const string Name = "InternalProfile";
+
+            public InternalProfile() : base(Name)
+            {
             }
         }
 

--- a/src/UnitTests/AssemblyScanning.cs
+++ b/src/UnitTests/AssemblyScanning.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-
-namespace AutoMapper.UnitTests
+﻿namespace AutoMapper.UnitTests
 {
     namespace AssemblyScanning
     {
@@ -18,51 +16,6 @@ namespace AutoMapper.UnitTests
             public void Should_load_profiles()
             {
                 Configuration.GetAllTypeMaps().Length.ShouldBeGreaterThan(0);
-            }
-
-            [Fact]
-            public void Should_not_load_internal_profile()
-            {
-                Configuration.Profiles.Where(t => t.Name == InternalProfile.Name).ShouldBeEmpty();
-            }
-        }
-
-        internal class InternalProfile : Profile
-        {
-            public const string Name = "InternalProfile";
-
-            public InternalProfile() : base(Name)
-            {
-            }
-        }
-
-        public class When_scanning_by_assembly_after_setting_internal_profiles_inclusion : NonValidatingSpecBase
-        {
-            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
-            {
-                cfg.Advanced.ScanForInternalProfiles = true;
-                cfg.AddProfiles(new[] { typeof(When_scanning_by_assembly_after_setting_internal_profiles_inclusion).Assembly });
-            });
-
-            [Fact]
-            public void Should_contain_internal_profile()
-            {
-                Configuration.Profiles.Where(t => t.Name == InternalProfile.Name).ShouldBeOfLength(1);
-            }
-        }
-
-        public class When_scanning_by_assembly_befor_setting_internal_profiles_inclusion : NonValidatingSpecBase
-        {
-            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
-            {
-                cfg.AddProfiles(new[] { typeof(When_scanning_by_assembly_befor_setting_internal_profiles_inclusion).Assembly });
-                cfg.Advanced.ScanForInternalProfiles = true;
-            });
-
-            [Fact]
-            public void Should_contain_internal_profile()
-            {
-                Configuration.Profiles.Where(t => t.Name == InternalProfile.Name).ShouldBeOfLength(1);
             }
         }
 


### PR DESCRIPTION
 - added tests for scanning internal profiles
 - determine the loading strategy based on "ScanForInternalProfiles" property
 - modified the current implementation so that the scanning is done later in the process, and not immediately (more user friendly)

Fixes #2063.