### PR TITLE
Detect cycles at config time and set PreserveReferences accordingly

### DIFF
--- a/src/AutoMapper/ConfigurationValidator.cs
+++ b/src/AutoMapper/ConfigurationValidator.cs
@@ -77,12 +77,12 @@ namespace AutoMapper
             }
             else
             {
-                var mapperToUse = _config.GetMappers().FirstOrDefault(mapper => mapper.IsMatch(types));
+                var mapperToUse = _config.FindMapper(types);
                 if (mapperToUse == null && types.SourceType.IsNullableType())
                 {
                     var nullableTypes = new TypePair(Nullable.GetUnderlyingType(types.SourceType),
                         types.DestinationType);
-                    mapperToUse = _config.GetMappers().FirstOrDefault(mapper => mapper.IsMatch(nullableTypes));
+                    mapperToUse = _config.FindMapper(nullableTypes);
                 }
                 if (mapperToUse == null)
                 {

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -92,7 +92,7 @@ namespace AutoMapper.Execution
             }
         }
 
-        public void CheckPropertyMapForCycles(PropertyMap propertyMap, HashSet<TypeMap> visitedTypeMaps)
+        private void CheckPropertyMapForCycles(PropertyMap propertyMap, HashSet<TypeMap> visitedTypeMaps)
         {
             if(propertyMap.SourceType == null)
             {

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -104,10 +104,7 @@ namespace AutoMapper.Execution
                 return;
             }
             visitedTypeMaps.Add(typeMap);
-            if(!typeMap.HasDerivedTypesToInclude())
-            {
-                typeMap.Seal(_configurationProvider, visitedTypeMaps);
-            }
+            typeMap.Seal(_configurationProvider, visitedTypeMaps);
         }
 
         private TypeMap ResolvePropertyTypeMap(PropertyMap propertyMap)

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -99,7 +99,7 @@ namespace AutoMapper.Execution
                 return;
             }
             var typeMap = ResolvePropertyTypeMap(propertyMap);
-            if(typeMap == null || visitedTypeMaps.Contains(typeMap))
+            if(typeMap == null || typeMap.PreserveReferences || visitedTypeMaps.Contains(typeMap))
             {
                 return;
             }

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -83,25 +83,25 @@ namespace AutoMapper.Execution
                 isRoot = false;
             }
 
-            CheckPropertyMapsForCycles(visitedTypeMaps);
+            CheckPropertyMapsForCycles();
 
             if(isRoot && visitedTypeMaps.Contains(_typeMap))
             {
                 _typeMap.PreserveReferences = true;
             }
-        }
 
-        private void CheckPropertyMapsForCycles(HashSet<TypeMap> visitedTypeMaps)
-        {
-            var propertyTypeMaps =
-                from propertyTypeMap in
-                (from pm in _typeMap.GetPropertyMaps() where pm.CanResolveValue() select ResolvePropertyTypeMap(pm))
-                where propertyTypeMap != null && !propertyTypeMap.PreserveReferences && !visitedTypeMaps.Contains(propertyTypeMap)
-                select propertyTypeMap;
-            foreach(var propertyTypeMap in propertyTypeMaps)
+            void CheckPropertyMapsForCycles()
             {
-                visitedTypeMaps.Add(propertyTypeMap);
-                propertyTypeMap.Seal(_configurationProvider, visitedTypeMaps);
+                var propertyTypeMaps =
+                    from propertyTypeMap in
+                    (from pm in _typeMap.GetPropertyMaps() where pm.CanResolveValue() select ResolvePropertyTypeMap(pm))
+                    where propertyTypeMap != null && !propertyTypeMap.PreserveReferences && !visitedTypeMaps.Contains(propertyTypeMap)
+                    select propertyTypeMap;
+                foreach(var propertyTypeMap in propertyTypeMaps)
+                {
+                    visitedTypeMaps.Add(propertyTypeMap);
+                    propertyTypeMap.Seal(_configurationProvider, visitedTypeMaps);
+                }
             }
         }
 

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -40,7 +40,7 @@ namespace AutoMapper.Execution
             _destination = Variable(_initialDestination.Type, "typeMapDestination");
         }
 
-        public LambdaExpression CreateMapperLambda(HashSet<TypeMap> visitedTypeMaps = null)
+        public LambdaExpression CreateMapperLambda(HashSet<TypeMap> visitedTypeMaps)
         {
             if (_typeMap.SourceType.IsGenericTypeDefinition() || _typeMap.DestinationTypeToUse.IsGenericTypeDefinition())
             {

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -40,7 +40,7 @@ namespace AutoMapper.Execution
             _destination = Variable(_initialDestination.Type, "typeMapDestination");
         }
 
-        public LambdaExpression CreateMapperLambda()
+        public LambdaExpression CreateMapperLambda(HashSet<TypeMap> visitedTypeMaps = null)
         {
             if (_typeMap.SourceType.IsGenericTypeDefinition() || _typeMap.DestinationTypeToUse.IsGenericTypeDefinition())
             {
@@ -52,6 +52,8 @@ namespace AutoMapper.Execution
                 return Lambda(customExpression.ReplaceParameters(_source, _initialDestination, _context), _source, _initialDestination, _context);
             }
 
+            CheckForCycles(visitedTypeMaps);
+
             var destinationFunc = CreateDestinationFunc(out bool constructorMapping);
 
             var assignmentFunc = CreateAssignmentFunc(destinationFunc, constructorMapping);
@@ -62,6 +64,65 @@ namespace AutoMapper.Execution
             var lambaBody = checkContext != null ? new[] { checkContext, mapperFunc } : new[] { mapperFunc };
 
             return Lambda(Block(new[] { _destination }, lambaBody), _source, _initialDestination, _context);
+        }
+
+        private void CheckForCycles(HashSet<TypeMap> visitedTypeMaps)
+        {
+            if(_typeMap.PreserveReferences)
+            {
+                return;
+            }
+            bool isRoot;
+            if(visitedTypeMaps == null)
+            {
+                isRoot = true;
+                visitedTypeMaps = new HashSet<TypeMap>();
+            }
+            else
+            {
+                isRoot = false;
+            }
+            foreach(var propertyMap in _typeMap.GetPropertyMaps().Where(pm => pm.CanResolveValue()))
+            {
+                CheckPropertyMapForCycles(propertyMap, visitedTypeMaps);
+            }
+            if(isRoot && visitedTypeMaps.Contains(_typeMap))
+            {
+                _typeMap.PreserveReferences = true;
+            }
+        }
+
+        public void CheckPropertyMapForCycles(PropertyMap propertyMap, HashSet<TypeMap> visitedTypeMaps)
+        {
+            if(propertyMap.SourceType == null)
+            {
+                return;
+            }
+            var typeMap = ResolvePropertyTypeMap(propertyMap);
+            if(typeMap == null || visitedTypeMaps.Contains(typeMap))
+            {
+                return;
+            }
+            visitedTypeMaps.Add(typeMap);
+            if(!typeMap.HasDerivedTypesToInclude())
+            {
+                typeMap.Seal(_configurationProvider, visitedTypeMaps);
+            }
+        }
+
+        private TypeMap ResolvePropertyTypeMap(PropertyMap propertyMap)
+        {
+            var types = new TypePair(propertyMap.SourceType, propertyMap.DestinationPropertyType);
+            var typeMap = _configurationProvider.ResolveTypeMap(types);
+            if(typeMap == null)
+            {
+                var mapper = _configurationProvider.FindMapper(types) as IObjectMapperInfo;
+                if(mapper != null)
+                {
+                    typeMap = _configurationProvider.ResolveTypeMap(mapper.GetAssociatedTypes(types));
+                }
+            }
+            return typeMap;
         }
 
         private LambdaExpression TypeConverterMapper()
@@ -567,7 +628,7 @@ namespace AutoMapper.Execution
 
         private static Expression ObjectMapperExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap, TypePair typePair, Expression sourceParameter, Expression contextParameter, PropertyMap propertyMap, Expression destinationParameter)
         {
-            var match = configurationProvider.GetMappers().FirstOrDefault(m => m.IsMatch(typePair));
+            var match = configurationProvider.FindMapper(typePair);
             if(match != null)
             {
                 var mapperExpression = match.MapExpression(configurationProvider, profileMap, propertyMap, sourceParameter, destinationParameter, contextParameter);

--- a/src/AutoMapper/IConfigurationProvider.cs
+++ b/src/AutoMapper/IConfigurationProvider.cs
@@ -83,6 +83,13 @@ namespace AutoMapper
         IEnumerable<IObjectMapper> GetMappers();
 
         /// <summary>
+        /// Find a matching object mapper.
+        /// </summary>
+        /// <param name="types">the types to match</param>
+        /// <returns>the matching mapper or null</returns>
+        IObjectMapper FindMapper(TypePair types);
+
+        /// <summary>
         /// Factory method to create formatters, resolvers and type converters
         /// </summary>
         Func<Type, object> ServiceCtor { get; }

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -211,7 +211,7 @@ namespace AutoMapper
                 {
                     return typeMap;
                 }
-                if (!CoveredByObjectMap(initialTypes))
+                if (FindMapper(initialTypes) == null)
                 {
                     typeMap = FindConventionTypeMapFor(types);
                     if (typeMap != null)
@@ -318,11 +318,6 @@ namespace AutoMapper
             }
         }
 
-        private bool CoveredByObjectMap(TypePair typePair)
-        {
-            return GetMappers().FirstOrDefault(m => m.IsMatch(typePair)) != null;
-        }
-
         private TypeMap FindConventionTypeMapFor(TypePair typePair)
         {
             var typeMap = Profiles
@@ -350,6 +345,8 @@ namespace AutoMapper
 
             return typeMap;
         }
+
+        public IObjectMapper FindMapper(TypePair types) =>_mappers.FirstOrDefault(m => m.IsMatch(types));
 
         internal struct MapperFuncs
         {

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -252,7 +252,7 @@ namespace AutoMapper
             }
         }
 
-        public void Seal(IConfigurationProvider configurationProvider)
+        public void Seal(IConfigurationProvider configurationProvider, HashSet<TypeMap> visitedTypeMaps = null)
         {
             if(_sealed)
             {
@@ -270,7 +270,7 @@ namespace AutoMapper
                     .Union(_inheritedMaps)
                     .OrderBy(map => map.MappingOrder).ToArray();
 
-            MapExpression = new TypeMapPlanBuilder(configurationProvider, this).CreateMapperLambda();
+            MapExpression = new TypeMapPlanBuilder(configurationProvider, this).CreateMapperLambda(visitedTypeMaps);
         }
 
         public PropertyMap GetExistingPropertyMapFor(MemberInfo destinationProperty)

--- a/src/UnitTests/BidirectionalRelationshipsWithoutPR.cs
+++ b/src/UnitTests/BidirectionalRelationshipsWithoutPR.cs
@@ -1,0 +1,409 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using Should;
+
+using Xunit;
+
+namespace AutoMapper.UnitTests
+{
+    public class When_mapping_to_a_destination_with_a_bidirectional_parent_one_to_many_child_relationship : AutoMapperSpecBase
+    {
+        private ParentDto _dto;
+
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<ParentModel, ParentDto>();
+            cfg.CreateMap<ChildModel, ChildDto>();
+        });
+
+        protected override void Because_of()
+        {
+            var parent = new ParentModel { ID = "PARENT_ONE" };
+
+            parent.AddChild(new ChildModel { ID = "CHILD_ONE" });
+
+            parent.AddChild(new ChildModel { ID = "CHILD_TWO" });
+
+            _dto = Mapper.Map<ParentModel, ParentDto>(parent);
+        }
+
+        [Fact]
+        public void Should_preserve_the_parent_child_relationship_on_the_destination()
+        {
+            _dto.Children[0].Parent.ShouldBeSameAs(_dto);
+            _dto.Children[1].Parent.ShouldBeSameAs(_dto);
+        }
+
+        public class ParentModel
+        {
+            public ParentModel()
+            {
+                Children = new List<ChildModel>();
+            }
+
+            public string ID { get; set; }
+
+            public IList<ChildModel> Children { get; private set; }
+
+            public void AddChild(ChildModel child)
+            {
+                child.Parent = this;
+                Children.Add(child);
+            }
+        }
+
+        public class ChildModel
+        {
+            public string ID { get; set; }
+            public ParentModel Parent { get; set; }
+        }
+
+        public class ParentDto
+        {
+            public string ID { get; set; }
+            public IList<ChildDto> Children { get; set; }
+        }
+
+        public class ChildDto
+        {
+            public string ID { get; set; }
+            public ParentDto Parent { get; set; }
+        }
+    }
+
+
+    //public class When_mapping_to_a_destination_with_a_bidirectional_parent_one_to_many_child_relationship_using_CustomMapper_StackOverflow : AutoMapperSpecBase
+    //{
+    //    private ParentDto _dto;
+    //    private ParentModel _parent;
+
+    //    protected override void Establish_context()
+    //    {
+    //        _parent = new ParentModel
+    //            {
+    //                ID = 2
+    //            };
+
+    //        List<ChildModel> childModels = new List<ChildModel>
+    //            {
+    //                new ChildModel
+    //                    {
+    //                        ID = 1,
+    //                        Parent = _parent
+    //                    }
+    //            };
+
+    //        Dictionary<int, ParentModel> parents = childModels.ToDictionary(x => x.ID, x => x.Parent);
+
+    //        Mapper.CreateMap<int, ParentDto>().ConvertUsing(new ChildIdToParentDtoConverter(parents));
+    //        Mapper.CreateMap<int, List<ChildDto>>().ConvertUsing(new ParentIdToChildDtoListConverter(childModels));
+
+    //        Mapper.CreateMap<ParentModel, ParentDto>()
+    //            .ForMember(dest => dest.Children, opt => opt.MapFrom(src => src.ID));
+    //        Mapper.CreateMap<ChildModel, ChildDto>();
+
+    //        config.AssertConfigurationIsValid();
+    //    }
+
+    //    protected override void Because_of()
+    //    {
+    //        _dto = Mapper.Map<ParentModel, ParentDto>(_parent);
+    //    }
+
+    //    [Fact(Skip = "This test breaks the Test Runner")]
+    //    public void Should_preserve_the_parent_child_relationship_on_the_destination()
+    //    {
+    //        _dto.Children[0].Parent.ID.ShouldEqual(_dto.ID);
+    //    }
+
+    //    public class ChildIdToParentDtoConverter : ITypeConverter<int, ParentDto>
+    //    {
+    //        private readonly Dictionary<int, ParentModel> _parentModels;
+
+    //        public ChildIdToParentDtoConverter(Dictionary<int, ParentModel> parentModels)
+    //        {
+    //            _parentModels = parentModels;
+    //        }
+
+    //        public ParentDto Convert(int childId)
+    //        {
+    //            ParentModel parentModel = _parentModels[childId];
+    //            MappingEngine mappingEngine = (MappingEngine)Mapper.Engine;
+    //            return mappingEngine.Map<ParentModel, ParentDto>(parentModel);
+    //        }
+    //    }
+
+    //    public class ParentIdToChildDtoListConverter : ITypeConverter<int, List<ChildDto>>
+    //    {
+    //        private readonly IList<ChildModel> _childModels;
+
+    //        public ParentIdToChildDtoListConverter(IList<ChildModel> childModels)
+    //        {
+    //            _childModels = childModels;
+    //        }
+
+    //        protected override List<ChildDto> ConvertCore(int childId)
+    //        {
+    //            List<ChildModel> childModels = _childModels.Where(x => x.Parent.ID == childId).ToList();
+    //            MappingEngine mappingEngine = (MappingEngine)Mapper.Engine;
+    //            return mappingEngine.Map<List<ChildModel>, List<ChildDto>>(childModels);
+    //        }
+    //    }
+
+    //    public class ParentModel
+    //    {
+    //        public int ID { get; set; }
+    //    }
+
+    //    public class ChildModel
+    //    {
+    //        public int ID { get; set; }
+    //        public ParentModel Parent { get; set; }
+    //    }
+
+    //    public class ParentDto
+    //    {
+    //        public int ID { get; set; }
+    //        public List<ChildDto> Children { get; set; }
+    //    }
+
+    //    public class ChildDto
+    //    {
+    //        public int ID { get; set; }
+    //        public ParentDto Parent { get; set; }
+    //    }
+    //}
+
+    public class When_mapping_to_a_destination_with_a_bidirectional_parent_one_to_one_child_relationship : AutoMapperSpecBase
+    {
+        private FooDto _dto;
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Foo, FooDto>();
+            cfg.CreateMap<Bar, BarDto>();
+        });
+
+        protected override void Because_of()
+        {
+            var foo = new Foo
+                {
+                    Bar = new Bar
+                        {
+                            Value = "something"
+                        }
+                };
+            foo.Bar.Foo = foo;
+            _dto = Mapper.Map<Foo, FooDto>(foo);
+        }
+
+        [Fact]
+        public void Should_preserve_the_parent_child_relationship_on_the_destination()
+        {
+            _dto.Bar.Foo.ShouldBeSameAs(_dto);
+        }
+
+        public class Foo
+        {
+            public Bar Bar { get; set; }
+        }
+
+        public class Bar
+        {
+            public Foo Foo { get; set; }
+            public string Value { get; set; }
+        }
+
+        public class FooDto
+        {
+            public BarDto Bar { get; set; }
+        }
+
+        public class BarDto
+        {
+            public FooDto Foo { get; set; }
+            public string Value { get; set; }
+        }
+    }
+
+    public class When_mapping_to_a_destination_containing_two_dtos_mapped_from_the_same_source : AutoMapperSpecBase
+    {
+        private FooContainerModel _dto;
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<FooModel, FooScreenModel>();
+            cfg.CreateMap<FooModel, FooInputModel>();
+            cfg.CreateMap<FooModel, FooContainerModel>()
+                .ForMember(dest => dest.Input, opt => opt.MapFrom(src => src))
+                .ForMember(dest => dest.Screen, opt => opt.MapFrom(src => src));
+        });
+
+        protected override void Because_of()
+        {
+            var model = new FooModel { Id = 3 };
+            _dto = Mapper.Map<FooModel, FooContainerModel>(model);
+        }
+
+        [Fact]
+        public void Should_not_preserve_identity_when_destinations_are_incompatible()
+        {
+            _dto.ShouldBeType<FooContainerModel>();
+            _dto.Input.ShouldBeType<FooInputModel>();
+            _dto.Screen.ShouldBeType<FooScreenModel>();
+            _dto.Input.Id.ShouldEqual(3);
+            _dto.Screen.Id.ShouldEqual("3");
+        }
+
+        public class FooContainerModel
+        {
+            public FooInputModel Input { get; set; }
+            public FooScreenModel Screen { get; set; }
+        }
+
+        public class FooScreenModel
+        {
+            public string Id { get; set; }
+        }
+
+        public class FooInputModel
+        {
+            public long Id { get; set; }
+        }
+
+        public class FooModel
+        {
+            public long Id { get; set; }
+        }
+    }
+
+    public class When_mapping_with_a_bidirectional_relationship_that_includes_arrays : AutoMapperSpecBase
+
+    {
+        private ParentDto _dtoParent;
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Parent, ParentDto>();
+            cfg.CreateMap<Child, ChildDto>();
+
+        });
+
+        protected override void Because_of()
+        {
+            var parent1 = new Parent { Name = "Parent 1" };
+            var child1 = new Child { Name = "Child 1" };
+
+            parent1.Children.Add(child1);
+            child1.Parents.Add(parent1);
+
+            _dtoParent = Mapper.Map<Parent, ParentDto>(parent1);
+        }
+
+        [Fact]
+        public void Should_map_successfully()
+        {
+            object.ReferenceEquals(_dtoParent.Children[0].Parents[0], _dtoParent).ShouldBeTrue();
+        }
+
+        public class Parent
+        {
+            public Guid Id { get; private set; }
+
+            public string Name { get; set; }
+
+            public List<Child> Children { get; set; }
+
+            public Parent()
+            {
+                Id = Guid.NewGuid();
+                Children = new List<Child>();
+            }
+
+            public bool Equals(Parent other)
+            {
+                if (ReferenceEquals(null, other)) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return other.Id.Equals(Id);
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                if (obj.GetType() != typeof (Parent)) return false;
+                return Equals((Parent) obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return Id.GetHashCode();
+            }
+        }
+
+        public class Child
+        {
+            public Guid Id { get; private set; }
+
+            public string Name { get; set; }
+
+            public List<Parent> Parents { get; set; }
+
+            public Child()
+            {
+                Id = Guid.NewGuid();
+                Parents = new List<Parent>();
+            }
+
+            public bool Equals(Child other)
+            {
+                if (ReferenceEquals(null, other)) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return other.Id.Equals(Id);
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                if (obj.GetType() != typeof (Child)) return false;
+                return Equals((Child) obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return Id.GetHashCode();
+            }
+        }
+
+        public class ParentDto
+        {
+            public Guid Id { get; set; }
+
+            public string Name { get; set; }
+
+            public List<ChildDto> Children { get; set; }
+
+            public ParentDto()
+            {
+                Children = new List<ChildDto>();
+            }
+        }
+
+        public class ChildDto
+        {
+            public Guid Id { get; set; }
+
+            public string Name { get; set; }
+
+            public List<ParentDto> Parents { get; set; }
+
+            public ChildDto()
+            {
+                Parents = new List<ParentDto>();
+            }
+        }
+    }
+}

--- a/src/UnitTests/Bug/DuplicateValuesBugWithoutPR.cs
+++ b/src/UnitTests/Bug/DuplicateValuesBugWithoutPR.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using Xunit;
+using Should;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public class DuplicateValuesIssue
+    {
+        public class SourceObject
+        {
+            public int Id;
+            public IList<SourceObject> Children;
+
+            public void AddChild(SourceObject childObject)
+            {
+                if(this.Children == null)
+                    this.Children = new List<SourceObject>();
+
+                Children.Add(childObject);
+            }
+        }
+
+
+        public class DestObject
+        {
+            public int Id;
+            public IList<DestObject> Children;
+
+            public DestObject()
+            {
+            }
+
+            public void AddChild(DestObject childObject)
+            {
+                if(this.Children == null)
+                    this.Children = new List<DestObject>();
+
+                Children.Add(childObject);
+            }
+        }
+
+        [Fact]
+        public void Should_map_the_existing_array_elements_over()
+        {
+            var sourceList = new List<SourceObject>();
+            var destList = new List<DestObject>();
+
+            var config = new MapperConfiguration(cfg => cfg.CreateMap<SourceObject, DestObject>());
+            config.AssertConfigurationIsValid();
+
+            var source1 = new SourceObject
+            {
+                Id = 1,
+            };
+            sourceList.Add(source1);
+
+            var source2 = new SourceObject
+            {
+                Id = 2,
+            };
+            sourceList.Add(source2);
+
+            source1.AddChild(source2); // This causes the problem
+
+            config.CreateMapper().Map(sourceList, destList);
+
+            destList.Count.ShouldEqual(2);
+            destList[0].Children.Count.ShouldEqual(1);
+            destList[0].Children[0].ShouldBeSameAs(destList[1]);
+        }
+    }
+}

--- a/src/UnitTests/Bug/OneSourceWithMultipleDestinationsWithoutPR.cs
+++ b/src/UnitTests/Bug/OneSourceWithMultipleDestinationsWithoutPR.cs
@@ -1,0 +1,41 @@
+﻿using Xunit;
+using Should;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public class OneSourceWithMultipleDestinationsWithoutPR : AutoMapperSpecBase
+    {
+        ClientModel _destination;
+
+        public partial class Client
+        {
+            public string Address1 { get; set; }
+        }
+        public class AddressModel
+        {
+            public string Address1 { get; set; }
+        }
+        public class ClientModel
+        {
+            public AddressModel Address { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(mapConfig =>
+        {
+            mapConfig.CreateMap<Client, ClientModel>()
+                .ForMember(m => m.Address, opt => opt.MapFrom(x => x));
+            mapConfig.CreateMap<Client, AddressModel>();
+        });
+
+        protected override void Because_of()
+        {
+            _destination = Mapper.Map<ClientModel>(new Client { Address1 = "abc" });
+        }
+
+        [Fact]
+        public void Should_map_ok()
+        {
+            _destination.Address.Address1.ShouldEqual("abc");
+        }
+    }
+}

--- a/src/UnitTests/Bug/WithoutPreserveReferencesSameDestination.cs
+++ b/src/UnitTests/Bug/WithoutPreserveReferencesSameDestination.cs
@@ -1,0 +1,92 @@
+﻿using Xunit;
+using Should;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public class Self_referencing_existing_destination_without_PreserveReferences : AutoMapperSpecBase
+    {
+        public class BaseType
+        {
+            public BaseType()
+            {
+                SelfReference = this;
+            }
+            public BaseType SelfReference { get; set; }
+        }
+
+        public class BaseTypeDto
+        {
+            public BaseTypeDto()
+            {
+                SelfReference = this;
+            }
+            public BaseTypeDto SelfReference { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg=> cfg.CreateMap<BaseType, BaseTypeDto>());
+
+        protected override void Because_of()
+        {
+            var baseType = new BaseType();
+            var baseTypeDto = new BaseTypeDto();
+
+            Mapper.Map(baseType, baseTypeDto);
+        }
+    }
+
+    public class WithoutPreserveReferencesSameDestination : AutoMapperSpecBase
+    {
+        public class DtoOne
+        {
+            public DtoTwo Two { get; set; }
+        }
+
+        public class DtoTwo
+        {
+            public virtual ICollection<DtoOne> Ones { get; set; }
+        }
+
+        public class DtoThree
+        {
+            public int Id { get; set; }
+        }
+
+        public class EntityOne
+        {
+            public int Id { get; set; }
+            public EntityTwo Two { get; set; }
+        }
+
+        public class EntityTwo
+        {
+            public virtual ICollection<EntityOne> Ones { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<EntityTwo, DtoTwo>();
+            cfg.CreateMap<EntityOne, DtoOne>();
+            cfg.CreateMap<EntityOne, DtoThree>();
+        });
+
+        [Fact]
+        public void Should_use_the_right_map()
+        {
+            var source =
+                    new EntityOne {
+                        Two = new EntityTwo {
+                            Ones = new List<EntityOne> {
+                                new EntityOne {
+                                    Two = new EntityTwo { Ones = new List<EntityOne>() }
+                                }
+                            }
+                        }
+                    };
+            Mapper.Map<EntityOne, DtoOne>(source).ShouldBeType<DtoOne>();
+            Mapper.Map<EntityOne, DtoThree>(source).ShouldBeType<DtoThree>();
+        }
+    }
+}

--- a/src/UnitTests/MaxDepthTests.cs
+++ b/src/UnitTests/MaxDepthTests.cs
@@ -1,87 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Should;
 using Xunit;
 
 namespace AutoMapper.UnitTests
 {
-    public class MaxDepthWithReverseMap : AutoMapperSpecBase
-    {
-        UserDto _destination;
-
-        public class UserModel
-        {
-            public virtual CategoryModel Category { get; set; }
-            public virtual UserGroupModel Group { get; set; }
-        }
-
-        public class CategoryModel
-        {
-            public CategoryModel Category { get; set; }
-        }
-
-        public class UserGroupModel
-        {
-            public UserGroupModel()
-            {
-                Users = new List<UserModel>();
-            }
-
-            public virtual ICollection<UserModel> Users { get; set; }
-        }
-
-        public class UserDto
-        {
-            public virtual CategoryDto Category { get; set; }
-            public virtual UserGroupDto Group { get; set; }
-        }
-
-        public class CategoryDto
-        {
-            public CategoryDto Category { get; set; }
-        }
-
-        public class UserGroupDto
-        {
-            public UserGroupDto()
-            {
-                Users = new List<UserDto>();
-            }
-
-            public virtual ICollection<UserDto> Users { get; set; }
-        }
-
-        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
-        {
-            cfg.CreateMap<CategoryModel, CategoryDto>(MemberList.Destination).PreserveReferences().ReverseMap();
-            cfg.CreateMap<UserModel, UserDto>(MemberList.Destination).PreserveReferences().ReverseMap();
-            cfg.CreateMap<UserGroupModel, UserGroupDto>(MemberList.Destination).PreserveReferences().ReverseMap();
-        });
-
-        protected override void Because_of()
-        {
-            var categoryModel = new CategoryModel();
-            categoryModel.Category = categoryModel;
-
-            var userModel = new UserModel();
-            var userGroupModel = new UserGroupModel();
-
-            userModel.Category = categoryModel;
-            userModel.Group = userGroupModel;
-            userGroupModel.Users.Add(userModel);
-
-            _destination = Mapper.Map<UserDto>(userModel);
-        }
-
-        [Fact]
-        public void Should_map_ok()
-        {
-            _destination.Group.Users.SequenceEqual(new[] { _destination }).ShouldBeTrue();
-        }
-    }
-
     public class MaxDepthTests
     {
         public class Source

--- a/src/UnitTests/ReverseMapWithPreserveReferences.cs
+++ b/src/UnitTests/ReverseMapWithPreserveReferences.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Should;
+using Xunit;
+
+namespace AutoMapper.UnitTests
+{
+    public class ReverseMapWithPreserveReferences : AutoMapperSpecBase
+    {
+        UserDto _destination;
+
+        public class UserModel
+        {
+            public virtual CategoryModel Category { get; set; }
+            public virtual UserGroupModel Group { get; set; }
+        }
+
+        public class CategoryModel
+        {
+            public CategoryModel Category { get; set; }
+        }
+
+        public class UserGroupModel
+        {
+            public UserGroupModel()
+            {
+                Users = new List<UserModel>();
+            }
+
+            public virtual ICollection<UserModel> Users { get; set; }
+        }
+
+        public class UserDto
+        {
+            public virtual CategoryDto Category { get; set; }
+            public virtual UserGroupDto Group { get; set; }
+        }
+
+        public class CategoryDto
+        {
+            public CategoryDto Category { get; set; }
+        }
+
+        public class UserGroupDto
+        {
+            public UserGroupDto()
+            {
+                Users = new List<UserDto>();
+            }
+
+            public virtual ICollection<UserDto> Users { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<CategoryModel, CategoryDto>(MemberList.Destination).PreserveReferences().ReverseMap();
+            cfg.CreateMap<UserModel, UserDto>(MemberList.Destination).PreserveReferences().ReverseMap();
+            cfg.CreateMap<UserGroupModel, UserGroupDto>(MemberList.Destination).PreserveReferences().ReverseMap();
+        });
+
+        protected override void Because_of()
+        {
+            var categoryModel = new CategoryModel();
+            categoryModel.Category = categoryModel;
+
+            var userModel = new UserModel();
+            var userGroupModel = new UserGroupModel();
+
+            userModel.Category = categoryModel;
+            userModel.Group = userGroupModel;
+            userGroupModel.Users.Add(userModel);
+
+            _destination = Mapper.Map<UserDto>(userModel);
+        }
+
+        [Fact]
+        public void Should_map_ok()
+        {
+            _destination.Group.Users.SequenceEqual(new[] { _destination }).ShouldBeTrue();
+        }
+    }
+}

--- a/src/UnitTests/ReverseMapWithoutPreserveReferences.cs
+++ b/src/UnitTests/ReverseMapWithoutPreserveReferences.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Should;
+using Xunit;
+
+namespace AutoMapper.UnitTests
+{
+    public class ReverseMapWithoutPreserveReferences : AutoMapperSpecBase
+    {
+        UserDto _destination;
+
+        public class UserModel
+        {
+            public virtual CategoryModel Category { get; set; }
+            public virtual UserGroupModel Group { get; set; }
+        }
+
+        public class CategoryModel
+        {
+            public CategoryModel Category { get; set; }
+        }
+
+        public class UserGroupModel
+        {
+            public UserGroupModel()
+            {
+                Users = new List<UserModel>();
+            }
+
+            public virtual ICollection<UserModel> Users { get; set; }
+        }
+
+        public class UserDto
+        {
+            public virtual CategoryDto Category { get; set; }
+            public virtual UserGroupDto Group { get; set; }
+        }
+
+        public class CategoryDto
+        {
+            public CategoryDto Category { get; set; }
+        }
+
+        public class UserGroupDto
+        {
+            public UserGroupDto()
+            {
+                Users = new List<UserDto>();
+            }
+
+            public virtual ICollection<UserDto> Users { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<CategoryModel, CategoryDto>(MemberList.Destination).ReverseMap();
+            cfg.CreateMap<UserModel, UserDto>(MemberList.Destination).ReverseMap();
+            cfg.CreateMap<UserGroupModel, UserGroupDto>(MemberList.Destination).ReverseMap();
+        });
+
+        protected override void Because_of()
+        {
+            var categoryModel = new CategoryModel();
+            categoryModel.Category = categoryModel;
+
+            var userModel = new UserModel();
+            var userGroupModel = new UserGroupModel();
+
+            userModel.Category = categoryModel;
+            userModel.Group = userGroupModel;
+            userGroupModel.Users.Add(userModel);
+
+            _destination = Mapper.Map<UserDto>(userModel);
+        }
+
+        [Fact]
+        public void Should_map_ok()
+        {
+            _destination.Group.Users.SequenceEqual(new[] { _destination }).ShouldBeTrue();
+        }
+    }
+}

--- a/src/UnitTests/UnitTests.Net4.csproj
+++ b/src/UnitTests/UnitTests.Net4.csproj
@@ -85,8 +85,11 @@
     <Compile Include="AssemblyScanning.cs" />
     <Compile Include="AssertionExtensions.cs" />
     <Compile Include="BasicFlattening.cs" />
+    <Compile Include="BidirectionalRelationshipsWithoutPR.cs" />
     <Compile Include="Bug\CannotProjectStringToNullableEnum.cs" />
+    <Compile Include="Bug\DuplicateValuesBugWithoutPR.cs" />
     <Compile Include="Bug\NullableToInvalid.cs" />
+    <Compile Include="Bug\OneSourceWithMultipleDestinationsWithoutPR.cs" />
     <Compile Include="Bug\OneSourceWithMultipleDestinationsAndPreserveReferences.cs" />
     <Compile Include="Bug\ConventionCreateMapsWithCircularReference.cs" />
     <Compile Include="Bug\ConvertMapperThreading.cs" />
@@ -222,6 +225,7 @@
     <Compile Include="Bug\NullToString.cs" />
     <Compile Include="Bug\NullSubstituteInnerClass.cs" />
     <Compile Include="Bug\MapExpandoObjectProperty.cs" />
+    <Compile Include="Bug\WithoutPreserveReferencesSameDestination.cs" />
     <Compile Include="Bug\PreserveReferencesSameDestination.cs" />
     <Compile Include="BuildExecutionPlan.cs" />
     <Compile Include="ConfigCompilation.cs" />
@@ -405,6 +409,8 @@
     <Compile Include="PropertyMapContexts.cs" />
     <Compile Include="Regression.cs" />
     <Compile Include="ReverseMapping.cs" />
+    <Compile Include="ReverseMapWithoutPreserveReferences.cs" />
+    <Compile Include="ReverseMapWithPreserveReferences.cs" />
     <Compile Include="SeparateConfiguration.cs" />
     <Compile Include="Should\Should.Core\Assertions\Assert.cs" />
     <Compile Include="Should\Should.Core\Assertions\AssertComparer.cs" />


### PR DESCRIPTION
This affects the complex types benchmark. I guess I should modify it to prevent that. It might break some people, but I think we should remove Configuration.GetMappers().