### PR TITLE
Fix ExpressionBuilder GetMapExpression behaviour

### DIFF
--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -19,7 +19,7 @@ namespace AutoMapper.QueryableExtensions
     public interface IExpressionBuilder
     {
         LambdaExpression[] GetMapExpression(Type sourceType, Type destinationType, ParameterBag parameters, MemberInfo[] membersToExpand);
-        Expression<Func<TSource, TDestination>> GetMapExpression<TSource, TDestination>(ParameterBag parameters = null, params MemberInfo[] membersToExpand);
+        Expression<Func<TSource, TDestination>> GetMapExpression<TSource, TDestination>(ParameterBag parameters, MemberInfo[] membersToExpand);
         LambdaExpression[] CreateMapExpression(ExpressionRequest request, TypePairCount typePairCount, LetPropertyMaps letPropertyMaps);
         Expression CreateMapExpression(ExpressionRequest request, Expression instanceParameter, TypePairCount typePairCount, LetPropertyMaps letPropertyMaps);
     }
@@ -99,12 +99,9 @@ namespace AutoMapper.QueryableExtensions
         }
 
         public Expression<Func<TSource, TDestination>> GetMapExpression<TSource, TDestination>(
-            ParameterBag parameters = null,
-            params MemberInfo[] membersToExpand)
-        {
-            parameters = parameters ?? new Dictionary<string, object>();
-            return (Expression<Func<TSource, TDestination>>) GetMapExpression(typeof(TSource), typeof(TDestination), parameters, membersToExpand)[0];
-        }
+            ParameterBag parameters, MemberInfo[] membersToExpand) =>
+            (Expression<Func<TSource, TDestination>>) GetMapExpression(typeof(TSource), typeof(TDestination),
+                parameters, membersToExpand)[0];
 
         private LambdaExpression[] CreateMapExpression(ExpressionRequest request) => CreateMapExpression(request, new Dictionary<ExpressionRequest, int>(), new FirstPassLetPropertyMaps(_configurationProvider));
 
@@ -552,5 +549,14 @@ namespace AutoMapper.QueryableExtensions
         public Expression First { get; }
         public Expression Second { get; }
         public ParameterExpression SecondParameter { get; }
+    }
+
+    public static class ExpressionBuilderExtensions
+    {
+        public static Expression<Func<TSource, TDestination>> GetMapExpression<TSource, TDestination>(this IExpressionBuilder expressionBuilder)
+        {
+            return expressionBuilder.GetMapExpression<TSource, TDestination>(new Dictionary<string, object>(),
+                new MemberInfo[0]);
+        }
     }
 }

--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -56,6 +56,8 @@ namespace AutoMapper.QueryableExtensions
         {
             parameters = parameters ?? new Dictionary<string, object>();
 
+            membersToExpand = membersToExpand ?? new MemberInfo[0];
+
             var cachedExpressions = _expressionCache.GetOrAdd(new ExpressionRequest(sourceType, destinationType, membersToExpand, null));
 
             return cachedExpressions.Select(e => Prepare(e, parameters)).Cast<LambdaExpression>().ToArray();

--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -52,11 +52,25 @@ namespace AutoMapper.QueryableExtensions
             _expressionCache = new LockingConcurrentDictionary<ExpressionRequest, LambdaExpression[]>(CreateMapExpression);
         }
 
-        public LambdaExpression[] GetMapExpression(Type sourceType, Type destinationType, ParameterBag parameters, MemberInfo[] membersToExpand)
+        public LambdaExpression[] GetMapExpression(Type sourceType, Type destinationType, ParameterBag parameters,
+            MemberInfo[] membersToExpand)
         {
-            parameters = parameters ?? new Dictionary<string, object>();
-
-            membersToExpand = membersToExpand ?? new MemberInfo[0];
+            if (sourceType == null)
+            {
+                throw new ArgumentNullException(nameof(sourceType));
+            }
+            if (destinationType == null)
+            {
+                throw new ArgumentNullException(nameof(destinationType));
+            }
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+            if (membersToExpand == null)
+            {
+                throw new ArgumentNullException(nameof(membersToExpand));
+            }
 
             var cachedExpressions = _expressionCache.GetOrAdd(new ExpressionRequest(sourceType, destinationType, membersToExpand, null));
 
@@ -86,8 +100,11 @@ namespace AutoMapper.QueryableExtensions
 
         public Expression<Func<TSource, TDestination>> GetMapExpression<TSource, TDestination>(
             ParameterBag parameters = null,
-            params MemberInfo[] membersToExpand) => 
-            (Expression<Func<TSource, TDestination>>)GetMapExpression(typeof(TSource), typeof(TDestination), parameters, membersToExpand)[0];
+            params MemberInfo[] membersToExpand)
+        {
+            parameters = parameters ?? new Dictionary<string, object>();
+            return (Expression<Func<TSource, TDestination>>) GetMapExpression(typeof(TSource), typeof(TDestination), parameters, membersToExpand)[0];
+        }
 
         private LambdaExpression[] CreateMapExpression(ExpressionRequest request) => CreateMapExpression(request, new Dictionary<ExpressionRequest, int>(), new FirstPassLetPropertyMaps(_configurationProvider));
 

--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -19,7 +19,6 @@ namespace AutoMapper.QueryableExtensions
     public interface IExpressionBuilder
     {
         LambdaExpression[] GetMapExpression(Type sourceType, Type destinationType, ParameterBag parameters, MemberInfo[] membersToExpand);
-        Expression<Func<TSource, TDestination>> GetMapExpression<TSource, TDestination>(ParameterBag parameters, MemberInfo[] membersToExpand);
         LambdaExpression[] CreateMapExpression(ExpressionRequest request, TypePairCount typePairCount, LetPropertyMaps letPropertyMaps);
         Expression CreateMapExpression(ExpressionRequest request, Expression instanceParameter, TypePairCount typePairCount, LetPropertyMaps letPropertyMaps);
     }
@@ -97,11 +96,6 @@ namespace AutoMapper.QueryableExtensions
             }
             return result;
         }
-
-        public Expression<Func<TSource, TDestination>> GetMapExpression<TSource, TDestination>(
-            ParameterBag parameters, MemberInfo[] membersToExpand) =>
-            (Expression<Func<TSource, TDestination>>) GetMapExpression(typeof(TSource), typeof(TDestination),
-                parameters, membersToExpand)[0];
 
         private LambdaExpression[] CreateMapExpression(ExpressionRequest request) => CreateMapExpression(request, new Dictionary<ExpressionRequest, int>(), new FirstPassLetPropertyMaps(_configurationProvider));
 
@@ -553,10 +547,11 @@ namespace AutoMapper.QueryableExtensions
 
     public static class ExpressionBuilderExtensions
     {
-        public static Expression<Func<TSource, TDestination>> GetMapExpression<TSource, TDestination>(this IExpressionBuilder expressionBuilder)
+        public static Expression<Func<TSource, TDestination>> GetMapExpression<TSource, TDestination>(
+            this IExpressionBuilder expressionBuilder)
         {
-            return expressionBuilder.GetMapExpression<TSource, TDestination>(new Dictionary<string, object>(),
-                new MemberInfo[0]);
+            return (Expression<Func<TSource, TDestination>>) expressionBuilder.GetMapExpression(typeof(TSource),
+                typeof(TDestination), new Dictionary<string, object>(), new MemberInfo[0])[0];
         }
     }
 }

--- a/src/AutoMapper/QueryableExtensions/ExpressionRequest.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionRequest.cs
@@ -27,7 +27,7 @@ namespace AutoMapper.QueryableExtensions
         {
             SourceType = sourceType;
             DestinationType = destinationType;
-            MembersToExpand = membersToExpand?.OrderBy(p => p.Name).ToArray();
+            MembersToExpand = membersToExpand.OrderBy(p => p.Name).ToArray();
 
             PreviousRequests = parentRequest == null 
                 ? new HashSet<ExpressionRequest>() 

--- a/src/AutoMapper/QueryableExtensions/ExpressionRequest.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionRequest.cs
@@ -27,7 +27,7 @@ namespace AutoMapper.QueryableExtensions
         {
             SourceType = sourceType;
             DestinationType = destinationType;
-            MembersToExpand = membersToExpand.OrderBy(p => p.Name).ToArray();
+            MembersToExpand = membersToExpand?.OrderBy(p => p.Name).ToArray() ?? new MemberInfo[0];
 
             PreviousRequests = parentRequest == null 
                 ? new HashSet<ExpressionRequest>() 

--- a/src/AutoMapper/QueryableExtensions/ExpressionRequest.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionRequest.cs
@@ -27,7 +27,7 @@ namespace AutoMapper.QueryableExtensions
         {
             SourceType = sourceType;
             DestinationType = destinationType;
-            MembersToExpand = membersToExpand?.OrderBy(p => p.Name).ToArray() ?? new MemberInfo[0];
+            MembersToExpand = membersToExpand?.OrderBy(p => p.Name).ToArray();
 
             PreviousRequests = parentRequest == null 
                 ? new HashSet<ExpressionRequest>() 

--- a/src/AutoMapper/QueryableExtensions/Impl/SourceInjectedQueryProvider.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/SourceInjectedQueryProvider.cs
@@ -36,7 +36,7 @@ namespace AutoMapper.QueryableExtensions.Impl
             _destQuery = destQuery;
             _beforeVisitors = beforeVisitors;
             _afterVisitors = afterVisitors;
-            _parameters = parameters;
+            _parameters = parameters ?? new Dictionary<string, object>();
             _membersToExpand = membersToExpand ?? Enumerable.Empty<IEnumerable<MemberInfo>>();
             _exceptionHandler = exceptionHandler ?? (x => { });
         }

--- a/src/AutoMapper/QueryableExtensions/ProjectionExpression.cs
+++ b/src/AutoMapper/QueryableExtensions/ProjectionExpression.cs
@@ -72,6 +72,7 @@ namespace AutoMapper.QueryableExtensions
         {
             var membersToExpand = memberPathsToExpand.SelectMany(m => m).Distinct().ToArray();
 
+            parameters = parameters ?? new Dictionary<string, object>();
             var mapExpressions = _builder.GetMapExpression(_source.ElementType, typeof(TResult), parameters, membersToExpand);
 
             return (IQueryable<TResult>)mapExpressions.Aggregate(_source, (source, lambda)=>Select(source, lambda));

--- a/src/UnitTests/Projection/MapFromTest.cs
+++ b/src/UnitTests/Projection/MapFromTest.cs
@@ -22,20 +22,6 @@ namespace AutoMapper.UnitTests.Projection.MapFromTest
             typeof(NullReferenceException).ShouldNotBeThrownBy(() => config.ExpressionBuilder.GetMapExpression<UserModel, UserDto>()); //null reference exception here
         }
 
-
-        [Fact]
-        public void Should_fail_Typed()
-        {
-            var config = new MapperConfiguration(cfg =>
-            {
-                cfg.CreateMap<UserModel, UserDto>()
-                    .ForMember(dto => dto.FullName, opt => opt.MapFrom(src => src.LastName + " " + src.FirstName));
-            });
-            typeof(ArgumentNullException).ShouldBeThrownBy(() => config.ExpressionBuilder.GetMapExpression<UserModel, UserDto>(null, new MemberInfo[0])); //ArgumentNullException here
-            typeof(ArgumentNullException).ShouldBeThrownBy(() => config.ExpressionBuilder.GetMapExpression<UserModel, UserDto>(new Dictionary<string, object>(), null)); //ArgumentNullException here
-
-        }
-
         [Fact]
         public void Should_fail_Untyped()
         {

--- a/src/UnitTests/Projection/MapFromTest.cs
+++ b/src/UnitTests/Projection/MapFromTest.cs
@@ -21,6 +21,18 @@ namespace AutoMapper.UnitTests.Projection.MapFromTest
         }
 
         [Fact]
+        public void Should_not_fail_Untyped()
+        {
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<UserModel, UserDto>()
+                    .ForMember(dto => dto.FullName, opt => opt.MapFrom(src => src.LastName + " " + src.FirstName));
+            });
+
+            typeof(ArgumentNullException).ShouldNotBeThrownBy(() => config.ExpressionBuilder.GetMapExpression(typeof(UserModel), typeof(UserDto), null, null)); //no ArgumentNullException here
+        }
+
+        [Fact]
         public void Should_map_from_String()
         {
             var config = new MapperConfiguration(cfg => cfg.CreateMap<UserModel, UserDto>()

--- a/src/UnitTests/Projection/MapFromTest.cs
+++ b/src/UnitTests/Projection/MapFromTest.cs
@@ -22,6 +22,20 @@ namespace AutoMapper.UnitTests.Projection.MapFromTest
             typeof(NullReferenceException).ShouldNotBeThrownBy(() => config.ExpressionBuilder.GetMapExpression<UserModel, UserDto>()); //null reference exception here
         }
 
+
+        [Fact]
+        public void Should_fail_Typed()
+        {
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<UserModel, UserDto>()
+                    .ForMember(dto => dto.FullName, opt => opt.MapFrom(src => src.LastName + " " + src.FirstName));
+            });
+            typeof(ArgumentNullException).ShouldBeThrownBy(() => config.ExpressionBuilder.GetMapExpression<UserModel, UserDto>(null, new MemberInfo[0])); //ArgumentNullException here
+            typeof(ArgumentNullException).ShouldBeThrownBy(() => config.ExpressionBuilder.GetMapExpression<UserModel, UserDto>(new Dictionary<string, object>(), null)); //ArgumentNullException here
+
+        }
+
         [Fact]
         public void Should_fail_Untyped()
         {

--- a/src/UnitTests/Projection/MapFromTest.cs
+++ b/src/UnitTests/Projection/MapFromTest.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Should;
 using Xunit;
 using AutoMapper.QueryableExtensions;
@@ -21,7 +23,7 @@ namespace AutoMapper.UnitTests.Projection.MapFromTest
         }
 
         [Fact]
-        public void Should_not_fail_Untyped()
+        public void Should_fail_Untyped()
         {
             var config = new MapperConfiguration(cfg =>
             {
@@ -29,7 +31,10 @@ namespace AutoMapper.UnitTests.Projection.MapFromTest
                     .ForMember(dto => dto.FullName, opt => opt.MapFrom(src => src.LastName + " " + src.FirstName));
             });
 
-            typeof(ArgumentNullException).ShouldNotBeThrownBy(() => config.ExpressionBuilder.GetMapExpression(typeof(UserModel), typeof(UserDto), null, null)); //no ArgumentNullException here
+            typeof(ArgumentNullException).ShouldBeThrownBy(() => config.ExpressionBuilder.GetMapExpression(null, typeof(UserDto), new Dictionary<string, object>(), new MemberInfo[0])); //ArgumentNullException here
+            typeof(ArgumentNullException).ShouldBeThrownBy(() => config.ExpressionBuilder.GetMapExpression(typeof(UserModel), null, new Dictionary<string, object>(), new MemberInfo[0])); //ArgumentNullException here
+            typeof(ArgumentNullException).ShouldBeThrownBy(() => config.ExpressionBuilder.GetMapExpression(typeof(UserModel), typeof(UserDto), null, new MemberInfo[0])); //ArgumentNullException here
+            typeof(ArgumentNullException).ShouldBeThrownBy(() => config.ExpressionBuilder.GetMapExpression(typeof(UserModel), typeof(UserDto), new Dictionary<string, object>(), null)); //ArgumentNullException here
         }
 
         [Fact]


### PR DESCRIPTION
The typed version of ``GetMapExpression()`` has ``params MemberInfo[]``. Make certain the untyped version creates an empty array otherwise ``ExpressionRequest`` crashes in ctor.