### PR TITLE
Allow ignores on reverse map paths

### DIFF
--- a/src/AutoMapper/Configuration/PathConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/PathConfigurationExpression.cs
@@ -28,6 +28,11 @@ namespace AutoMapper.Configuration
             MapFromUntyped(sourceExpression);
         }
 
+        public void Ignore()
+        {
+            PathMapActions.Add(pm => pm.Ignored = true);
+        }
+
         public void MapFromUntyped(LambdaExpression sourceExpression)
         {
             _sourceExpression = sourceExpression;
@@ -39,14 +44,6 @@ namespace AutoMapper.Configuration
 
         public void Configure(TypeMap typeMap)
         {
-            //var destMember = DestinationMember;
-
-            //if(destMember.DeclaringType.IsGenericType())
-            //{
-            //    var destTypeInfo = typeMap.Profile.CreateTypeDetails(destMember.DeclaringType);
-            //    destMember = destTypeInfo.PublicReadAccessors.Single(m => m.Name == destMember.Name);
-            //}
-
             var pathMap = typeMap.FindOrCreatePathMapFor(_destinationExpression, MemberPath, typeMap);
 
             Apply(pathMap);

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -201,7 +201,7 @@ namespace AutoMapper.Execution
                 }
                 actions.Add(property);
             }
-            foreach(var pathMap in _typeMap.PathMaps)
+            foreach(var pathMap in _typeMap.PathMaps.Where(pm => !pm.Ignored))
             {
                 actions.Add(HandlePath(pathMap));
             }

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -188,12 +188,8 @@ namespace AutoMapper.Execution
         private Expression CreateAssignmentFunc(Expression destinationFunc, bool constructorMapping)
         {
             var actions = new List<Expression>();
-            foreach(var propertyMap in _typeMap.GetPropertyMaps())
+            foreach(var propertyMap in _typeMap.GetPropertyMaps().Where(pm => pm.CanResolveValue()))
             {
-                if(!propertyMap.CanResolveValue())
-                {
-                    continue;
-                }
                 var property = TryPropertyMap(propertyMap);
                 if(constructorMapping && _typeMap.ConstructorParameterMatches(propertyMap.DestinationProperty.Name))
                 {

--- a/src/AutoMapper/IPathConfigurationExpression.cs
+++ b/src/AutoMapper/IPathConfigurationExpression.cs
@@ -18,5 +18,10 @@ namespace AutoMapper
         /// <typeparam name="TSourceMember">Member type of the source member to use</typeparam>
         /// <param name="sourceMember">Expression referencing the source member to map against</param>
         void MapFrom<TSourceMember>(Expression<Func<TSource, TSourceMember>> sourceMember);
+
+        /// <summary>
+        /// Ignore this member for configuration validation and skip during mapping
+        /// </summary>
+        void Ignore();
     }
 }

--- a/src/AutoMapper/PathMap.cs
+++ b/src/AutoMapper/PathMap.cs
@@ -6,7 +6,7 @@ namespace AutoMapper
 {
     using Internal;
 
-    [DebuggerDisplay("{" + nameof(DestinationExpression) + "}")]
+    [DebuggerDisplay("{DestinationExpression}")]
     public class PathMap
     {
         public PathMap(LambdaExpression destinationExpression, MemberPath memberPath, TypeMap typeMap)

--- a/src/AutoMapper/PathMap.cs
+++ b/src/AutoMapper/PathMap.cs
@@ -6,7 +6,7 @@ namespace AutoMapper
 {
     using Internal;
 
-    [DebuggerDisplay("{DestinationExpression}")]
+    [DebuggerDisplay("{" + nameof(DestinationExpression) + "}")]
     public class PathMap
     {
         public PathMap(LambdaExpression destinationExpression, MemberPath memberPath, TypeMap typeMap)
@@ -21,5 +21,6 @@ namespace AutoMapper
         public LambdaExpression SourceExpression { get; set; }
         public MemberPath MemberPath { get; }
         public MemberInfo DestinationMember => MemberPath.Last;
+        public bool Ignored { get; set; }
     }
 }

--- a/src/UnitTests/ForPath.cs
+++ b/src/UnitTests/ForPath.cs
@@ -131,6 +131,55 @@ namespace AutoMapper.UnitTests
         }
     }
 
+    public class ForPathWithIgnoreShouldNotSetValue : AutoMapperSpecBase
+    {
+        public partial class TimesheetModel
+        {
+            public int ID { get; set; }
+            public DateTime? StartDate { get; set; }
+            public int? Contact { get; set; }
+            public ContactModel ContactNavigation { get; set; }
+        }
+
+        public class TimesheetViewModel
+        {
+            public int? Contact { get; set; }
+            public DateTime? StartDate { get; set; }
+        }
+
+        public class ContactModel
+        {
+            public int Id { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<TimesheetModel, TimesheetViewModel>()
+                .ForMember(d => d.Contact, o => o.MapFrom(s => s.ContactNavigation.Id))
+                .ReverseMap()
+                .ForPath(s => s.ContactNavigation.Id, opt => opt.Ignore());
+        });
+
+        [Fact]
+        public void Should_not_set_value()
+        {
+            var source = new TimesheetModel
+            {
+                Contact = 6,
+                ContactNavigation = new ContactModel
+                {
+                    Id = 5
+                }
+            };
+            var dest = new TimesheetViewModel
+            {
+                Contact = 10
+            };
+            Mapper.Map(dest, source);
+
+            source.ContactNavigation.Id.ShouldEqual(5);
+        }
+    }
 
     public class ForPathWithPrivateSetters : AutoMapperSpecBase
     {


### PR DESCRIPTION
Should really have done this with 6.1.0, whoops.

Allow you to ignore a path:

```csharp
cfg =>
    {
		cfg.CreateMap<TimesheetModel, TimesheetViewModel>()
			.ForMember(d=>d.Contact, o=>o.MapFrom(s=>s.ContactNavigation.Id))
			.ReverseMap()
                        .ForPath(s => s.ContactNavigation.Id, opt => opt.Ignore());
    }
```