### PR TITLE
Fix for issue #2166

### DIFF
--- a/src/AutoMapper/XpressionMapper/XpressionMapperVisitor.cs
+++ b/src/AutoMapper/XpressionMapper/XpressionMapperVisitor.cs
@@ -97,7 +97,7 @@ namespace AutoMapper.XpressionMapper
             {
                 if (constantExpression.Value == null)
                 {
-                    return base.VisitBinary(node.Left.Type.GetTypeInfo().IsValueType
+                    return base.VisitBinary(node.Left.Type.GetTypeInfo().IsValueType || node.Left.Type == typeof(string)
                         ? node.Update(node.Left, node.Conversion, Expression.Constant(null, node.Left.Type))
                         : node.Update(node.Left, node.Conversion, Expression.Constant(null, typeof(object))));
                 }
@@ -108,7 +108,7 @@ namespace AutoMapper.XpressionMapper
             {
                 if (constantExpression.Value == null)
                 {
-                    return base.VisitBinary(node.Right.Type.GetTypeInfo().IsValueType 
+                    return base.VisitBinary(node.Right.Type.GetTypeInfo().IsValueType || node.Right.Type == typeof(string)
                         ? node.Update(Expression.Constant(null, node.Right.Type), node.Conversion, node.Right) 
                         : node.Update(Expression.Constant(null, typeof(object)), node.Conversion, node.Right));
                 }

--- a/src/UnitTests/XpressionMapperTests.cs
+++ b/src/UnitTests/XpressionMapperTests.cs
@@ -382,10 +382,25 @@ namespace AutoMapper.UnitTests
         }
 
         [Fact]
-        public void Map_accountModel_to_account_with_null_checks_against_string_type()
+        public void Map_accountModel_to_account_with_right_null_checks_against_string_type()
         {
             //Arrange
             Expression<Func<AccountModel, bool>> exp = f => f.Description == null;
+
+
+            //Act
+            Expression<Func<Account, bool>> expMapped = mapper.MapExpression<Expression<Func<Account, bool>>>(exp);
+            List<Account> accounts = Users.Select(u => u.Account).Where(expMapped).ToList();
+
+            //Assert
+            Assert.True(accounts.Count == 0);
+        }
+
+        [Fact]
+        public void Map_accountModel_to_account_with_left_null_checks_against_string_type()
+        {
+            //Arrange
+            Expression<Func<AccountModel, bool>> exp = f => null == f.Description;
 
 
             //Act

--- a/src/UnitTests/XpressionMapperTests.cs
+++ b/src/UnitTests/XpressionMapperTests.cs
@@ -2,11 +2,8 @@
 using Should.Core.Assertions;
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace AutoMapper.UnitTests
@@ -385,6 +382,21 @@ namespace AutoMapper.UnitTests
         }
 
         [Fact]
+        public void Map_accountModel_to_account_with_null_checks_against_string_type()
+        {
+            //Arrange
+            Expression<Func<AccountModel, bool>> exp = f => f.Description == null;
+
+
+            //Act
+            Expression<Func<Account, bool>> expMapped = mapper.MapExpression<Expression<Func<Account, bool>>>(exp);
+            List<Account> accounts = Users.Select(u => u.Account).Where(expMapped).ToList();
+
+            //Assert
+            Assert.True(accounts.Count == 0);
+        }
+
+        [Fact]
         public void When_use_lambda_statement_with_typemapped_property_being_other_than_first()
         {
             //Arrange
@@ -465,7 +477,7 @@ namespace AutoMapper.UnitTests
                             new Thing { Bar = "Bar4", Car = new Car { Color = "White", Year = 2015 } }
                         },
                         Type = "Business",
-                        Users = new User[] 
+                        Users = new User[]
                         {
                             new User
                             {


### PR DESCRIPTION
This should be the fix for this issue
["Issue with MapExpression when expression checks if a string equals null"](https://github.com/AutoMapper/AutoMapper/issues/2166)
Closes #2166.