### PR TITLE
Use Resolve instead of Find for expression generation

### DIFF
--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -170,7 +170,7 @@ namespace AutoMapper.Mappers
                     let sourceParamType = t.Type
                     from destParamType in _destSubTypes.Where(dt => dt != sourceParamType)
                     let a = destParamType.IsGenericType() ? destParamType.GetTypeInfo().GenericTypeArguments[0] : destParamType
-                    let typeMap = _configurationProvider.FindTypeMapFor(a, sourceParamType)
+                    let typeMap = _configurationProvider.ResolveTypeMap(a, sourceParamType)
                     where typeMap != null
                     let oldParam = t
                     let newParam = Parameter(a, oldParam.Name)
@@ -236,7 +236,7 @@ namespace AutoMapper.Mappers
                 var destType = propertyMap.DestinationPropertyType;
                 if (sourceType == destType)
                     return MakeMemberAccess(baseExpression, node.Member);
-                var typeMap = _configurationProvider.FindTypeMapFor(sourceType, destType);
+                var typeMap = _configurationProvider.ResolveTypeMap(sourceType, destType);
                 var subVisitor = new MappingVisitor(_configurationProvider, typeMap, node.Expression, baseExpression, this);
                 var newExpression = subVisitor.Visit(node);
                 _destSubTypes = _destSubTypes.Concat(subVisitor._destSubTypes).ToArray();

--- a/src/AutoMapper/QueryableExtensions/Impl/QueryMapperHelper.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/QueryMapperHelper.cs
@@ -24,7 +24,7 @@ namespace AutoMapper.QueryableExtensions.Impl
 
         public static TypeMap CheckIfMapExists(this IConfigurationProvider config, Type sourceType, Type destinationType)
         {
-            var typeMap = config.FindTypeMapFor(sourceType, destinationType);
+            var typeMap = config.ResolveTypeMap(sourceType, destinationType);
             if(typeMap == null)
             {
                 throw MissingMapException(sourceType, destinationType);

--- a/src/AutoMapper/QueryableExtensions/Impl/SourceInjectedQueryProvider.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/SourceInjectedQueryProvider.cs
@@ -268,7 +268,7 @@ namespace AutoMapper.QueryableExtensions.Impl
             // call beforevisitors
             expression = _beforeVisitors.Aggregate(expression, (current, before) => before.Visit(current));
 
-            var typeMap = _mapper.ConfigurationProvider.FindTypeMapFor(typeof(TDestination), typeof(TSource));
+            var typeMap = _mapper.ConfigurationProvider.ResolveTypeMap(typeof(TDestination), typeof(TSource));
             var visitor = new ExpressionMapper.MappingVisitor(_mapper.ConfigurationProvider, typeMap, _destQuery.Expression, _dataSource.Expression, null,
                 new[] { typeof(TSource) });
             var sourceExpression = visitor.Visit(expression);

--- a/src/UnitTests/Query/SourceInjectedQuery.cs
+++ b/src/UnitTests/Query/SourceInjectedQuery.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
+using AutoMapper.Mappers;
 using Shouldly;
 using AutoMapper.QueryableExtensions;
 using Xunit;
@@ -606,6 +607,21 @@ namespace AutoMapper.UnitTests.Query
             var sourceItem = _source.First(s => s.InttoStringValue == 7);
 
             destItem.DestValue.ShouldBe(sourceItem.SrcValue);
+        }
+
+        [Fact]
+        public void Shoud_work_with_conventions()
+        {
+            var mapper = new MapperConfiguration(cfg => cfg.AddConditionalObjectMapper()
+                .Where((s, d) => s.Name == d.Name + "Model" || s.Name + "Model" == d.Name)).CreateMapper();
+
+
+            IQueryable<Destination> result = _source.AsQueryable()
+                .UseAsDataSource(Mapper).For<Destination>()
+                .Where(s => s.DestValue > 6);
+
+            result.Count().ShouldBe(1);
+            result.Any(s => s.DestValue > 6).ShouldBeTrue();
         }
 
         private static IMapper SetupAutoMapper()


### PR DESCRIPTION
Conventions can't use UseAsDataSource without calling map first because when generate expressions it doesn't try to resolve type map, just find if it exists.