### PR TITLE
Add static ResolutionContext.Map MethodInfo field in ExpressionBuilder

### DIFF
--- a/src/AutoMapper/Execution/ExpressionBuilder.cs
+++ b/src/AutoMapper/Execution/ExpressionBuilder.cs
@@ -17,7 +17,7 @@ namespace AutoMapper.Execution
             mapper => new ResolutionContext(mapper.DefaultContext.Options, mapper);
 
         private static readonly MethodInfo ContextMapMethod =
-            ExpressionFactory.Method<ResolutionContext, object>(a => a.Map<object, object>(null, null));            
+            ExpressionFactory.Method<ResolutionContext, object>(a => a.Map<object, object>(null, null)).GetGenericMethodDefinition();            
 
         public static Expression MapExpression(IConfigurationProvider configurationProvider,
             ProfileMap profileMap,

--- a/src/AutoMapper/Execution/ExpressionBuilder.cs
+++ b/src/AutoMapper/Execution/ExpressionBuilder.cs
@@ -1,4 +1,3 @@
-using static System.Linq.Expressions.Expression;
 
 namespace AutoMapper.Execution
 {
@@ -6,6 +5,7 @@ namespace AutoMapper.Execution
     using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
+    using System.Reflection;
     using AutoMapper.Configuration;
     using AutoMapper.Internal;
     using AutoMapper.Mappers.Internal;
@@ -15,6 +15,9 @@ namespace AutoMapper.Execution
     {
         private static readonly Expression<Func<IRuntimeMapper, ResolutionContext>> CreateContext =
             mapper => new ResolutionContext(mapper.DefaultContext.Options, mapper);
+
+        private static readonly MethodInfo ContextMapMethod =
+            ExpressionFactory.Method<ResolutionContext, object>(a => a.Map<object, object>(null, null));            
 
         public static Expression MapExpression(IConfigurationProvider configurationProvider,
             ProfileMap profileMap,
@@ -132,9 +135,7 @@ namespace AutoMapper.Execution
         public static Expression ContextMap(TypePair typePair, Expression sourceParameter, Expression contextParameter,
             Expression destinationParameter)
         {
-            var mapMethod = typeof(ResolutionContext).GetDeclaredMethods()
-                .First(m => m.Name == "Map")
-                .MakeGenericMethod(typePair.SourceType, typePair.DestinationType);
+            var mapMethod = ContextMapMethod.MakeGenericMethod(typePair.SourceType, typePair.DestinationType);
             return Call(contextParameter, mapMethod, sourceParameter, destinationParameter);
         }
 

--- a/src/AutoMapper/Internal/ExpressionFactory.cs
+++ b/src/AutoMapper/Internal/ExpressionFactory.cs
@@ -19,9 +19,11 @@ namespace AutoMapper.Internal
                         null;
         }
 
-        public static MethodInfo Method<T>(Expression<Func<T>> expression) => ((MethodCallExpression) expression.Body).Method;
+        public static MethodInfo Method<T>(Expression<Func<T>> expression) => GetExpressionBodyMethod(expression);
 
-        public static MethodInfo Method<TType, TResult>(Expression<Func<TType, TResult>> expression) => ((MethodCallExpression)expression.Body).Method;
+        public static MethodInfo Method<TType, TResult>(Expression<Func<TType, TResult>> expression) => GetExpressionBodyMethod(expression);
+
+        private static MethodInfo GetExpressionBodyMethod(LambdaExpression expression) => ((MethodCallExpression) expression.Body).Method;
 
         public static Expression ForEach(Expression collection, ParameterExpression loopVar, Expression loopContent)
         {

--- a/src/AutoMapper/Internal/ExpressionFactory.cs
+++ b/src/AutoMapper/Internal/ExpressionFactory.cs
@@ -21,11 +21,7 @@ namespace AutoMapper.Internal
 
         public static MethodInfo Method<T>(Expression<Func<T>> expression) => ((MethodCallExpression) expression.Body).Method;
 
-        public static MethodInfo Method<TType, TResult>(Expression<Func<TType, TResult>> expression)
-        {
-            var methodInfo = ((MethodCallExpression)expression.Body).Method;
-            return methodInfo.IsGenericMethod ? methodInfo.GetGenericMethodDefinition() : methodInfo;
-        }
+        public static MethodInfo Method<TType, TResult>(Expression<Func<TType, TResult>> expression) => ((MethodCallExpression)expression.Body).Method;
 
         public static Expression ForEach(Expression collection, ParameterExpression loopVar, Expression loopContent)
         {

--- a/src/AutoMapper/Internal/ExpressionFactory.cs
+++ b/src/AutoMapper/Internal/ExpressionFactory.cs
@@ -21,6 +21,12 @@ namespace AutoMapper.Internal
 
         public static MethodInfo Method<T>(Expression<Func<T>> expression) => ((MethodCallExpression) expression.Body).Method;
 
+        public static MethodInfo Method<TType, TResult>(Expression<Func<TType, TResult>> expression)
+        {
+            var methodInfo = ((MethodCallExpression)expression.Body).Method;
+            return methodInfo.IsGenericMethod ? methodInfo.GetGenericMethodDefinition() : methodInfo;
+        }
+
         public static Expression ForEach(Expression collection, ParameterExpression loopVar, Expression loopContent)
         {
             if(collection.Type.IsArray)


### PR DESCRIPTION
This is just a minor refactoring, currently ``ContextMap`` uses ``.First`` with the method name to get the proper methodinfo, this depends on the order of methods in the ``ResolutionContext`` class, there are already two methods called ``Map``, now it uses the ``Method`` idea from ``ExpressionFactory``, this should prevent suprises when refactoring ``ResolutionContext``.
I added another of the ``Method`` methods to the ``ExpressionFactory`` to support non-static methods.

No extra tests were added as this method is called in many unit tests, if you want to see how it fails, use the old code and swap the ``Map`` methods in ``ResolutionContext``, I get ~150 failed tests then.