### PR TITLE
Introduce a global lock when creating type maps on the fly

### DIFF
--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -351,16 +351,15 @@ namespace AutoMapper
             {
                 return null;
             }
+            var mapInfo = Profiles.Select(p => new { GenericMap = p.GetGenericMap(typePair), Profile = p }).FirstOrDefault(p => p.GenericMap != null);
+            if(mapInfo == null)
+            {
+                return null;
+            }
             TypeMap typeMap;
             lock(this)
             {
-                typeMap = Profiles
-                    .Select(p => p.CreateClosedGenericTypeMap(_typeMapRegistry, typePair, requestedTypes))
-                    .FirstOrDefault(t => t != null);
-            }
-            if(typeMap == null)
-            {
-                return null;
+                typeMap = mapInfo.Profile.CreateClosedGenericTypeMap(mapInfo.GenericMap, _typeMapRegistry, typePair, requestedTypes);
             }
             lock(typeMap)
             {

--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -167,11 +167,13 @@ namespace AutoMapper
             ApplyDerivedMaps(typeMapRegistry, typeMap, typeMap);
         }
 
-        public TypeMap ConfigureConventionTypeMap(TypeMapRegistry typeMapRegistry, TypePair types)
+        public bool IsConventionMap(TypePair types)
         {
-            if (!TypeConfigurations.Any(c => c.IsMatch(types)))
-                return null;
+            return TypeConfigurations.Any(c => c.IsMatch(types));
+        }
 
+        public TypeMap CreateConventionTypeMap(TypeMapRegistry typeMapRegistry, TypePair types)
+        {
             var typeMap = _typeMapFactory.CreateTypeMap(types.SourceType, types.DestinationType, this, MemberList.Destination);
 
             var config = new MappingExpression(typeMap.Types, typeMap.ConfiguredMemberList);
@@ -183,7 +185,7 @@ namespace AutoMapper
             return typeMap;
         }
 
-        public TypeMap ConfigureClosedGenericTypeMap(TypeMapRegistry typeMapRegistry, TypePair closedTypes, TypePair requestedTypes)
+        public TypeMap CreateClosedGenericTypeMap(TypeMapRegistry typeMapRegistry, TypePair closedTypes, TypePair requestedTypes)
         {
             var openMapConfig = _openTypeMapConfigs
                 .SelectMany(tm => tm.ReverseTypeMap == null ? new[] { tm } : new[] { tm, tm.ReverseTypeMap })

--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -455,7 +455,11 @@ namespace AutoMapper.QueryableExtensions
                 var letProperties = letMapInfos.Select(m => m.Property);
                 var letType = ProxyGenerator.GetSimilarType(request.SourceType, letProperties);
                 var typeMapFactory = new TypeMapFactory();
-                var firstTypeMap = typeMapFactory.CreateTypeMap(request.SourceType, letType, typeMap.Profile, MemberList.None);
+                TypeMap firstTypeMap;
+                lock(_configurationProvider)
+                {
+                    firstTypeMap = typeMapFactory.CreateTypeMap(request.SourceType, letType, typeMap.Profile, MemberList.None);
+                }
                 var secondParameter = Parameter(letType, "dto");
 
                 ReplaceSubQueries();

--- a/src/UnitTests/Bug/MultiThreadingIssues.cs
+++ b/src/UnitTests/Bug/MultiThreadingIssues.cs
@@ -279,4 +279,1048 @@ namespace AutoMapper.UnitTests.Bug
         }
     }
 
+    public class ResolveWithCreateMissingTypeMaps
+    {
+        public class SomeDtoA
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoB
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoC
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoD
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoE
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoF
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoG
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoH
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoI
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoJ
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoK
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoL
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoM
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoN
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoO
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoP
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeEntityA
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityB
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityC
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityD
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityE
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityF
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityG
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityH
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityI
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityJ
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityK
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityL
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityM
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityN
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityO
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityP
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        [Fact]
+        public void Should_work()
+        {
+            var c = new MapperConfiguration(cfg => cfg.CreateMissingTypeMaps = true);
+            var types = new[]{
+                new[] { typeof(SomeEntityA), typeof(SomeDtoA) },
+                new[] { typeof(SomeEntityB), typeof(SomeDtoB) },
+                new[] { typeof(SomeEntityC), typeof(SomeDtoC) },
+                new[] { typeof(SomeEntityD), typeof(SomeDtoD) },
+                new[] { typeof(SomeEntityE), typeof(SomeDtoE) },
+                new[] { typeof(SomeEntityF), typeof(SomeDtoF) },
+                new[] { typeof(SomeEntityG), typeof(SomeDtoG) },
+                new[] { typeof(SomeEntityH), typeof(SomeDtoH) },
+                new[] { typeof(SomeEntityI), typeof(SomeDtoI) },
+                new[] { typeof(SomeEntityJ), typeof(SomeDtoJ) },
+                new[] { typeof(SomeEntityK), typeof(SomeDtoK) },
+                new[] { typeof(SomeEntityL), typeof(SomeDtoL) },
+                new[] { typeof(SomeEntityM), typeof(SomeDtoM) },
+                new[] { typeof(SomeEntityN), typeof(SomeDtoN) },
+                new[] { typeof(SomeEntityO), typeof(SomeDtoO) },
+                new[] { typeof(SomeEntityP), typeof(SomeDtoP) },
+            };
+            var tasks = 
+                types
+                .Concat(types.Select(t=>t.Reverse().ToArray()))
+                .ToArray()
+                .Select(s => Task.Factory.StartNew(() => c.ResolveTypeMap(s[0], s[1])))
+                .ToArray();
+            Task.WaitAll(tasks);
+        }
+    }
+
+    public class ResolveWithGenericMap
+    {
+        public class SomeDtoA
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoB
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoC
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoD
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoE
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoF
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoG
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoH
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoI
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoJ
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoK
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoL
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoM
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoN
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoO
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeDtoP
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string PropertyX { get; set; }
+        }
+
+        public class SomeEntityA
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityB
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityC
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityD
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityE
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityF
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityG
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityH
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityI
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityJ
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityK
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityL
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityM
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityN
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityO
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class SomeEntityP
+        {
+            public string Property1 { get; set; }
+            public string Property21 { get; set; }
+            public string Property3 { get; set; }
+            public string Property4 { get; set; }
+            public string Property5 { get; set; }
+            public string Property6 { get; set; }
+            public string Property7 { get; set; }
+            public string Property8 { get; set; }
+            public string Property9 { get; set; }
+            public string Property10 { get; set; }
+            public string Property11 { get; set; }
+        }
+
+        public class Entity<T>
+        {
+            public T Data { get; set; }
+        }
+
+        public class Dto<T>
+        {
+            public T Data { get; set; }
+            public int Value { get; set; }
+        }
+
+        [Fact]
+        public void Should_work()
+        {
+            var sourceType = typeof(Entity<>);
+            var destinationType = typeof(Dto<>);
+            var c = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap(sourceType, destinationType).ForMember("Value", o => o.Ignore());
+            });
+            var types = new[]{
+                new[] { typeof(SomeEntityA), typeof(SomeDtoA) },
+                new[] { typeof(SomeEntityB), typeof(SomeDtoB) },
+                new[] { typeof(SomeEntityC), typeof(SomeDtoC) },
+                new[] { typeof(SomeEntityD), typeof(SomeDtoD) },
+                new[] { typeof(SomeEntityE), typeof(SomeDtoE) },
+                new[] { typeof(SomeEntityF), typeof(SomeDtoF) },
+                new[] { typeof(SomeEntityG), typeof(SomeDtoG) },
+                new[] { typeof(SomeEntityH), typeof(SomeDtoH) },
+                new[] { typeof(SomeEntityI), typeof(SomeDtoI) },
+                new[] { typeof(SomeEntityJ), typeof(SomeDtoJ) },
+                new[] { typeof(SomeEntityK), typeof(SomeDtoK) },
+                new[] { typeof(SomeEntityL), typeof(SomeDtoL) },
+                new[] { typeof(SomeEntityM), typeof(SomeDtoM) },
+                new[] { typeof(SomeEntityN), typeof(SomeDtoN) },
+                new[] { typeof(SomeEntityO), typeof(SomeDtoO) },
+                new[] { typeof(SomeEntityP), typeof(SomeDtoP) },
+            };
+            var tasks =
+                types
+                .Concat(types.Select(t => t.Reverse().ToArray()))
+                .Select(t=>new { SourceType = sourceType.MakeGenericType(t[0]), DestinationType = destinationType.MakeGenericType(t[1]) })
+                .ToArray()
+                .Select(s => Task.Factory.StartNew(() => c.ResolveTypeMap(s.SourceType, s.DestinationType)))
+                .ToArray();
+            Task.WaitAll(tasks);
+        }
+    }
 }


### PR DESCRIPTION
Fixes #2206.
I think there is too much code that tries to be thread safe. The configuration code doesn't need to be thread safe, except when creating type maps on the fly. A global lock should solve it. Of course, there is less concurrency, but only those cases should be affected. I believe it's a good compromise between performance and code complexity.