### PR TITLE
It's always a new map, locking on it doesn't help

### DIFF
--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -337,10 +337,7 @@ namespace AutoMapper
             }
             if(!Configuration.CreateMissingTypeMaps)
             {
-                lock(typeMap)
-                {
-                    typeMap.Seal(this);
-                }
+                typeMap.Seal(this);
             }
             return typeMap;
         }
@@ -361,10 +358,7 @@ namespace AutoMapper
             {
                 typeMap = mapInfo.Profile.CreateClosedGenericTypeMap(mapInfo.GenericMap, _typeMapRegistry, typePair, requestedTypes);
             }
-            lock(typeMap)
-            {
-                typeMap.Seal(this);
-            }
+            typeMap.Seal(this);
             return typeMap;
         }
 


### PR DESCRIPTION
I've tried to do the same as in Resolve, lock on the map, but that is meaningless here because it's always a new map, so nothing gets locked. What can happen here is that two threads create the same map. I'm not sure that's bad. I'd say it isn't. I don't see an easy way out here. A different cache for the on the fly maps would work I believe. But I'd rather wait for someone to report a problem with it.