### PR TITLE
Ignore member paths

### DIFF
--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -225,10 +225,8 @@ namespace AutoMapper.Configuration
             return this;
         }
 
-        private void IgnoreDestinationMember(MemberInfo property, bool ignorePaths = true)
-        {
+        private void IgnoreDestinationMember(MemberInfo property, bool ignorePaths = true) =>
             ForDestinationMember<object>(property, options => options.Ignore(ignorePaths));
-        }
 
         public IMappingExpression<TSource, TDestination> IgnoreAllSourcePropertiesWithAnInaccessibleSetter()
         {
@@ -532,10 +530,8 @@ namespace AutoMapper.Configuration
             return this;
         }
 
-        private IPropertyMapConfiguration GetDestinationMemberConfiguration(MemberInfo destinationMember)
-        {
-            return _memberConfigurations.FirstOrDefault(m => m.DestinationMember == destinationMember);
-        }
+        private IPropertyMapConfiguration GetDestinationMemberConfiguration(MemberInfo destinationMember) =>
+            _memberConfigurations.FirstOrDefault(m => m.DestinationMember == destinationMember);
 
         public void Configure(TypeMap typeMap)
         {

--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -232,7 +232,7 @@ namespace AutoMapper.Configuration
             Ignore(ignorePaths: true);
         }
 
-        public void Ignore(bool ignorePaths)
+        internal void Ignore(bool ignorePaths)
         {
             PropertyMapActions.Add(pm =>
             {

--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -227,13 +227,9 @@ namespace AutoMapper.Configuration
             PropertyMapActions.Add(pm => pm.ExplicitExpansion = true);
         }
 
-        public void Ignore()
-        {
-            Ignore(ignorePaths: true);
-        }
+        public void Ignore() => Ignore(ignorePaths: true);
 
-        internal void Ignore(bool ignorePaths)
-        {
+        internal void Ignore(bool ignorePaths) =>
             PropertyMapActions.Add(pm =>
             {
                 pm.Ignored = true;
@@ -242,7 +238,6 @@ namespace AutoMapper.Configuration
                     pm.TypeMap.IgnorePaths(DestinationMember);
                 }
             });
-        }
 
         public void AllowNull()
         {

--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -229,10 +229,18 @@ namespace AutoMapper.Configuration
 
         public void Ignore()
         {
+            Ignore(ignorePaths: true);
+        }
+
+        public void Ignore(bool ignorePaths)
+        {
             PropertyMapActions.Add(pm =>
             {
                 pm.Ignored = true;
-                pm.TypeMap.IgnorePaths(DestinationMember);
+                if(ignorePaths)
+                {
+                    pm.TypeMap.IgnorePaths(DestinationMember);
+                }
             });
         }
 

--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -229,7 +229,11 @@ namespace AutoMapper.Configuration
 
         public void Ignore()
         {
-            PropertyMapActions.Add(pm => pm.Ignored = true);
+            PropertyMapActions.Add(pm =>
+            {
+                pm.Ignored = true;
+                pm.TypeMap.IgnorePaths(DestinationMember);
+            });
         }
 
         public void AllowNull()

--- a/src/AutoMapper/Configuration/PathConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/PathConfigurationExpression.cs
@@ -39,6 +39,7 @@ namespace AutoMapper.Configuration
             PathMapActions.Add(pm =>
             {
                 pm.SourceExpression = sourceExpression;
+                pm.Ignored = false;
             });
         }
 

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -219,6 +219,14 @@ namespace AutoMapper
             _includedBaseTypes.Add(baseTypes);
         }
 
+        internal void IgnorePaths(MemberInfo destinationMember)
+        {
+            foreach(var pathMap in _pathMaps.Where(pm => pm.MemberPath.First == destinationMember))
+            {
+                pathMap.Ignored = true;
+            }
+        }
+
         public Type GetDerivedTypeFor(Type derivedSourceType)
         {
             if (DestinationTypeOverride != null)

--- a/src/UnitTests/ReverseMapping.cs
+++ b/src/UnitTests/ReverseMapping.cs
@@ -158,6 +158,48 @@ namespace AutoMapper.UnitTests
         }
     }
 
+    public class ReverseDefaultFlatteningWithIgnoreMember : AutoMapperSpecBase
+    {
+        public class Order
+        {
+            public CustomerHolder Customerholder { get; set; }
+        }
+
+        public class CustomerHolder
+        {
+            public Customer Customer { get; set; }
+        }
+
+        public class Customer
+        {
+            public string Name { get; set; }
+            public decimal Total { get; set; }
+        }
+
+        public class OrderDto
+        {
+            public string CustomerholderCustomerName { get; set; }
+            public decimal CustomerholderCustomerTotal { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Order, OrderDto>()
+                .ReverseMap()
+                .ForMember(d=>d.Customerholder, o=>o.Ignore())
+                .ForPath(d=>d.Customerholder.Customer.Total, o=>o.MapFrom(s=>s.CustomerholderCustomerTotal));
+        });
+
+        [Fact]
+        public void Should_unflatten()
+        {
+            var dto = new OrderDto { CustomerholderCustomerName = "George Costanza", CustomerholderCustomerTotal = 74.85m };
+            var model = Mapper.Map<Order>(dto);
+            model.Customerholder.Customer.Name.ShouldBeNull();
+            model.Customerholder.Customer.Total.ShouldBe(74.85m);
+        }
+    }
+
     public class ReverseDefaultFlattening : AutoMapperSpecBase
     {
         public class Order


### PR DESCRIPTION
Fixes #2199.
Kind of convoluted. Maybe it's the implementation, but I'd say it's the requirements.
- ForPath should make the first member pass validation
- ignoring the first member ignores all the paths that start with it
- an explicit ForPath should override the ignored first member

Maybe we should give up a few of these :)