### PR TITLE
Help the CLR find the assemblies it needs

### DIFF
--- a/src/UnitTests/TypeConverters.cs
+++ b/src/UnitTests/TypeConverters.cs
@@ -298,10 +298,19 @@ namespace AutoMapper.UnitTests.CustomMapping
             _result.Value.Type.ShouldBe(5);
         }
     }
-#if NETSTANDARD1_3 || NET45 || NET40
     public class When_specifying_mapping_with_the_BCL_type_converter_class : NonValidatingSpecBase
     {
         protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => { });
+
+#if NET452 || NET40
+        public When_specifying_mapping_with_the_BCL_type_converter_class()
+        {
+            AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
+            {
+                return Assembly.Load(args.Name);
+            };
+        }
+#endif
 
         [TypeConverter(typeof(CustomTypeConverter))]
         public class Source
@@ -362,7 +371,6 @@ namespace AutoMapper.UnitTests.CustomMapping
             destination.Value.ShouldBe(5);
         }
     }
-#endif
     public class When_specifying_a_type_converter_for_a_non_generic_configuration : NonValidatingSpecBase
     {
         private Destination _result;

--- a/src/UnitTests/TypeConverters.cs
+++ b/src/UnitTests/TypeConverters.cs
@@ -305,6 +305,7 @@ namespace AutoMapper.UnitTests.CustomMapping
 #if NET452 || NET40
         public When_specifying_mapping_with_the_BCL_type_converter_class()
         {
+            // only needed for the xUnitRunner without AppDomains
             AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
             {
                 return Assembly.Load(args.Name);

--- a/src/UnitTests/TypeConverters.cs
+++ b/src/UnitTests/TypeConverters.cs
@@ -308,7 +308,7 @@ namespace AutoMapper.UnitTests.CustomMapping
             // only needed for the xUnitRunner without AppDomains
             AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
             {
-                return Assembly.Load(args.Name);
+                return args.Name == typeof(CustomTypeConverter).Assembly.FullName ? typeof(CustomTypeConverter).Assembly : null;
             };
         }
 #endif


### PR DESCRIPTION
All I did with that #if was to skip the test :) The problem is that without AppDomains, the CLR cannot find the test assembly. Load contexts and stuff. It should be OK now.