### PR TITLE
Add PreCondition overload that takes source and ResolutionContext as parameters

### DIFF
--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -222,6 +222,17 @@ namespace AutoMapper.Configuration
             });
         }
 
+        public void PreCondition(Func<TSource, ResolutionContext, bool> condition)
+        {
+            PropertyMapActions.Add(pm =>
+            {
+                Expression<Func<TSource, ResolutionContext, bool>> expr =
+                    (src, ctxt) => condition(src, ctxt);
+
+                pm.PreCondition = expr;
+            });
+        }
+
         public void ExplicitExpansion()
         {
             PropertyMapActions.Add(pm => pm.ExplicitExpansion = true);

--- a/src/AutoMapper/IMemberConfigurationExpression.cs
+++ b/src/AutoMapper/IMemberConfigurationExpression.cs
@@ -185,6 +185,12 @@ namespace AutoMapper
         void PreCondition(Func<ResolutionContext, bool> condition);
 
         /// <summary>
+        /// Conditionally map this member, evaluated before accessing the source value
+        /// </summary>
+        /// <param name="condition">Condition to evaluate using the source object and the current resolution context</param>
+        void PreCondition(Func<TSource, ResolutionContext, bool> condition);
+
+        /// <summary>
         /// Ignore this member for LINQ projections unless explicitly expanded during projection
         /// </summary>
         void ExplicitExpansion();


### PR DESCRIPTION
Added an overload to PreCondition that had both TSource and ResolutionContext as parameters.
Closes #2251.