### PR TITLE
Don't throw ArgumentOutOfRangeException when there is no reverse property to IgnoreMap. issue #2266

### DIFF
--- a/src/AutoMapper/Configuration/Internal/PrimitiveHelper.cs
+++ b/src/AutoMapper/Configuration/Internal/PrimitiveHelper.cs
@@ -17,16 +17,13 @@ namespace AutoMapper.Configuration.Internal
         private static IEnumerable<MemberInfo> GetAllMembers(this Type type) =>
             type.GetTypeInheritance().Concat(type.GetTypeInfo().ImplementedInterfaces).SelectMany(i => i.GetDeclaredMembers());
 
-        private static MemberInfo GetInheritedMember(this Type type, string name) => type.GetAllMembers().FirstOrDefault(mi => mi.Name == name);
+        public static MemberInfo GetInheritedMember(this Type type, string name) => type.GetAllMembers().FirstOrDefault(mi => mi.Name == name);
 
         public static MethodInfo GetInheritedMethod(Type type, string name)
             => type.GetInheritedMember(name) as MethodInfo ?? throw new ArgumentOutOfRangeException(nameof(name), $"Cannot find method {name} of type {type}.");
 
         public static MemberInfo GetFieldOrProperty(Type type, string name) 
             => type.GetInheritedMember(name) ?? throw new ArgumentOutOfRangeException(nameof(name), $"Cannot find member {name} of type {type}.");
-
-        public static bool HasFieldOrProperty(Type type, string name)
-            => type.GetInheritedMember(name) != null;
 
         public static bool IsNullableType(Type type) 
             => type.IsGenericType(typeof(Nullable<>));

--- a/src/AutoMapper/Configuration/Internal/PrimitiveHelper.cs
+++ b/src/AutoMapper/Configuration/Internal/PrimitiveHelper.cs
@@ -25,6 +25,9 @@ namespace AutoMapper.Configuration.Internal
         public static MemberInfo GetFieldOrProperty(Type type, string name) 
             => type.GetInheritedMember(name) ?? throw new ArgumentOutOfRangeException(nameof(name), $"Cannot find member {name} of type {type}.");
 
+        public static bool HasFieldOrProperty(Type type, string name)
+            => type.GetInheritedMember(name) != null;
+
         public static bool IsNullableType(Type type) 
             => type.IsGenericType(typeof(Nullable<>));
 

--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -541,7 +541,14 @@ namespace AutoMapper.Configuration
                 if (attrs.Any(x => x is IgnoreMapAttribute))
                 {
                     IgnoreDestinationMember(destProperty);
-                    _reverseMap?.ForMember(destProperty.Name, opt => opt.Ignore());
+                    try
+                    {
+                        _reverseMap?.ForMember(destProperty.Name, opt => opt.Ignore());
+                    }
+                    catch (ArgumentOutOfRangeException)
+                    {
+                        // Silently ignore it. in cases that there is no reverse property to IgnoreMap. issue #2266
+                    }
                 }
                 if (typeMap.Profile.GlobalIgnores.Contains(destProperty.Name) && GetDestinationMemberConfiguration(destProperty) == null)
                 {

--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using AutoMapper.Internal;
+using AutoMapper.Configuration.Internal;
 
 namespace AutoMapper.Configuration
 {
@@ -541,7 +542,7 @@ namespace AutoMapper.Configuration
                 if (attrs.Any(x => x is IgnoreMapAttribute))
                 {
                     IgnoreDestinationMember(destProperty);
-                    if (typeMap.SourceType.HasFieldOrProperty(destProperty.Name))
+                    if (typeMap.SourceType.GetInheritedMember(destProperty.Name) != null)
                     {
                         _reverseMap?.ForMember(destProperty.Name, opt => opt.Ignore());
                     }

--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -542,9 +542,10 @@ namespace AutoMapper.Configuration
                 if (attrs.Any(x => x is IgnoreMapAttribute))
                 {
                     IgnoreDestinationMember(destProperty);
-                    if (typeMap.SourceType.GetInheritedMember(destProperty.Name) != null)
+                    var sourceProperty = typeMap.SourceType.GetInheritedMember(destProperty.Name);
+                    if (sourceProperty != null)
                     {
-                        _reverseMap?.ForMember(destProperty.Name, opt => opt.Ignore());
+                        _reverseMap?.IgnoreDestinationMember(sourceProperty);
                     }
                 }
                 if (typeMap.Profile.GlobalIgnores.Contains(destProperty.Name) && GetDestinationMemberConfiguration(destProperty) == null)

--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -541,13 +541,9 @@ namespace AutoMapper.Configuration
                 if (attrs.Any(x => x is IgnoreMapAttribute))
                 {
                     IgnoreDestinationMember(destProperty);
-                    try
+                    if (typeMap.SourceType.HasFieldOrProperty(destProperty.Name))
                     {
                         _reverseMap?.ForMember(destProperty.Name, opt => opt.Ignore());
-                    }
-                    catch (ArgumentOutOfRangeException)
-                    {
-                        // Silently ignore it. in cases that there is no reverse property to IgnoreMap. issue #2266
                     }
                 }
                 if (typeMap.Profile.GlobalIgnores.Contains(destProperty.Name) && GetDestinationMemberConfiguration(destProperty) == null)

--- a/src/AutoMapper/Configuration/PrimitiveExtensions.cs
+++ b/src/AutoMapper/Configuration/PrimitiveExtensions.cs
@@ -19,9 +19,6 @@ namespace AutoMapper.Configuration
         public static MemberInfo GetFieldOrProperty(this Type type, string name)
             => PrimitiveHelper.GetFieldOrProperty(type, name);
 
-        public static bool HasFieldOrProperty(this Type type, string name)
-            => PrimitiveHelper.HasFieldOrProperty(type, name);
-
         public static bool IsNullableType(this Type type)
             => PrimitiveHelper.IsNullableType(type);
 

--- a/src/AutoMapper/Configuration/PrimitiveExtensions.cs
+++ b/src/AutoMapper/Configuration/PrimitiveExtensions.cs
@@ -19,6 +19,9 @@ namespace AutoMapper.Configuration
         public static MemberInfo GetFieldOrProperty(this Type type, string name)
             => PrimitiveHelper.GetFieldOrProperty(type, name);
 
+        public static bool HasFieldOrProperty(this Type type, string name)
+            => PrimitiveHelper.HasFieldOrProperty(type, name);
+
         public static bool IsNullableType(this Type type)
             => PrimitiveHelper.IsNullableType(type);
 

--- a/src/UnitTests/IgnoreAllTests.cs
+++ b/src/UnitTests/IgnoreAllTests.cs
@@ -200,5 +200,22 @@ namespace AutoMapper.UnitTests
             destination.ShouldNotBeMapped.ShouldBe(null);
 
         }
+
+        public class Source2
+        {
+        }
+
+        public class Destination2
+        {
+            [IgnoreMap]
+            public string ShouldNotThrowExceptionOnReverseMapping { get; set; }
+        }
+
+        [Fact]
+        public void Sould_not_throw_exception_when_reverse_property_does_not_exist()
+        {
+            typeof(ArgumentOutOfRangeException).ShouldNotBeThrownBy(() => new MapperConfiguration(cfg => cfg.CreateMap<Source2, Destination2>()
+                 .ReverseMap()));
+        }
     }
 }


### PR DESCRIPTION
I want to Ignore a property mapping even if currently there is no equivalent property in the source type to ignore. I want to Ignore it in destination type permanently, now and in the future. so I put an `IgnoreMap` attribute on the destination property