### PR TITLE
Add ForPath conditions

### DIFF
--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -173,13 +173,13 @@ namespace AutoMapper.Configuration
             => new MappingExpression<TDestination, TSource>(MemberList.None, DestinationType, SourceType);
 
         public IMappingExpression<TSource, TDestination> ForPath<TMember>(Expression<Func<TDestination, TMember>> destinationMember,
-            Action<IPathConfigurationExpression<TSource, TDestination>> memberOptions)
+            Action<IPathConfigurationExpression<TSource, TDestination, TMember>> memberOptions)
         {
             if(!destinationMember.IsMemberPath())
             {
                 throw new ArgumentOutOfRangeException(nameof(destinationMember), "Only member accesses are allowed.");
             }
-            var expression = new PathConfigurationExpression<TSource, TDestination>(destinationMember);
+            var expression = new PathConfigurationExpression<TSource, TDestination, TMember>(destinationMember);
             var firstMember = expression.MemberPath.First;
             var firstMemberConfig = GetDestinationMemberConfiguration(firstMember);
             if(firstMemberConfig == null)

--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -289,7 +289,7 @@ namespace AutoMapper.Configuration
             var newSource = Parameter(DestinationMember.DeclaringType, "source");
             var newSourceProperty = MakeMemberAccess(newSource, _destinationMember);
             var newSourceExpression = Lambda(newSourceProperty, newSource);
-            return PathConfigurationExpression<TDestination, TSource>.Create(_sourceMember, newSourceExpression);
+            return PathConfigurationExpression<TDestination, TSource, object>.Create(_sourceMember, newSourceExpression);
         }
     }
 }

--- a/src/AutoMapper/Configuration/PathConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/PathConfigurationExpression.cs
@@ -7,7 +7,7 @@ using AutoMapper.Internal;
 
 namespace AutoMapper.Configuration
 {
-    public class PathConfigurationExpression<TSource, TDestination> : IPathConfigurationExpression<TSource, TDestination>, IPropertyMapConfiguration
+    public class PathConfigurationExpression<TSource, TDestination, TMember> : IPathConfigurationExpression<TSource, TDestination, TMember>, IPropertyMapConfiguration
     {
         private readonly LambdaExpression _destinationExpression;
         private LambdaExpression _sourceExpression;
@@ -64,7 +64,7 @@ namespace AutoMapper.Configuration
             {
                 return null;
             }
-            var reversed = new PathConfigurationExpression<TSource, TDestination>(destination);
+            var reversed = new PathConfigurationExpression<TSource, TDestination, object>(destination);
             if(reversed.MemberPath.Length == 1)
             {
                 var reversedMemberExpression = new MemberConfigurationExpression<TSource, TDestination, object>(reversed.DestinationMember, typeof(TSource));
@@ -78,6 +78,17 @@ namespace AutoMapper.Configuration
         public IPropertyMapConfiguration Reverse()
         {
             return Create(_sourceExpression, _destinationExpression);
+        }
+
+        public void Condition(Func<ConditionParameters<TSource, TDestination, TMember>, bool> condition)
+        {
+            PathMapActions.Add(pm =>
+            {
+                Expression<Func<TSource, TDestination, TMember, TMember, ResolutionContext, bool>> expr =
+                    (src, dest, srcMember, destMember, ctxt) => 
+                        condition(new ConditionParameters<TSource, TDestination, TMember>(src, dest, srcMember, destMember, ctxt));
+                pm.Condition = expr;
+            });
         }
     }
 }

--- a/src/AutoMapper/IMappingExpression.cs
+++ b/src/AutoMapper/IMappingExpression.cs
@@ -197,7 +197,7 @@ namespace AutoMapper
         /// <param name="memberOptions">Callback for member options</param>
         /// <returns>Itself</returns>
         IMappingExpression<TSource, TDestination> ForPath<TMember>(Expression<Func<TDestination, TMember>> destinationMember,
-            Action<IPathConfigurationExpression<TSource, TDestination>> memberOptions);
+            Action<IPathConfigurationExpression<TSource, TDestination, TMember>> memberOptions);
 
         /// <summary>
         /// Preserve object identity. Useful for circular references.

--- a/src/AutoMapper/IPathConfigurationExpression.cs
+++ b/src/AutoMapper/IPathConfigurationExpression.cs
@@ -8,7 +8,8 @@ namespace AutoMapper
     /// </summary>
     /// <typeparam name="TSource">Source type for this member</typeparam>
     /// <typeparam name="TDestination">Destination type for this map</typeparam>
-    public interface IPathConfigurationExpression<TSource, out TDestination>
+    /// <typeparam name="TMember">Type for this member</typeparam>
+    public interface IPathConfigurationExpression<TSource, TDestination, TMember>
     {
         /// <summary>
         /// Specify the source member to map from. Can only reference a member on the <typeparamref name="TSource"/> type
@@ -23,5 +24,24 @@ namespace AutoMapper
         /// Ignore this member for configuration validation and skip during mapping
         /// </summary>
         void Ignore();
+
+        void Condition(Func<ConditionParameters<TSource, TDestination, TMember>, bool> condition);
+    }
+
+    public struct ConditionParameters<TSource, TDestination, TMember>
+    {
+        public ConditionParameters(TSource source, TDestination destination, TMember sourceMember, TMember destinationMember, ResolutionContext context)
+        {
+            Source = source;
+            Destination = destination;
+            SourceMember = sourceMember;
+            DestinationMember = destinationMember;
+            Context = context;
+        }
+        public TSource Source { get; }
+        public TDestination Destination { get; }
+        public TMember SourceMember { get; }
+        public TMember DestinationMember { get; }
+        public ResolutionContext Context { get; }
     }
 }

--- a/src/AutoMapper/PathMap.cs
+++ b/src/AutoMapper/PathMap.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 
 namespace AutoMapper
 {
+    using System;
     using Internal;
 
     [DebuggerDisplay("{DestinationExpression}")]
@@ -22,5 +23,6 @@ namespace AutoMapper
         public MemberPath MemberPath { get; }
         public MemberInfo DestinationMember => MemberPath.Last;
         public bool Ignored { get; set; }
+        public LambdaExpression Condition { get; set; }
     }
 }

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -20,6 +20,7 @@ namespace AutoMapper
 
         public PropertyMap(PathMap pathMap)
         {
+            Condition = pathMap.Condition;
             DestinationProperty = pathMap.DestinationMember;
             CustomExpression = pathMap.SourceExpression;
             TypeMap = pathMap.TypeMap;

--- a/src/UnitTests/ForPath.cs
+++ b/src/UnitTests/ForPath.cs
@@ -323,4 +323,61 @@ namespace AutoMapper.UnitTests
             model.CustomerHolder.Customer.Total.ShouldBe(74.85m);
         }
     }
+
+    public class ForPathWithConditions : AutoMapperSpecBase
+    {
+        public class Order
+        {
+            public CustomerHolder CustomerHolder { get; set; }
+        }
+
+        public class CustomerHolder
+        {
+            public Customer Customer { get; set; }
+        }
+
+        public class Customer
+        {
+            public string Name { get; set; }
+            public decimal Total { get; set; }
+            public int Value { get; set; }
+        }
+
+        public class OrderDto
+        {
+            public string CustomerName { get; set; }
+            public decimal Total { get; set; }
+            public int Value { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<OrderDto, Order>()
+                .ForPath(o => o.CustomerHolder.Customer.Name, o =>
+                {
+                    o.Condition(c => !c.SourceMember.StartsWith("George"));
+                    o.MapFrom(s => s.CustomerName);
+                })
+                .ForPath(o => o.CustomerHolder.Customer.Total, o =>
+                {
+                    o.Condition(c => c.Source.Total < 50);
+                    o.MapFrom(s => s.Total);
+                })
+                .ForPath(o => o.CustomerHolder.Customer.Value, o =>
+                {
+                    o.Condition(c => c.Source.Value > 0);
+                    o.MapFrom(s => s.Value);
+                });
+        });
+
+        [Fact]
+        public void Should_unflatten()
+        {
+            var dto = new OrderDto { CustomerName = "George Costanza", Total = 74.85m, Value = 100 };
+            var model = Mapper.Map<Order>(dto);
+            model.CustomerHolder.Customer.Name.ShouldBeNull();
+            model.CustomerHolder.Customer.Total.ShouldBe(0);
+            model.CustomerHolder.Customer.Value.ShouldBe(100);
+        }
+    }
 }

--- a/src/UnitTests/ForPath.cs
+++ b/src/UnitTests/ForPath.cs
@@ -365,7 +365,7 @@ namespace AutoMapper.UnitTests
                 })
                 .ForPath(o => o.CustomerHolder.Customer.Value, o =>
                 {
-                    o.Condition(c => c.Source.Value > 0);
+                    o.Condition(c => c.Destination.CustomerHolder.Customer.Value == 0);
                     o.MapFrom(s => s.Value);
                 });
         });


### PR DESCRIPTION
Fixes #2298. It's different, but the way I see it, the regular conditions should work the same way too :) If we had [this](https://github.com/dotnet/csharplang/issues/258) we could have it both ways. I could add a Deconstruct method now, but the usage syntax is clumsy.