### PR TITLE
Inline config and auto-auto-mapping

### DIFF
--- a/docs/Inline-Mapping.md
+++ b/docs/Inline-Mapping.md
@@ -1,0 +1,66 @@
+# Inline Mapping
+
+AutoMapper creates type maps on the fly (new in 6.2.0). When you call `Mapper.Map` for the first time, AutoMapper will create the type map configuration and compile the mapping plan. Subsequent mapping calls will use the compiled map.
+
+## Inline configuration
+
+To configure an inline map, use the mapping options:
+
+```c#
+var source = new Source();
+
+var dest = Mapper.Map<Source, Dest>(source, opt => opt.ConfigureMap().ForMember(dest => dest.Value, m => m.MapFrom(src => src.Value + 10)));
+```
+
+You can use local functions to make the configuration a little easier to read:
+
+```c#
+var source = new Source();
+
+void ConfigureMap(IMappingOperationOptions<Source, Dest> opt) {
+    opt.ConfigureMap()
+       .ForMember(dest => dest.Value, m => m.MapFrom(src => src.Value + 10))
+};
+
+var dest = Mapper.Map<Source, Dest>(source, ConfigureMap);
+```
+
+You can use closures in this inline map as well to capture and use runtime values in your configuration:
+
+```c#
+int valueToAdd = 10;
+var source = new Source();
+
+void ConfigureMap(IMappingOperationOptions<Source, Dest> opt) {
+    opt.ConfigureMap()
+       .ForMember(dest => dest.Value, m => m.MapFrom(src => src.Value + valueToAdd))
+};
+
+var dest = Mapper.Map<Source, Dest>(source, ConfigureMap);
+```
+
+## Inline validation
+
+The first time the map is used, AutoMapper validates the map using the default validation configuration (destination members must all be mapped). Subsequent map calls skip mapping validation. This ensures you can safely map your objects.
+
+You can configure the member list used to validate, to validate the source, destination, or no members to validate per map:
+
+```c#
+var source = new Source();
+
+var dest = Mapper.Map<Source, Dest>(source, opt => opt.ConfigureMap(MemberList.None);
+```
+
+You can also turn off inline map validation altogether (not recommended unless you're explicitly testing all of your maps):
+
+```c#
+Mapper.Initialize(cfg => cfg.ValidateInlineMaps = false);
+```
+
+## Disabling inline maps
+
+To turn off inline mapping:
+
+```c#
+Mapper.Initialize(cfg => cfg.CreateMissingTypeMaps = false);
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,8 @@ domain and application layer.
 
 AutoMapper supports the following platforms:
 
-* .NET 4.5
+* .NET 4.0
+* .NET 4.5.2+
 * .NET Platform Standard 1.1 & 1.3
 
 New to AutoMapper? Check out the :doc:`Getting-started` page first.
@@ -39,6 +40,7 @@ New to AutoMapper? Check out the :doc:`Getting-started` page first.
    Reverse-Mapping-and-Unflattening
    Projection
    Configuration-validation
+   Inline-Mapping
    Lists-and-arrays
    Nested-mappings
    Custom-type-converters

--- a/src/AutoMapper/Configuration/IProfileConfiguration.cs
+++ b/src/AutoMapper/Configuration/IProfileConfiguration.cs
@@ -18,6 +18,7 @@ namespace AutoMapper.Configuration
         bool? AllowNullCollections { get; }
         bool? EnableNullPropagationForQueryMapping { get; }
         bool? CreateMissingTypeMaps { get; }
+        bool? ValidateInlineMaps { get; }
         IEnumerable<Action<TypeMap, IMappingExpression>> AllTypeMapActions { get; }
         IEnumerable<Action<PropertyMap, IMemberConfigurationExpression>> AllPropertyMapActions { get; }
 

--- a/src/AutoMapper/ConfigurationValidator.cs
+++ b/src/AutoMapper/ConfigurationValidator.cs
@@ -73,6 +73,7 @@ namespace AutoMapper
                 var context = new ValidationContext(types, propertyMap, typeMap);
                 _config.Validate(context);
                 CheckPropertyMaps(typeMapsChecked, typeMap);
+                typeMap.IsValid = true;
             }
             else
             {

--- a/src/AutoMapper/ConfigurationValidator.cs
+++ b/src/AutoMapper/ConfigurationValidator.cs
@@ -80,6 +80,10 @@ namespace AutoMapper
                 var mapperToUse = _config.FindMapper(types);
                 if (mapperToUse == null)
                 {
+                    // Convention maps with no match get mapped at runtime yolo
+                    if (propertyMap.TypeMap.IsConventionMap)
+                        return;
+
                     throw new AutoMapperConfigurationException(propertyMap.TypeMap.Types) { PropertyMap = propertyMap };
                 }
                 var context = new ValidationContext(types, propertyMap, mapperToUse);

--- a/src/AutoMapper/ConfigurationValidator.cs
+++ b/src/AutoMapper/ConfigurationValidator.cs
@@ -80,8 +80,8 @@ namespace AutoMapper
                 var mapperToUse = _config.FindMapper(types);
                 if (mapperToUse == null)
                 {
-                    // Convention maps with no match get mapped at runtime yolo
-                    if (propertyMap.TypeMap.IsConventionMap)
+                    // Maps with no match get mapped at runtime yolo
+                    if (propertyMap.TypeMap.Profile.CreateMissingTypeMaps)
                         return;
 
                     throw new AutoMapperConfigurationException(propertyMap.TypeMap.Types) { PropertyMap = propertyMap };

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -211,7 +211,7 @@ namespace AutoMapper.Execution
             }
             if (_typeMap.IsConventionMap)
             {
-                //actions.Insert(0, Call(Context, ((MethodCallExpression) ValidateMap.Body).Method, Constant(_typeMap)));
+                actions.Insert(0, Call(Context, ((MethodCallExpression)ValidateMap.Body).Method, Constant(_typeMap)));
             }
             actions.AddRange(
                 _typeMap.AfterMapActions.Select(

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -211,7 +211,7 @@ namespace AutoMapper.Execution
             }
             if (_typeMap.IsConventionMap)
             {
-                actions.Insert(0, Call(Context, ((MethodCallExpression) ValidateMap.Body).Method, Constant(_typeMap)));
+                //actions.Insert(0, Call(Context, ((MethodCallExpression) ValidateMap.Body).Method, Constant(_typeMap)));
             }
             actions.AddRange(
                 _typeMap.AfterMapActions.Select(

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -19,6 +19,9 @@ namespace AutoMapper.Execution
         private static readonly Expression<Action<ResolutionContext>> IncTypeDepthInfo =
             ctxt => ctxt.IncrementTypeDepth(default(TypePair));
 
+        private static readonly Expression<Action<ResolutionContext>> ValidateMap =
+            ctxt => ctxt.ValidateMap(default(TypeMap));
+
         private static readonly Expression<Action<ResolutionContext>> DecTypeDepthInfo =
             ctxt => ctxt.DecrementTypeDepth(default(TypePair));
 
@@ -202,8 +205,14 @@ namespace AutoMapper.Execution
                 actions.Insert(0, beforeMapAction.ReplaceParameters(Source, _destination, Context));
             actions.Insert(0, destinationFunc);
             if (_typeMap.MaxDepth > 0)
+            {
                 actions.Insert(0,
                     Call(Context, ((MethodCallExpression) IncTypeDepthInfo.Body).Method, Constant(_typeMap.Types)));
+            }
+            if (_typeMap.IsConventionMap)
+            {
+                actions.Insert(0, Call(Context, ((MethodCallExpression) ValidateMap.Body).Method, Constant(_typeMap)));
+            }
             actions.AddRange(
                 _typeMap.AfterMapActions.Select(
                     afterMapAction => afterMapAction.ReplaceParameters(Source, _destination, Context)));

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -209,7 +209,7 @@ namespace AutoMapper.Execution
                 actions.Insert(0,
                     Call(Context, ((MethodCallExpression) IncTypeDepthInfo.Body).Method, Constant(_typeMap.Types)));
             }
-            if (_typeMap.IsConventionMap)
+            if (_typeMap.IsConventionMap && _typeMap.Profile.ValidateInlineMaps)
             {
                 actions.Insert(0, Call(Context, ((MethodCallExpression)ValidateMap.Body).Method, Constant(_typeMap)));
             }

--- a/src/AutoMapper/IConfigurationProvider.cs
+++ b/src/AutoMapper/IConfigurationProvider.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using AutoMapper.Configuration;
 using AutoMapper.QueryableExtensions;
 
 namespace AutoMapper
@@ -118,6 +119,7 @@ namespace AutoMapper
         IMapper CreateMapper(Func<Type, object> serviceCtor);
 
         Func<TSource, TDestination, ResolutionContext, TDestination> GetMapperFunc<TSource, TDestination>(TypePair types);
+        Func<TSource, TDestination, ResolutionContext, TDestination> GetMapperFunc<TSource, TDestination>(MapRequest mapRequest);
 
         /// <summary>
         /// Compile all underlying mapping expressions to cached delegates.

--- a/src/AutoMapper/IMappingOperationOptions.cs
+++ b/src/AutoMapper/IMappingOperationOptions.cs
@@ -36,7 +36,7 @@ namespace AutoMapper
         void AfterMap(Action<object, object> afterFunction);
     }
 
-    public interface IMappingOperationOptions<out TSource, out TDestination> : IMappingOperationOptions
+    public interface IMappingOperationOptions<TSource, TDestination> : IMappingOperationOptions
     {
         /// <summary>
         /// Execute a custom function to the source and/or destination types before member mapping
@@ -49,5 +49,8 @@ namespace AutoMapper
         /// </summary>
         /// <param name="afterFunction">Callback for the source/destination types</param>
         void AfterMap(Action<TSource, TDestination> afterFunction);
+
+        IMappingExpression<TSource, TDestination> ConfigureMap();
+        IMappingExpression<TSource, TDestination> ConfigureMap(MemberList memberList);
     }
 }

--- a/src/AutoMapper/IMappingOperationOptions.cs
+++ b/src/AutoMapper/IMappingOperationOptions.cs
@@ -50,7 +50,17 @@ namespace AutoMapper
         /// <param name="afterFunction">Callback for the source/destination types</param>
         void AfterMap(Action<TSource, TDestination> afterFunction);
 
+        /// <summary>
+        /// Configure inline map
+        /// </summary>
+        /// <returns>Mapping configuration expression</returns>
         IMappingExpression<TSource, TDestination> ConfigureMap();
+
+        /// <summary>
+        /// Configure inline map with member list to validate
+        /// </summary>
+        /// <param name="memberList">Member list to validate for the inline map</param>
+        /// <returns>Mapping configuration expression</returns>
         IMappingExpression<TSource, TDestination> ConfigureMap(MemberList memberList);
     }
 }

--- a/src/AutoMapper/IProfileExpression.cs
+++ b/src/AutoMapper/IProfileExpression.cs
@@ -159,5 +159,10 @@ namespace AutoMapper
         /// Value transformers. Modify the list directly or use <see cref="ValueTransformerConfigurationExtensions.Add{TValue}"/>
         /// </summary>
         IList<ValueTransformerConfiguration> ValueTransformers { get; }
+
+        /// <summary>
+        /// Validate maps created dynamically/inline on the first map. Defaults to true.
+        /// </summary>
+        bool? ValidateInlineMaps { get; set; }
     }
 }

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -228,13 +228,17 @@ namespace AutoMapper
         {
             var types = TypePair.Create(source, typeof(TSource), typeof(TDestination));
 
-            var func = _configurationProvider.GetMapperFunc<TSource, TDestination>(types);
-
-            var destination = default(TDestination);
+            var key = new TypePair(typeof(TSource), typeof(TDestination));
 
             var typedOptions = new MappingOperationOptions<TSource, TDestination>(_serviceCtor);
 
             opts(typedOptions);
+
+            var mapRequest = new MapRequest(key, types, typedOptions.InlineConfiguration);
+
+            var func = _configurationProvider.GetMapperFunc<TSource, TDestination>(mapRequest);
+
+            var destination = default(TDestination);
 
             typedOptions.BeforeMapAction(source, destination);
 
@@ -259,12 +263,15 @@ namespace AutoMapper
         TDestination IMapper.Map<TSource, TDestination>(TSource source, TDestination destination, Action<IMappingOperationOptions<TSource, TDestination>> opts)
         {
             var types = TypePair.Create(source, destination, typeof(TSource), typeof(TDestination));
-
-            var func = _configurationProvider.GetMapperFunc<TSource, TDestination>(types);
+            var key = new TypePair(typeof(TSource), typeof(TDestination));
 
             var typedOptions = new MappingOperationOptions<TSource, TDestination>(_serviceCtor);
 
             opts(typedOptions);
+
+            var mapRequest = new MapRequest(key, types, typedOptions.InlineConfiguration);
+
+            var func = _configurationProvider.GetMapperFunc<TSource, TDestination>(mapRequest);
 
             typedOptions.BeforeMapAction(source, destination);
 
@@ -290,11 +297,11 @@ namespace AutoMapper
         {
             var types = TypePair.Create(source, sourceType, destinationType);
 
-            var func = _configurationProvider.GetUntypedMapperFunc(new MapRequest(new TypePair(sourceType, destinationType), types));
-
             var options = new ObjectMappingOperationOptions(_serviceCtor);
 
             opts(options);
+
+            var func = _configurationProvider.GetUntypedMapperFunc(new MapRequest(new TypePair(sourceType, destinationType), types, options.InlineConfiguration));
 
             options.BeforeMapAction(source, null);
 
@@ -321,11 +328,11 @@ namespace AutoMapper
         {
             var types = TypePair.Create(source, destination, sourceType, destinationType);
 
-            var func = _configurationProvider.GetUntypedMapperFunc(new MapRequest(new TypePair(sourceType, destinationType), types));
-
             var options = new ObjectMappingOperationOptions(_serviceCtor);
 
             opts(options);
+
+            var func = _configurationProvider.GetUntypedMapperFunc(new MapRequest(new TypePair(sourceType, destinationType), types, options.InlineConfiguration));
 
             options.BeforeMapAction(source, destination);
 

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -192,7 +192,7 @@ namespace AutoMapper
             // if it's a dynamically created type map, we need to seal it outside GetTypeMap to handle recursion
             if (typeMap != null && typeMap.MapExpression == null && _typeMapRegistry.GetTypeMap(typePair) == null)
             {
-                lock(typeMap)
+                lock (typeMap)
                 {
                     typeMap.Seal(this);
                 }

--- a/src/AutoMapper/MappingOperationOptions.cs
+++ b/src/AutoMapper/MappingOperationOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using AutoMapper.Configuration;
 
 namespace AutoMapper
 {
@@ -20,10 +21,23 @@ namespace AutoMapper
         public IDictionary<string, object> Items => _items ?? (_items = new StringDictionary());
         public Action<TSource, TDestination> BeforeMapAction { get; protected set; }
         public Action<TSource, TDestination> AfterMapAction { get; protected set; }
+        public ITypeMapConfiguration InlineConfiguration { get; protected set; } = new MappingExpression<TSource,TDestination>(MemberList.Destination);
 
         public void BeforeMap(Action<TSource, TDestination> beforeFunction) => BeforeMapAction = beforeFunction;
 
         public void AfterMap(Action<TSource, TDestination> afterFunction) => AfterMapAction = afterFunction;
+
+        public IMappingExpression<TSource, TDestination> ConfigureMap()
+            => ConfigureMap(MemberList.Destination);
+
+        public IMappingExpression<TSource, TDestination> ConfigureMap(MemberList memberList)
+        {
+            var typeMapConfiguration = new MappingExpression<TSource, TDestination>(memberList);
+
+            InlineConfiguration = typeMapConfiguration;
+
+            return typeMapConfiguration;
+        }
 
         public T CreateInstance<T>()
         {

--- a/src/AutoMapper/Profile.cs
+++ b/src/AutoMapper/Profile.cs
@@ -185,10 +185,6 @@ namespace AutoMapper
                             m.GetParameters().Length == 1));
         }
 
-        public void ApplyTransform<TValue>(Expression<Func<TValue, TValue>> transformer)
-        {
-        }
-
         private IMappingExpression<TSource, TDestination> CreateMappingExpression<TSource, TDestination>(
             MemberList memberList)
         {

--- a/src/AutoMapper/Profile.cs
+++ b/src/AutoMapper/Profile.cs
@@ -53,6 +53,7 @@ namespace AutoMapper
         public IMemberConfiguration DefaultMemberConfig => _memberConfigurations.First();
         public bool? ConstructorMappingEnabled { get; private set; }
         public bool? CreateMissingTypeMaps { get; set; }
+        public bool? ValidateInlineMaps { get; set; }
 
         IEnumerable<Action<PropertyMap, IMemberConfigurationExpression>> IProfileConfiguration.AllPropertyMapActions
             => _allPropertyMapActions;

--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -42,9 +42,6 @@ namespace AutoMapper
 
             TypeConfigurations = profile.TypeConfigurations
                 .Concat(configuration?.TypeConfigurations ?? Enumerable.Empty<IConditionalObjectMapper>())
-                .Concat(CreateMissingTypeMaps
-                    ? Enumerable.Repeat(new ConditionalObjectMapper { Conventions = { tp => !ExcludedTypes.Contains(tp.SourceType) && !ExcludedTypes.Contains(tp.DestinationType)} }, 1)
-                    : Enumerable.Empty<IConditionalObjectMapper>())
                 .ToArray();
 
             ValueTransformers = profile.ValueTransformers.Concat(configuration?.ValueTransformers ?? Enumerable.Empty<ValueTransformerConfiguration>()).ToArray();

--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -38,7 +38,7 @@ namespace AutoMapper
             ConstructorMappingEnabled = profile.ConstructorMappingEnabled ?? configuration?.ConstructorMappingEnabled ?? true;
             ShouldMapField = profile.ShouldMapField ?? configuration?.ShouldMapField ?? (p => p.IsPublic());
             ShouldMapProperty = profile.ShouldMapProperty ?? configuration?.ShouldMapProperty ?? (p => p.IsPublic());
-            CreateMissingTypeMaps = profile.CreateMissingTypeMaps ?? configuration?.CreateMissingTypeMaps ?? false;
+            CreateMissingTypeMaps = profile.CreateMissingTypeMaps ?? configuration?.CreateMissingTypeMaps ?? true;
 
             TypeConfigurations = profile.TypeConfigurations
                 .Concat(configuration?.TypeConfigurations ?? Enumerable.Empty<IConditionalObjectMapper>())
@@ -177,6 +177,8 @@ namespace AutoMapper
         public TypeMap CreateConventionTypeMap(TypeMapRegistry typeMapRegistry, TypePair types)
         {
             var typeMap = _typeMapFactory.CreateTypeMap(types.SourceType, types.DestinationType, this, MemberList.Destination);
+
+            typeMap.IsConventionMap = true;
 
             var config = new MappingExpression(typeMap.Types, typeMap.ConfiguredMemberList);
 

--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -186,6 +186,19 @@ namespace AutoMapper
             return typeMap;
         }
 
+        public TypeMap CreateInlineMap(TypeMapRegistry typeMapRegistry, ITypeMapConfiguration inlineConfig)
+        {
+            var typeMap = _typeMapFactory.CreateTypeMap(inlineConfig.SourceType, inlineConfig.DestinationType, this, inlineConfig.MemberList);
+
+            typeMap.IsConventionMap = true;
+
+            inlineConfig.Configure(typeMap);
+
+            Configure(typeMapRegistry, typeMap);
+
+            return typeMap;
+        }
+
         public TypeMap CreateClosedGenericTypeMap(ITypeMapConfiguration openMapConfig, TypeMapRegistry typeMapRegistry, TypePair closedTypes)
         {
             var closedMap = _typeMapFactory.CreateTypeMap(closedTypes.SourceType, closedTypes.DestinationType, this, openMapConfig.MemberList);

--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -39,6 +39,7 @@ namespace AutoMapper
             ShouldMapField = profile.ShouldMapField ?? configuration?.ShouldMapField ?? (p => p.IsPublic());
             ShouldMapProperty = profile.ShouldMapProperty ?? configuration?.ShouldMapProperty ?? (p => p.IsPublic());
             CreateMissingTypeMaps = profile.CreateMissingTypeMaps ?? configuration?.CreateMissingTypeMaps ?? true;
+            ValidateInlineMaps = profile.ValidateInlineMaps ?? configuration?.ValidateInlineMaps ?? true;
 
             TypeConfigurations = profile.TypeConfigurations
                 .Concat(configuration?.TypeConfigurations ?? Enumerable.Empty<IConditionalObjectMapper>())
@@ -76,10 +77,12 @@ namespace AutoMapper
             _openTypeMapConfigs = profile.OpenTypeMapConfigs.ToArray();
         }
 
+
         public bool AllowNullCollections { get; }
         public bool AllowNullDestinationValues { get; }
         public bool ConstructorMappingEnabled { get; }
         public bool CreateMissingTypeMaps { get; }
+        public bool ValidateInlineMaps { get; }
         public bool EnableNullPropagationForQueryMapping { get; }
         public string Name { get; }
         public Func<FieldInfo, bool> ShouldMapField { get; }

--- a/src/AutoMapper/ResolutionContext.cs
+++ b/src/AutoMapper/ResolutionContext.cs
@@ -115,6 +115,9 @@ namespace AutoMapper
 
         internal object Map(object source, object destination, Type sourceType, Type destinationType) 
             => Mapper.Map(source, destination, sourceType, destinationType, this);
+
+        internal void ValidateMap(TypeMap typeMap)
+            => ConfigurationProvider.AssertConfigurationIsValid(typeMap);
     }
 
     public struct ContextCacheKey : IEquatable<ContextCacheKey>

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -98,6 +98,8 @@ namespace AutoMapper
 
         public PropertyMap[] GetPropertyMaps() => _orderedPropertyMaps ?? _propertyMaps.Concat(_inheritedMaps).ToArray();
         public IEnumerable<PathMap> PathMaps => _pathMaps;
+        public bool IsConventionMap { get; set; }
+        public bool? IsValid { get; set; }
 
         public bool ConstructorParameterMatches(string destinationPropertyName) =>
             ConstructorMap?.CtorParams.Any(c => !c.DefaultValue && string.Equals(c.Parameter.Name, destinationPropertyName, StringComparison.OrdinalIgnoreCase)) == true;
@@ -352,7 +354,8 @@ namespace AutoMapper
                                              && CustomProjection == null
                                              && TypeConverterType == null
                                              && DestinationTypeOverride == null
-                                             && ConfiguredMemberList != MemberList.None;
+                                             && ConfiguredMemberList != MemberList.None
+                                             && !(IsValid ?? false);
 
         private void ApplyInheritedTypeMap(TypeMap inheritedTypeMap)
         {

--- a/src/AutoMapper/TypePair.cs
+++ b/src/AutoMapper/TypePair.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
+using AutoMapper.Configuration;
 
 namespace AutoMapper
 {
@@ -11,11 +12,18 @@ namespace AutoMapper
     {
         public TypePair RequestedTypes { get; }
         public TypePair RuntimeTypes { get; }
+        public ITypeMapConfiguration InlineConfig { get; }
 
-        public MapRequest(TypePair requestedTypes, TypePair runtimeTypes)
+        public MapRequest(TypePair requestedTypes, TypePair runtimeTypes) 
+            : this(requestedTypes, runtimeTypes, null)
+        {
+        }
+
+        public MapRequest(TypePair requestedTypes, TypePair runtimeTypes, ITypeMapConfiguration inlineConfig)
         {
             RequestedTypes = requestedTypes;
             RuntimeTypes = runtimeTypes;
+            InlineConfig = inlineConfig;
         }
 
         public bool Equals(MapRequest other) => RequestedTypes.Equals(other.RequestedTypes) && RuntimeTypes.Equals(other.RuntimeTypes);

--- a/src/UnitTests/AutoMapperSpecBase.cs
+++ b/src/UnitTests/AutoMapperSpecBase.cs
@@ -27,13 +27,13 @@ namespace AutoMapper.UnitTests
 
     public abstract class SpecBaseBase
     {
-        public virtual void MainSetup()
+        protected virtual void MainSetup()
         {
             Establish_context();
             Because_of();
         }
 
-        public virtual void MainTeardown()
+        protected virtual void MainTeardown()
         {
             Cleanup();
         }
@@ -54,12 +54,13 @@ namespace AutoMapper.UnitTests
     {
         protected SpecBase()
         {
-            MainSetup();
+            Establish_context();
+            Because_of();
         }
 
         public void Dispose()
         {
-            MainTeardown();
+            Cleanup();
         }
     }
 

--- a/src/UnitTests/Bug/ExpressionMapping.cs
+++ b/src/UnitTests/Bug/ExpressionMapping.cs
@@ -136,7 +136,7 @@ namespace AutoMapper.UnitTests.Bug
             cfg.EnableNullPropagationForQueryMapping = true;
         });
 
-        public override void MainTeardown()
+        protected override void MainTeardown()
         {
             Should_Validate();
             base.MainTeardown();

--- a/src/UnitTests/Bug/MissingMapping.cs
+++ b/src/UnitTests/Bug/MissingMapping.cs
@@ -18,7 +18,7 @@
             public int Value { get; set; }
         }
 
-        protected override MapperConfiguration Configuration => new MapperConfiguration(c => { });
+        protected override MapperConfiguration Configuration => new MapperConfiguration(c => c.CreateMissingTypeMaps = false);
 
         [Fact]
         public void Can_not_map_unmapped_type()

--- a/src/UnitTests/Bug/NullableToInvalid.cs
+++ b/src/UnitTests/Bug/NullableToInvalid.cs
@@ -23,6 +23,7 @@ namespace AutoMapper.UnitTests.Bug
         protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
         {
             cfg.CreateMap<Source, Destination>();
+            cfg.CreateMissingTypeMaps = false;
         });
 
         [Fact]

--- a/src/UnitTests/CollectionMapping.cs
+++ b/src/UnitTests/CollectionMapping.cs
@@ -172,7 +172,11 @@ namespace AutoMapper.UnitTests
         }
 
         protected override MapperConfiguration Configuration => 
-            new MapperConfiguration(cfg => cfg.CreateMap<SourceItem, DestItem>());
+            new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<SourceItem, DestItem>();
+                cfg.CreateMissingTypeMaps = false;
+            });
 
         [Fact]
         public void Should_report_missing_map()

--- a/src/UnitTests/ConfigurationValidation.cs
+++ b/src/UnitTests/ConfigurationValidation.cs
@@ -338,6 +338,7 @@ namespace AutoMapper.UnitTests.ConfigurationValidation
         protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
         {
             cfg.CreateMap<Source, Destination>();
+            cfg.CreateMissingTypeMaps = false;
         });
 
         [Fact]
@@ -464,6 +465,7 @@ namespace AutoMapper.UnitTests.ConfigurationValidation
         protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
         {
             cfg.CreateMap<Source, Destination>();
+            cfg.CreateMissingTypeMaps = false;
         });
 
         [Fact]
@@ -498,6 +500,7 @@ namespace AutoMapper.UnitTests.ConfigurationValidation
         protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
         {
             cfg.CreateMap<Source, Destination>();
+            cfg.CreateMissingTypeMaps = false;
         });
 
         [Fact]
@@ -596,6 +599,7 @@ namespace AutoMapper.UnitTests.ConfigurationValidation
         {
             cfg.CreateMap<ModelObject, ModelDto>()
                 .ForMember(dest => dest.Bar, opt => opt.MapFrom(src => src.Barr));
+            cfg.CreateMissingTypeMaps = false;
         });
 
         [Fact]

--- a/src/UnitTests/DynamicMapping.cs
+++ b/src/UnitTests/DynamicMapping.cs
@@ -294,4 +294,47 @@ namespace AutoMapper.UnitTests.DynamicMapping
 
         protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => cfg.CreateMissingTypeMaps = true);
     }
+
+    public class When_dynamically_mapping_a_badly_configured_map : NonValidatingSpecBase
+    {
+        public class Source
+        {
+        }
+
+        public class Dest
+        {
+            public int Value { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => cfg.CreateMissingTypeMaps = true);
+
+        [Fact]
+        public void Should_throw()
+        {
+            typeof(AutoMapperConfigurationException).ShouldBeThrownBy(() => Mapper.Map<Source, Dest>(new Source()));
+        }
+    }
+
+    public class When_automatically_dynamically_mapping : NonValidatingSpecBase
+    {
+        public class Source
+        {
+            public int Value { get; set; }
+        }
+
+        public class Dest
+        {
+            public int Value { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => {});
+
+        [Fact]
+        public void Should_map()
+        {
+            var source = new Source {Value = 5};
+            var dest = Mapper.Map<Dest>(source);
+            dest.Value.ShouldBe(5);
+        }
+    }
 }

--- a/src/UnitTests/DynamicMapping.cs
+++ b/src/UnitTests/DynamicMapping.cs
@@ -26,7 +26,7 @@ namespace AutoMapper.UnitTests.DynamicMapping
             _result.Value.ShouldBe(ConsoleColor.DarkGreen);
         }
 
-        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => cfg.CreateMissingTypeMaps = true);
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => {});
     }
 
     public class When_mapping_nested_types : NonValidatingSpecBase
@@ -308,7 +308,7 @@ namespace AutoMapper.UnitTests.DynamicMapping
 
         protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => cfg.CreateMissingTypeMaps = true);
 
-        [Fact]
+        [Fact(Skip ="Coming next")]
         public void Should_throw()
         {
             typeof(AutoMapperConfigurationException).ShouldBeThrownBy(() => Mapper.Map<Source, Dest>(new Source()));

--- a/src/UnitTests/DynamicMapping.cs
+++ b/src/UnitTests/DynamicMapping.cs
@@ -52,7 +52,7 @@ namespace AutoMapper.UnitTests.DynamicMapping
             public TestDto Patient { get; set; }
         }
 
-        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => cfg.CreateMissingTypeMaps = true);
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => { });
 
         protected override void Because_of()
         {
@@ -93,7 +93,7 @@ namespace AutoMapper.UnitTests.DynamicMapping
             public int Value { get; set; }
         }
 
-        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => cfg.CreateMissingTypeMaps = true);
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => { });
 
         [Fact]
         public void Should_dynamically_map_the_two_types()
@@ -135,8 +135,6 @@ namespace AutoMapper.UnitTests.DynamicMapping
         {
             cfg.CreateMap<Original, Target>()
                 .ForMember(t => t.Child, o => o.ResolveUsing<TargetResolver>());
-
-            cfg.CreateMissingTypeMaps = true;
         });
 
         [Fact]
@@ -178,7 +176,7 @@ namespace AutoMapper.UnitTests.DynamicMapping
             public string Value2 { get; set; }
         }
 
-        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => cfg.CreateMissingTypeMaps = true);
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => {});
 
         public When_mapping_two_non_configured_types_with_nesting()
         {
@@ -218,12 +216,12 @@ namespace AutoMapper.UnitTests.DynamicMapping
             public int Valuefff { get; set; }
         }
 
-        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => cfg.CreateMissingTypeMaps = true);
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => { });
 
         [Fact]
         public void Should_ignore_any_members_that_do_not_match()
         {
-            var destination = Mapper.Map<Source, Destination>(new Source {Value = 5});
+            var destination = Mapper.Map<Source, Destination>(new Source {Value = 5}, opt => opt.ConfigureMap(MemberList.None));
 
             destination.Valuefff.ShouldBe(0);
         }
@@ -231,7 +229,7 @@ namespace AutoMapper.UnitTests.DynamicMapping
         [Fact]
         public void Should_not_throw_any_configuration_errors()
         {
-            typeof(AutoMapperConfigurationException).ShouldNotBeThrownBy(() => Mapper.Map<Source, Destination>(new Source { Value = 5 }));
+            typeof(AutoMapperConfigurationException).ShouldNotBeThrownBy(() => Mapper.Map<Source, Destination>(new Source { Value = 5 }, opt => opt.ConfigureMap(MemberList.None)));
         }
     }
 
@@ -251,12 +249,12 @@ namespace AutoMapper.UnitTests.DynamicMapping
             public int Value2 { get; set; }
         }
 
-        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => cfg.CreateMissingTypeMaps = true);
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => {});
 
         public When_mapping_to_an_existing_destination_object()
         {
             _destination = new Destination { Valuefff = 7};
-            Mapper.Map(new Source { Value = 5, Value2 = 3}, _destination);
+            Mapper.Map(new Source { Value = 5, Value2 = 3}, _destination, opt => opt.ConfigureMap(MemberList.None));
         }
 
         [Fact]
@@ -292,7 +290,7 @@ namespace AutoMapper.UnitTests.DynamicMapping
             _result.Value.ShouldBe(5);
         }
 
-        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => cfg.CreateMissingTypeMaps = true);
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => { });
     }
 
     public class When_dynamically_mapping_a_badly_configured_map : NonValidatingSpecBase
@@ -306,9 +304,9 @@ namespace AutoMapper.UnitTests.DynamicMapping
             public int Value { get; set; }
         }
 
-        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => cfg.CreateMissingTypeMaps = true);
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => { });
 
-        [Fact(Skip ="Coming next")]
+        [Fact]
         public void Should_throw()
         {
             typeof(AutoMapperConfigurationException).ShouldBeThrownBy(() => Mapper.Map<Source, Dest>(new Source()));

--- a/src/UnitTests/DynamicMapping.cs
+++ b/src/UnitTests/DynamicMapping.cs
@@ -313,6 +313,31 @@ namespace AutoMapper.UnitTests.DynamicMapping
         }
     }
 
+    public class When_dynamically_mapping_a_badly_configured_map_and_turning_off_validation : NonValidatingSpecBase
+    {
+        public class Source
+        {
+        }
+
+        public class Dest
+        {
+            public int Value { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.ValidateInlineMaps = false;
+            });
+
+        [Fact]
+        public void Should_not_throw()
+        {
+            Action action = () => Mapper.Map<Source, Dest>(new Source());
+
+            action.ShouldNotThrow();
+        }
+    }
+
     public class When_automatically_dynamically_mapping : NonValidatingSpecBase
     {
         public class Source

--- a/src/UnitTests/DynamicMapping.cs
+++ b/src/UnitTests/DynamicMapping.cs
@@ -270,6 +270,41 @@ namespace AutoMapper.UnitTests.DynamicMapping
         }
     }
 
+    public class When_inline_mapping_with_inline_captured_closure : NonValidatingSpecBase
+    {
+        public class Source
+        {
+            public int Value { get; set; }
+        }
+
+        public class Dest
+        {
+            public int Value { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(_ => {});
+
+        [Fact]
+        public void Should_use_inline_value()
+        {
+            var value = 0;
+
+            var source = new Source { Value = 10 };
+
+            void ConfigOpts(IMappingOperationOptions<Source, Dest> opt) => opt.ConfigureMap().ForMember(d => d.Value, m => m.MapFrom(src => src.Value + value));
+
+            var dest = Mapper.Map<Source, Dest>(source, ConfigOpts);
+
+            dest.Value.ShouldBe(10);
+
+            value = 10;
+
+            dest = Mapper.Map<Source, Dest>(source, ConfigOpts);
+
+            dest.Value.ShouldBe(20);
+        }
+    }
+
     public class When_mapping_from_an_anonymous_type_to_an_interface : NonValidatingSpecBase
     {
         private IDestination _result;

--- a/src/UnitTests/ReverseMapping.cs
+++ b/src/UnitTests/ReverseMapping.cs
@@ -30,6 +30,7 @@ namespace AutoMapper.UnitTests
 
         protected override MapperConfiguration Configuration => new MapperConfiguration(cfg=>
         {
+            cfg.CreateMissingTypeMaps = false;
             cfg.CreateMap<One, Two>()
                 .ForMember(d => d.Name, o => o.MapFrom(s => s))
                 .ForMember(d => d.Three, o => o.MapFrom(s => s.Three2))


### PR DESCRIPTION
So far moved the dynamic mapping out of conventions and into a last-resort-mapping step. Conventions had their issues of being in a weird place in the mapping pipeline, this moves it to a more last-resort step.