### PR TITLE
Fix for #2378 Expression mapping with coalesce operator is extremely slow or just hangs up.

### DIFF
--- a/src/AutoMapper/XpressionMapper/Extensions/MapperExtensions.cs
+++ b/src/AutoMapper/XpressionMapper/Extensions/MapperExtensions.cs
@@ -169,7 +169,7 @@ namespace AutoMapper.XpressionMapper.Extensions
 
         private static bool HasUnderlyingType(this Type type)
         {
-            return type.IsGenericType() || type.HasElementType;
+            return (type.IsGenericType() && typeof(System.Collections.IEnumerable).IsAssignableFrom(type)) || type.IsArray;
         }
 
         private static void AddUnderlyingTypes(this Dictionary<Type, Type> typeMappings, Type sourceType, Type destType)

--- a/src/AutoMapper/XpressionMapper/XpressionMapperVisitor.cs
+++ b/src/AutoMapper/XpressionMapper/XpressionMapperVisitor.cs
@@ -102,16 +102,6 @@ namespace AutoMapper.XpressionMapper
             return base.VisitConstant(node);
         }
 
-        protected override Expression VisitBinary(BinaryExpression node)
-        {
-            var newLeft = Visit(node.Left);
-            var newRight = Visit(node.Right);
-            if ((newLeft.Type.GetTypeInfo().IsGenericType && newLeft.Type.GetGenericTypeDefinition() == typeof(Nullable<>)) ^ (newRight.Type.GetTypeInfo().IsGenericType && newRight.Type.GetGenericTypeDefinition() == typeof(Nullable<>)))
-                throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, Resource.cannotCreateBinaryExpressionFormat, newLeft.ToString(), newLeft.Type.Name, newRight.ToString(), newRight.Type.Name));
-
-            return base.VisitBinary(node);
-        }
-
         protected override Expression VisitMethodCall(MethodCallExpression node)
         {
             var parameterExpression = node.GetParameterExpression();


### PR DESCRIPTION
Fixes #2378 

The type check in XpressionMapperVisitor.VisitBinary was redundant - the exception will only be thrown if type checks in XpressionMapperVisitor.FindDestinationFullName (Resource.expressionMapValueTypeMustMatchFormat) are removed.