### PR TITLE
added IgnoreMembers implementation

### DIFF
--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -51,6 +51,9 @@ namespace AutoMapper.Configuration
         public new IMappingExpression IgnoreAllSourcePropertiesWithAnInaccessibleSetter() 
             => (IMappingExpression)base.IgnoreAllSourcePropertiesWithAnInaccessibleSetter();
 
+        public new IMappingExpression IgnoreMembers(params Expression<Func<object, object>>[] memberExpressionTrees)
+            => (IMappingExpression)base.IgnoreMembers(memberExpressionTrees);
+
         public new IMappingExpression IncludeBase(Type sourceBase, Type destinationBase) 
             => (IMappingExpression)base.IncludeBase(sourceBase, destinationBase);
 
@@ -244,6 +247,14 @@ namespace AutoMapper.Configuration
             }
             return this;
         }
+
+        public IMappingExpression<TSource, TDestination> IgnoreMembers(
+            params Expression<Func<TDestination, object>>[] memberExpressionTrees
+        ) =>
+            memberExpressionTrees.Length < 1
+                ? this
+                : ForMember(memberExpressionTrees[0], options => options.Ignore())
+                    .IgnoreMembers(memberExpressionTrees.Skip(1).ToArray());
 
         public IMappingExpression<TSource, TDestination> Include<TOtherSource, TOtherDestination>()
             where TOtherSource : TSource

--- a/src/AutoMapper/IMappingExpression.cs
+++ b/src/AutoMapper/IMappingExpression.cs
@@ -146,6 +146,14 @@ namespace AutoMapper
         IMappingExpression IgnoreAllSourcePropertiesWithAnInaccessibleSetter();
 
         /// <summary>
+        /// Ignores destination members as specified in an array of expressions
+        /// </summary>
+        /// <param name="memberExpressionTrees">An array of expressions that evaluate to properties that should be ignored when mapping.</param>
+        /// <returns>Itself</returns>
+        /// <remarks>This method is syntactic sugar for calling .ForMember and .Ignore repeatedly.</remarks>
+        IMappingExpression IgnoreMembers(params Expression<Func<object, object>>[] memberExpressionTrees);
+
+        /// <summary>
         /// Include the base type map's configuration in this map
         /// </summary>
         /// <param name="sourceBase">Base source type</param>
@@ -250,6 +258,21 @@ namespace AutoMapper
         /// </summary>
         /// <returns>Itself</returns>
         IMappingExpression<TSource, TDestination> IgnoreAllSourcePropertiesWithAnInaccessibleSetter();
+
+        /// <summary>
+        /// Ignores <typeparamref name="TDestination"/> members as specified in an array of expressions
+        /// </summary>
+        /// <param name="memberExpressionTrees">An array of expressions that evaluate to properties that should be ignored when mapping.</param>
+        /// <returns>Itself</returns>
+        /// <remarks>This method is syntactic sugar for calling .ForMember and .Ignore repeatedly.</remarks>
+        /// <example>
+        /// To ignore several properties when mapping, specify each in a lambda expression.
+        /// <code>
+        /// config.CreateMap&gt;Foo, FooDto&lt;()
+        ///       .IgnoreMembers(target => target.Number, target => target.Name, target => target.CreateDate);
+        /// </code>
+        /// </example>
+        IMappingExpression<TSource, TDestination> IgnoreMembers(params Expression<Func<TDestination, object>>[] memberExpressionTrees);
 
         /// <summary>
         /// Include this configuration in derived types' maps

--- a/src/AutoMapper/IMappingExpression.cs
+++ b/src/AutoMapper/IMappingExpression.cs
@@ -268,10 +268,10 @@ namespace AutoMapper
         /// <example>
         /// To ignore several properties when mapping, specify each in a lambda expression.
         /// <code>
-        /// config.CreateMap&gt;Foo, FooDto&lt;()
+        /// config.CreateMap&lt;Foo, FooDto&gt;()
         ///       .IgnoreMembers(target => target.Number, target => target.Name, target => target.CreateDate);
-        /// </code>
-        /// </example>
+        /// </code> 
+        /// </example> 
         IMappingExpression<TSource, TDestination> IgnoreMembers(params Expression<Func<TDestination, object>>[] memberExpressionTrees);
 
         /// <summary>


### PR DESCRIPTION
Added IgnoreMembers.  

I've found a version of this new method to be very helpful to simplify and shorten my mapping configuration code, and to avoid repeating myself.  Would you like to make it part of the API?  An example is shown in the XML comments on IMappingExpression.