### PR TITLE
Better error message when the creation of the instantiation expression fails

### DIFF
--- a/src/AutoMapper/ConstructorMap.cs
+++ b/src/AutoMapper/ConstructorMap.cs
@@ -43,7 +43,7 @@ namespace AutoMapper
                     ExpressionResultConverters.FirstOrDefault(c => c.CanGetExpressionResolutionResult(result, map));
 
                 result = matchingExpressionConverter?.GetExpressionResolutionResult(result, map)
-                    ?? throw new AutoMapperMappingException($"Unable to generate the instantiation expression for the constructor {Ctor}: no expression could be mapped for constructor parameter '{map.Parameter}'.", null, TypeMap.Types, null, null);
+                    ?? throw new AutoMapperMappingException($"Unable to generate the instantiation expression for the constructor {Ctor}: no expression could be mapped for constructor parameter '{map.Parameter}'.", null, TypeMap.Types);
 
                 return result;
             });

--- a/src/AutoMapper/ConstructorMap.cs
+++ b/src/AutoMapper/ConstructorMap.cs
@@ -42,8 +42,8 @@ namespace AutoMapper
                 var matchingExpressionConverter =
                     ExpressionResultConverters.FirstOrDefault(c => c.CanGetExpressionResolutionResult(result, map));
 
-                result = matchingExpressionConverter?.GetExpressionResolutionResult(result, map) 
-                    ?? throw new Exception("Can't resolve this to Queryable Expression");
+                result = matchingExpressionConverter?.GetExpressionResolutionResult(result, map)
+                    ?? throw new AutoMapperMappingException($"Unable to generate the instantiation expression for the constructor {Ctor}: no expression could be mapped for constructor parameter '{map.Parameter}'.", null, TypeMap.Types, null, null);
 
                 return result;
             });

--- a/src/UnitTests/Projection/MoreExplanatoryExceptionTests.cs
+++ b/src/UnitTests/Projection/MoreExplanatoryExceptionTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using AutoMapper.QueryableExtensions;
+
+namespace AutoMapper.UnitTests.Projection
+{
+    public class MoreExplanatoryExceptionTests
+    {
+        [Fact]
+        public void ConstructorWithUnknownParameterTypeThrowsExplicitException()
+        {
+            // Arrange
+            var config = new MapperConfiguration(cfg =>
+                cfg.CreateMap<EntitySource, EntityDestination>());
+
+            // Act
+            var exception = Assert.Throws<AutoMapperMappingException>(() =>
+                new EntitySource[0].AsQueryable().ProjectTo<EntityDestination>(config));
+
+            // Assert
+            Assert.Contains("object notSupported", exception.Message, StringComparison.OrdinalIgnoreCase);
+        }
+
+        class EntitySource
+        {
+        }
+        class EntityDestination
+        {
+            public EntityDestination(object notSupported = null) { }
+        }
+    }
+}


### PR DESCRIPTION
While defining a new mapping between two classes, I was getting a mysterious `Can't resolve this to Queryable Expression` error message. The message was not meaningful enough so I had to debug AutoMapper to understand what the problem was. I simply had to tell AutoMapper which constructor had to be used...

This PR intends to generate a more explanatory error message.