### PR TITLE
Collection bug

### DIFF
--- a/src/AutoMapper/AutoMapper.csproj
+++ b/src/AutoMapper/AutoMapper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Summary>A convention-based object-object mapper</Summary>
     <Description>A convention-based object-object mapper. AutoMapper uses a fluent configuration API to define an object-object mapping strategy. AutoMapper uses a convention-based matching algorithm to match up source to destination values. Currently, AutoMapper is designed for model projection scenarios to flatten complex object models to DTOs and other simple objects, whose design is better suited for serialization, communication, messaging, or simply an anti-corruption layer between the domain and application layer.</Description>
-    <VersionPrefix>6.2.1</VersionPrefix>
+    <VersionPrefix>6.2.2</VersionPrefix>
     <Authors>Jimmy Bogard</Authors>
     <TargetFrameworks>netstandard1.3;netstandard1.1;net45;net40</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>

--- a/src/AutoMapper/Mappers/Internal/CollectionMapperExpressionFactory.cs
+++ b/src/AutoMapper/Mappers/Internal/CollectionMapperExpressionFactory.cs
@@ -34,7 +34,7 @@ namespace AutoMapper.Mappers.Internal
                 destinationCollectionType = typeof(IList);
             var addMethod = destinationCollectionType.GetDeclaredMethod("Add");
 
-            Expression destination, createInstance, assignNewExpression;
+            Expression destination, assignNewExpression;
 
             UseDestinationValue();
 
@@ -48,7 +48,6 @@ namespace AutoMapper.Mappers.Internal
                     assignNewExpression,
                     Call(destination, clearMethod),
                     mapExpr
-                    //ToType(mapExpr, createInstance.Type)
                 );
             if (propertyMap != null)
                 return checkNull;
@@ -63,14 +62,13 @@ namespace AutoMapper.Mappers.Internal
             {
                 if(propertyMap?.UseDestinationValue == true)
                 {
-                    createInstance = passedDestination;
                     destination = passedDestination;
                     assignNewExpression = Empty();
                 }
                 else
                 {
                     destination = newExpression;
-                    createInstance = passedDestination.Type.NewExpr(ifInterfaceType);
+                    Expression createInstance = passedDestination.Type.NewExpr(ifInterfaceType);
                     var isReadOnly = Property(ToType(passedDestination, destinationCollectionType), "IsReadOnly");
                     assignNewExpression = Assign(newExpression,
                         Condition(OrElse(Equal(passedDestination, Constant(null)), isReadOnly), ToType(createInstance, passedDestination.Type), passedDestination));

--- a/src/AutoMapper/Mappers/Internal/CollectionMapperExpressionFactory.cs
+++ b/src/AutoMapper/Mappers/Internal/CollectionMapperExpressionFactory.cs
@@ -9,8 +9,9 @@ using AutoMapper.Internal;
 namespace AutoMapper.Mappers.Internal
 {
     using static Expression;
-    using static AutoMapper.Execution.ExpressionBuilder;
+    using static ExpressionBuilder;
     using static ExpressionFactory;
+    using static ElementTypeHelper;
 
     public static class CollectionMapperExpressionFactory
     {
@@ -22,7 +23,7 @@ namespace AutoMapper.Mappers.Internal
         {
             var passedDestination = Variable(destExpression.Type, "passedDestination");
             var newExpression = Variable(passedDestination.Type, "collectionDestination");
-            var sourceElementType = ElementTypeHelper.GetElementType(sourceExpression.Type);
+            var sourceElementType = GetElementType(sourceExpression.Type);
 
             var itemExpr = mapItem(configurationProvider, profileMap, sourceExpression.Type, passedDestination.Type,
                 contextExpression, out ParameterExpression itemParam);
@@ -46,7 +47,8 @@ namespace AutoMapper.Mappers.Internal
                     Assign(passedDestination, destExpression),
                     assignNewExpression,
                     Call(destination, clearMethod),
-                    ToType(mapExpr, createInstance.Type)
+                    mapExpr
+                    //ToType(mapExpr, createInstance.Type)
                 );
             if (propertyMap != null)
                 return checkNull;
@@ -80,7 +82,7 @@ namespace AutoMapper.Mappers.Internal
         {
             var newExpr = baseType.IsInterface()
                 ? New(
-                    ifInterfaceType.MakeGenericType(ElementTypeHelper.GetElementTypes(baseType,
+                    ifInterfaceType.MakeGenericType(GetElementTypes(baseType,
                         ElementTypeFlags.BreakKeyValuePair)))
                 : DelegateFactory.GenerateConstructorExpression(baseType);
             return newExpr;
@@ -88,8 +90,8 @@ namespace AutoMapper.Mappers.Internal
 
         public static Expression MapItemExpr(IConfigurationProvider configurationProvider, ProfileMap profileMap, Type sourceType, Type destType, Expression contextParam, out ParameterExpression itemParam)
         {
-            var sourceElementType = ElementTypeHelper.GetElementType(sourceType);
-            var destElementType = ElementTypeHelper.GetElementType(destType);
+            var sourceElementType = GetElementType(sourceType);
+            var destElementType = GetElementType(destType);
             itemParam = Parameter(sourceElementType, "item");
 
             var typePair = new TypePair(sourceElementType, destElementType);
@@ -100,8 +102,8 @@ namespace AutoMapper.Mappers.Internal
 
         public static Expression MapKeyPairValueExpr(IConfigurationProvider configurationProvider, ProfileMap profileMap, Type sourceType, Type destType, Expression contextParam, out ParameterExpression itemParam)
         {
-            var sourceElementTypes = ElementTypeHelper.GetElementTypes(sourceType, ElementTypeFlags.BreakKeyValuePair);
-            var destElementTypes = ElementTypeHelper.GetElementTypes(destType, ElementTypeFlags.BreakKeyValuePair);
+            var sourceElementTypes = GetElementTypes(sourceType, ElementTypeFlags.BreakKeyValuePair);
+            var destElementTypes = GetElementTypes(destType, ElementTypeFlags.BreakKeyValuePair);
 
             var typePairKey = new TypePair(sourceElementTypes[0], destElementTypes[0]);
             var typePairValue = new TypePair(sourceElementTypes[1], destElementTypes[1]);

--- a/src/UnitTests/CollectionMapping.cs
+++ b/src/UnitTests/CollectionMapping.cs
@@ -616,6 +616,54 @@ namespace AutoMapper.UnitTests
         }
     }
 
+    public class When_mapping_from_ICollection_types_but_implementations_are_different : AutoMapperSpecBase
+    {
+        public class Source
+        {
+            public ICollection<Item> Items { get; set; }
+
+            public class Item
+            {
+                public int Value { get; set; }
+            }
+        }
+        public class Dest
+        {
+            public ICollection<Item> Items { get; set; } = new HashSet<Item>();
+
+            public class Item
+            {
+                public int Value { get; set; }
+            }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Dest>();
+            cfg.CreateMap<Source.Item, Dest.Item>();
+        });
+
+        [Fact]
+        public void Should_map_items()
+        {
+            var source = new Source
+            {
+                Items = new List<Source.Item>
+                {
+                    new Source.Item { Value = 5 }
+                }
+            };
+            var dest = new Dest();
+
+            var plan = Mapper.ConfigurationProvider.FindTypeMapFor<Source, Dest>().MapExpression;
+
+            Mapper.Map(source, dest);
+
+            dest.Items.Count.ShouldBe(1);
+            dest.Items.First().Value.ShouldBe(5);
+        }
+    }
+
     public class When_mapping_enumerable_to_array : AutoMapperSpecBase
     {
         public class Source

--- a/src/UnitTests/CollectionMapping.cs
+++ b/src/UnitTests/CollectionMapping.cs
@@ -655,8 +655,6 @@ namespace AutoMapper.UnitTests
             };
             var dest = new Dest();
 
-            var plan = Mapper.ConfigurationProvider.FindTypeMapFor<Source, Dest>().MapExpression;
-
             Mapper.Map(source, dest);
 
             dest.Items.Count.ShouldBe(1);

--- a/src/UnitTests/Dictionaries.cs
+++ b/src/UnitTests/Dictionaries.cs
@@ -192,8 +192,6 @@ namespace AutoMapper.UnitTests
                             }
                 };
 
-                var plan = Configuration.FindTypeMapFor<Foo, FooDto>().MapExpression;
-
                 _result = Mapper.Map<Foo, FooDto>(foo1);
             }
 

--- a/src/UnitTests/Dictionaries.cs
+++ b/src/UnitTests/Dictionaries.cs
@@ -192,6 +192,8 @@ namespace AutoMapper.UnitTests
                             }
                 };
 
+                var plan = Configuration.FindTypeMapFor<Foo, FooDto>().MapExpression;
+
                 _result = Mapper.Map<Foo, FooDto>(foo1);
             }
 


### PR DESCRIPTION
This fixes the newly introduced issue of casting collection types. I didn't think forcing everyone to use `UseDestinationValue` was a good solution, this change centers around the interfaces and the concrete types are only used for instantiation.