### PR TITLE
Make mapping at runtime closer to inline mapping

### DIFF
--- a/src/AutoMapper/AutoMapper.csproj
+++ b/src/AutoMapper/AutoMapper.csproj
@@ -17,13 +17,6 @@
     <PackageIconUrl>https://s3.amazonaws.com/automapper/icon.png</PackageIconUrl>
     <PackageProjectUrl>http://automapper.org</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/AutoMapper/AutoMapper/blob/master/LICENSE.txt</PackageLicenseUrl>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.3|AnyCPU'">
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.3|AnyCPU'">
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 

--- a/src/AutoMapper/AutoMapper.csproj
+++ b/src/AutoMapper/AutoMapper.csproj
@@ -19,6 +19,14 @@
     <PackageLicenseUrl>https://github.com/AutoMapper/AutoMapper/blob/master/LICENSE.txt</PackageLicenseUrl>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.3|AnyCPU'">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard1.3|AnyCPU'">
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' Or '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />

--- a/src/AutoMapper/Execution/DelegateFactory.cs
+++ b/src/AutoMapper/Execution/DelegateFactory.cs
@@ -52,7 +52,7 @@ namespace AutoMapper.Execution
             {
                 return type.ImplementsGenericInterface(typeof(IDictionary<,>))
                     ? CreateCollection(type, typeof(Dictionary<,>))
-                    : (type.ImplementsGenericInterface(typeof(ICollection<>))
+                    : (type.IsEnumerableType()
                         ? CreateCollection(type, typeof(List<>))
                         : InvalidType(type, $"Cannot create an instance of interface type {type}."));
             }

--- a/src/AutoMapper/Execution/ExpressionBuilder.cs
+++ b/src/AutoMapper/Execution/ExpressionBuilder.cs
@@ -17,7 +17,7 @@ namespace AutoMapper.Execution
             mapper => new ResolutionContext(mapper.DefaultContext.Options, mapper);
 
         private static readonly MethodInfo ContextMapMethod =
-            ExpressionFactory.Method<ResolutionContext, object>(a => a.Map<object, object>(null, null)).GetGenericMethodDefinition();            
+            ExpressionFactory.Method<ResolutionContext, object>(a => a.Map<object, object>(null, null, null)).GetGenericMethodDefinition();            
 
         public static Expression MapExpression(IConfigurationProvider configurationProvider,
             ProfileMap profileMap,
@@ -38,9 +38,9 @@ namespace AutoMapper.Execution
                     return typeMap.MapExpression != null
                         ? typeMap.MapExpression.ConvertReplaceParameters(sourceParameter, destinationParameter,
                             contextParameter)
-                        : ContextMap(typePair, sourceParameter, contextParameter, destinationParameter);
+                        : ContextMap(typePair, sourceParameter, contextParameter, destinationParameter, propertyMap);
                 }
-                return ContextMap(typePair, sourceParameter, contextParameter, destinationParameter);
+                return ContextMap(typePair, sourceParameter, contextParameter, destinationParameter, propertyMap);
             }
             var objectMapperExpression = ObjectMapperExpression(configurationProvider, profileMap, typePair,
                 sourceParameter, contextParameter, propertyMap, destinationParameter);
@@ -52,7 +52,7 @@ namespace AutoMapper.Execution
             Expression sourceParameter,
             Expression destinationParameter,
             Expression objectMapperExpression,
-            PropertyMap propertyMap = null)
+            PropertyMap propertyMap)
         {
             var declaredDestinationType = destinationParameter.Type;
             var destinationType = objectMapperExpression.Type;
@@ -101,14 +101,14 @@ namespace AutoMapper.Execution
                     sourceParameter, destinationParameter, contextParameter);
                 return mapperExpression;
             }
-            return ContextMap(typePair, sourceParameter, contextParameter, destinationParameter);
+            return ContextMap(typePair, sourceParameter, contextParameter, destinationParameter, propertyMap);
         }
 
         public static Expression ContextMap(TypePair typePair, Expression sourceParameter, Expression contextParameter,
-            Expression destinationParameter)
+            Expression destinationParameter, PropertyMap propertyMap)
         {
             var mapMethod = ContextMapMethod.MakeGenericMethod(typePair.SourceType, typePair.DestinationType);
-            return Call(contextParameter, mapMethod, sourceParameter, destinationParameter);
+            return Call(contextParameter, mapMethod, sourceParameter, destinationParameter, Constant(propertyMap, typeof(PropertyMap)));
         }
 
         public static ConditionalExpression CheckContext(TypeMap typeMap, Expression context)

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -410,7 +410,7 @@ namespace AutoMapper.Execution
             valueResolverExpr = propertyMap.Inline
                 ? MapExpression(_configurationProvider, _typeMap.Profile, typePair, valueResolverExpr, Context,
                     propertyMap, destValueExpr)
-                : ContextMap(typePair, valueResolverExpr, Context, destValueExpr);
+                : ContextMap(typePair, valueResolverExpr, Context, destValueExpr, propertyMap);
 
             valueResolverExpr = propertyMap.ValueTransformers
                 .Concat(_typeMap.ValueTransformers)

--- a/src/AutoMapper/IConfigurationProvider.cs
+++ b/src/AutoMapper/IConfigurationProvider.cs
@@ -135,7 +135,7 @@ namespace AutoMapper
         /// <returns>The mapper instance</returns>
         IMapper CreateMapper(Func<Type, object> serviceCtor);
 
-        Func<TSource, TDestination, ResolutionContext, TDestination> GetMapperFunc<TSource, TDestination>(TypePair types);
+        Func<TSource, TDestination, ResolutionContext, TDestination> GetMapperFunc<TSource, TDestination>(TypePair types, PropertyMap propertyMap = null);
         Func<TSource, TDestination, ResolutionContext, TDestination> GetMapperFunc<TSource, TDestination>(MapRequest mapRequest);
 
         /// <summary>

--- a/src/AutoMapper/IMapper.cs
+++ b/src/AutoMapper/IMapper.cs
@@ -120,7 +120,7 @@ namespace AutoMapper
     public interface IRuntimeMapper : IMapper
     {
         ResolutionContext DefaultContext { get; }
-        object Map(object source, object destination, Type sourceType, Type destinationType, ResolutionContext parent);
-        TDestination Map<TSource, TDestination>(TSource source, TDestination destination, ResolutionContext parent);
+        object Map(object source, object destination, Type sourceType, Type destinationType, ResolutionContext parent, PropertyMap propertyMap = null);
+        TDestination Map<TSource, TDestination>(TSource source, TDestination destination, ResolutionContext parent, PropertyMap propertyMap = null);
     }
 }

--- a/src/AutoMapper/Internal/ReflectionHelper.cs
+++ b/src/AutoMapper/Internal/ReflectionHelper.cs
@@ -32,7 +32,7 @@ namespace AutoMapper.Internal
         {
             var memberType = GetMemberType(member);
             var destValue = destination == null ? null : GetMemberValue(member, destination);
-            return context.Map(value, destValue, value?.GetType() ?? memberType, memberType, new PropertyMap(member, null));
+            return context.Map(value, destValue, value?.GetType() ?? memberType, memberType, PropertyMap.Default);
         }
 
         public static bool IsDynamic(object obj) => obj is IDynamicMetaObjectProvider;

--- a/src/AutoMapper/Internal/ReflectionHelper.cs
+++ b/src/AutoMapper/Internal/ReflectionHelper.cs
@@ -28,17 +28,11 @@ namespace AutoMapper.Internal
             return parameter.DefaultValue;
         }
 
-        public static object MapMember(ResolutionContext context, MemberInfo member, object value, object destination)
+        public static object MapMember(ResolutionContext context, MemberInfo member, object value, object destination = null)
         {
             var memberType = GetMemberType(member);
-            var destValue = GetMemberValue(member, destination);
-            return context.Map(value, destValue, value?.GetType() ?? memberType, memberType);
-        }
-
-        public static object MapMember(ResolutionContext context, MemberInfo member, object value)
-        {
-            var memberType = GetMemberType(member);
-            return context.Map(value, null, value?.GetType() ?? memberType, memberType);
+            var destValue = destination == null ? null : GetMemberValue(member, destination);
+            return context.Map(value, destValue, value?.GetType() ?? memberType, memberType, new PropertyMap(member, null));
         }
 
         public static bool IsDynamic(object obj) => obj is IDynamicMetaObjectProvider;

--- a/src/AutoMapper/Internal/ReflectionHelper.cs
+++ b/src/AutoMapper/Internal/ReflectionHelper.cs
@@ -32,13 +32,13 @@ namespace AutoMapper.Internal
         {
             var memberType = GetMemberType(member);
             var destValue = GetMemberValue(member, destination);
-            return context.Mapper.Map(value, destValue, value?.GetType() ?? memberType, memberType, context);
+            return context.Map(value, destValue, value?.GetType() ?? memberType, memberType);
         }
 
         public static object MapMember(ResolutionContext context, MemberInfo member, object value)
         {
             var memberType = GetMemberType(member);
-            return context.Mapper.Map(value, null, value?.GetType() ?? memberType, memberType, context);
+            return context.Map(value, null, value?.GetType() ?? memberType, memberType);
         }
 
         public static bool IsDynamic(object obj) => obj is IDynamicMetaObjectProvider;

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -356,6 +356,11 @@ namespace AutoMapper
 
         object IRuntimeMapper.Map(object source, object destination, Type sourceType, Type destinationType, ResolutionContext context)
         {
+            if(destinationType.IsValueType())
+            {
+                destination = null;
+            }
+
             var types = TypePair.Create(source, destination, sourceType, destinationType);
 
             var func = _configurationProvider.GetUntypedMapperFunc(new MapRequest(new TypePair(sourceType, destinationType), types));
@@ -365,6 +370,11 @@ namespace AutoMapper
 
         TDestination IRuntimeMapper.Map<TSource, TDestination>(TSource source, TDestination destination, ResolutionContext context)
         {
+            if(typeof(TDestination).IsValueType())
+            {
+                destination = default(TDestination);
+            }
+
             var types = TypePair.Create(source, destination, typeof(TSource), typeof(TDestination));
 
             var func = _configurationProvider.GetMapperFunc<TSource, TDestination>(types);

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -354,30 +354,20 @@ namespace AutoMapper
             return destination;
         }
 
-        object IRuntimeMapper.Map(object source, object destination, Type sourceType, Type destinationType, ResolutionContext context)
+        object IRuntimeMapper.Map(object source, object destination, Type sourceType, Type destinationType, ResolutionContext context, PropertyMap propertyMap)
         {
-            if(destinationType.IsValueType())
-            {
-                destination = null;
-            }
-
             var types = TypePair.Create(source, destination, sourceType, destinationType);
 
-            var func = _configurationProvider.GetUntypedMapperFunc(new MapRequest(new TypePair(sourceType, destinationType), types));
+            var func = _configurationProvider.GetUntypedMapperFunc(new MapRequest(new TypePair(sourceType, destinationType), types, propertyMap));
 
             return func(source, destination, context);
         }
 
-        TDestination IRuntimeMapper.Map<TSource, TDestination>(TSource source, TDestination destination, ResolutionContext context)
+        TDestination IRuntimeMapper.Map<TSource, TDestination>(TSource source, TDestination destination, ResolutionContext context, PropertyMap propertyMap)
         {
-            if(typeof(TDestination).IsValueType())
-            {
-                destination = default(TDestination);
-            }
-
             var types = TypePair.Create(source, destination, typeof(TSource), typeof(TDestination));
 
-            var func = _configurationProvider.GetMapperFunc<TSource, TDestination>(types);
+            var func = _configurationProvider.GetMapperFunc<TSource, TDestination>(types, propertyMap);
 
             return func(source, destination, context);
         }

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -171,7 +171,8 @@ namespace AutoMapper
                         Throw(New(ExceptionConstructor, Constant("Error mapping types."), exception, Constant(mapRequest.RequestedTypes))),
                         Default(destination.Type)), null));
             }
-            var nullCheckSource = NullCheckSource(Configuration, source, destination, fullExpression, mapRequest.PropertyMap);
+            var profileMap = mapRequest.PropertyMap?.TypeMap?.Profile ?? Configuration;
+            var nullCheckSource = NullCheckSource(profileMap, source, destination, fullExpression, mapRequest.PropertyMap);
             return Lambda(nullCheckSource, source, destination, context);
         }
 

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -117,7 +117,7 @@ namespace AutoMapper
                 return GenerateTypeMapExpression(mapRequest, typeMap);
             }
             var mapperToUse = FindMapper(mapRequest.RuntimeTypes);
-            return GenerateObjectMapperExpression(mapRequest, mapperToUse, this);
+            return GenerateObjectMapperExpression(mapRequest, mapperToUse);
         }
 
         private static LambdaExpression GenerateTypeMapExpression(MapRequest mapRequest, TypeMap typeMap)
@@ -145,7 +145,7 @@ namespace AutoMapper
             return mapExpression;
         }
 
-        private LambdaExpression GenerateObjectMapperExpression(MapRequest mapRequest, IObjectMapper mapperToUse, MapperConfiguration mapperConfiguration)
+        private LambdaExpression GenerateObjectMapperExpression(MapRequest mapRequest, IObjectMapper mapperToUse)
         {
             var destinationType = mapRequest.RequestedTypes.DestinationType;
 
@@ -160,7 +160,7 @@ namespace AutoMapper
             }
             else
             {
-                var map = mapperToUse.MapExpression(mapperConfiguration, Configuration, mapRequest.PropertyMap, 
+                var map = mapperToUse.MapExpression(this, Configuration, mapRequest.PropertyMap, 
                                                                         ToType(source, mapRequest.RuntimeTypes.SourceType), 
                                                                         ToType(destination, mapRequest.RuntimeTypes.DestinationType), 
                                                                         context);

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -79,10 +79,10 @@ namespace AutoMapper
 
         public IEnumerable<ProfileMap> Profiles { get; }
 
-        public Func<TSource, TDestination, ResolutionContext, TDestination> GetMapperFunc<TSource, TDestination>(TypePair types)
+        public Func<TSource, TDestination, ResolutionContext, TDestination> GetMapperFunc<TSource, TDestination>(TypePair types, PropertyMap propertyMap)
         {
             var key = new TypePair(typeof(TSource), typeof(TDestination));
-            var mapRequest = new MapRequest(key, types);
+            var mapRequest = new MapRequest(key, types, propertyMap);
             return GetMapperFunc<TSource, TDestination>(mapRequest);
         }
 
@@ -160,7 +160,7 @@ namespace AutoMapper
             }
             else
             {
-                var map = mapperToUse.MapExpression(mapperConfiguration, Configuration, null, 
+                var map = mapperToUse.MapExpression(mapperConfiguration, Configuration, mapRequest.PropertyMap, 
                                                                         ToType(source, mapRequest.RuntimeTypes.SourceType), 
                                                                         ToType(destination, mapRequest.RuntimeTypes.DestinationType), 
                                                                         context);
@@ -171,7 +171,7 @@ namespace AutoMapper
                         Throw(New(ExceptionConstructor, Constant("Error mapping types."), exception, Constant(mapRequest.RequestedTypes))),
                         Default(destination.Type)), null));
             }
-            var nullCheckSource = NullCheckSource(Configuration, source, destination, fullExpression);
+            var nullCheckSource = NullCheckSource(Configuration, source, destination, fullExpression, mapRequest.PropertyMap);
             return Lambda(nullCheckSource, source, destination, context);
         }
 

--- a/src/AutoMapper/Mappers/MultidimensionalArrayMapper.cs
+++ b/src/AutoMapper/Mappers/MultidimensionalArrayMapper.cs
@@ -13,7 +13,7 @@ namespace AutoMapper.Mappers
 
     public class MultidimensionalArrayMapper : IObjectMapper
     {
-        private static Array Map<TDestination, TSource, TSourceElement>(TSource source, ResolutionContext context, ProfileMap profileMap)
+        private static Array Map<TDestination, TSource, TSourceElement>(TSource source, ResolutionContext context, PropertyMap propertyMap)
             where TSource : IEnumerable
         {
             var destElementType = ElementTypeHelper.GetElementType(typeof(TDestination));
@@ -34,7 +34,7 @@ namespace AutoMapper.Mappers
             var filler = new MultidimensionalArrayFiller(destinationArray);
             foreach (var item in sourceList)
             {
-                filler.NewValue(context.Map(item, null, typeof(TSourceElement), destElementType));
+                filler.NewValue(context.Map(item, null, typeof(TSourceElement), destElementType, propertyMap));
             }
             return destinationArray;
         }
@@ -54,7 +54,7 @@ namespace AutoMapper.Mappers
                     ElementTypeHelper.GetElementType(sourceExpression.Type)),
                 sourceExpression,
                 contextExpression,
-                Constant(profileMap));
+                Constant(propertyMap, typeof(PropertyMap)));
 
         public class MultidimensionalArrayFiller
         {

--- a/src/AutoMapper/Mappers/MultidimensionalArrayMapper.cs
+++ b/src/AutoMapper/Mappers/MultidimensionalArrayMapper.cs
@@ -34,7 +34,7 @@ namespace AutoMapper.Mappers
             var filler = new MultidimensionalArrayFiller(destinationArray);
             foreach (var item in sourceList)
             {
-                filler.NewValue(context.Map(item, null, typeof(TSourceElement), destElementType, PropertyMap.Default));
+                filler.NewValue(context.Map(item, null, typeof(TSourceElement), destElementType, null));
             }
             return destinationArray;
         }

--- a/src/AutoMapper/Mappers/MultidimensionalArrayMapper.cs
+++ b/src/AutoMapper/Mappers/MultidimensionalArrayMapper.cs
@@ -13,7 +13,7 @@ namespace AutoMapper.Mappers
 
     public class MultidimensionalArrayMapper : IObjectMapper
     {
-        private static Array Map<TDestination, TSource, TSourceElement>(TSource source, ResolutionContext context, PropertyMap propertyMap)
+        private static Array Map<TDestination, TSource, TSourceElement>(TSource source, ResolutionContext context)
             where TSource : IEnumerable
         {
             var destElementType = ElementTypeHelper.GetElementType(typeof(TDestination));
@@ -34,7 +34,7 @@ namespace AutoMapper.Mappers
             var filler = new MultidimensionalArrayFiller(destinationArray);
             foreach (var item in sourceList)
             {
-                filler.NewValue(context.Map(item, null, typeof(TSourceElement), destElementType, propertyMap));
+                filler.NewValue(context.Map(item, null, typeof(TSourceElement), destElementType, PropertyMap.Default));
             }
             return destinationArray;
         }
@@ -53,8 +53,7 @@ namespace AutoMapper.Mappers
                 MapMethodInfo.MakeGenericMethod(destExpression.Type, sourceExpression.Type,
                     ElementTypeHelper.GetElementType(sourceExpression.Type)),
                 sourceExpression,
-                contextExpression,
-                Constant(propertyMap, typeof(PropertyMap)));
+                contextExpression);
 
         public class MultidimensionalArrayFiller
         {

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -16,7 +16,7 @@ namespace AutoMapper
         private readonly List<MemberInfo> _memberChain = new List<MemberInfo>();
         private readonly List<ValueTransformerConfiguration> _valueTransformerConfigs = new List<ValueTransformerConfiguration>();
 
-        internal static PropertyMap Default { get; } = new PropertyMap(null, null);
+        internal static PropertyMap Default { get; } = new PropertyMap(default(MemberInfo), default(TypeMap));
         
         public PropertyMap(PathMap pathMap)
         {

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -16,6 +16,8 @@ namespace AutoMapper
         private readonly List<MemberInfo> _memberChain = new List<MemberInfo>();
         private readonly List<ValueTransformerConfiguration> _valueTransformerConfigs = new List<ValueTransformerConfiguration>();
 
+        internal static PropertyMap Default { get; } = new PropertyMap(null, null);
+        
         public PropertyMap(PathMap pathMap)
         {
             Condition = pathMap.Condition;

--- a/src/AutoMapper/ReflectionExtensions.cs
+++ b/src/AutoMapper/ReflectionExtensions.cs
@@ -11,11 +11,8 @@ namespace AutoMapper
         public static object GetDefaultValue(this ParameterInfo parameter)
             => ReflectionHelper.GetDefaultValue(parameter);
 
-        public static object MapMember(this ResolutionContext context, MemberInfo member, object value, object destination)
+        public static object MapMember(this ResolutionContext context, MemberInfo member, object value, object destination = null)
             => ReflectionHelper.MapMember(context, member, value, destination);
-
-        public static object MapMember(this ResolutionContext context, MemberInfo member, object value)
-            => ReflectionHelper.MapMember(context, member, value);
 
         public static bool IsDynamic(this object obj)
             => ReflectionHelper.IsDynamic(obj);

--- a/src/AutoMapper/ResolutionContext.cs
+++ b/src/AutoMapper/ResolutionContext.cs
@@ -110,11 +110,11 @@ namespace AutoMapper
 
         internal bool IsDefault => this == Mapper.DefaultContext;
 
-        internal TDestination Map<TSource, TDestination>(TSource source, TDestination destination)
-            => Mapper.Map(source, destination, this);
+        internal TDestination Map<TSource, TDestination>(TSource source, TDestination destination, PropertyMap propertyMap)
+            => Mapper.Map(source, destination, this, propertyMap);
 
-        internal object Map(object source, object destination, Type sourceType, Type destinationType) 
-            => Mapper.Map(source, destination, sourceType, destinationType, this);
+        internal object Map(object source, object destination, Type sourceType, Type destinationType, PropertyMap propertyMap) 
+            => Mapper.Map(source, destination, sourceType, destinationType, this, propertyMap);
 
         internal void ValidateMap(TypeMap typeMap)
             => ConfigurationProvider.AssertConfigurationIsValid(typeMap);

--- a/src/AutoMapper/TypePair.cs
+++ b/src/AutoMapper/TypePair.cs
@@ -13,17 +13,19 @@ namespace AutoMapper
         public TypePair RequestedTypes { get; }
         public TypePair RuntimeTypes { get; }
         public ITypeMapConfiguration InlineConfig { get; }
+        public PropertyMap PropertyMap { get; }
 
-        public MapRequest(TypePair requestedTypes, TypePair runtimeTypes) 
-            : this(requestedTypes, runtimeTypes, new MapperConfiguration.DefaultTypeMapConfig(requestedTypes))
+        public MapRequest(TypePair requestedTypes, TypePair runtimeTypes, PropertyMap propertyMap = null) 
+            : this(requestedTypes, runtimeTypes, new MapperConfiguration.DefaultTypeMapConfig(requestedTypes), propertyMap)
         {
         }
 
-        public MapRequest(TypePair requestedTypes, TypePair runtimeTypes, ITypeMapConfiguration inlineConfig)
+        public MapRequest(TypePair requestedTypes, TypePair runtimeTypes, ITypeMapConfiguration inlineConfig, PropertyMap propertyMap = null)
         {
             RequestedTypes = requestedTypes;
             RuntimeTypes = runtimeTypes;
             InlineConfig = inlineConfig;
+            PropertyMap = propertyMap;
         }
 
         public bool Equals(MapRequest other) => RequestedTypes.Equals(other.RequestedTypes) && RuntimeTypes.Equals(other.RuntimeTypes);
@@ -34,7 +36,15 @@ namespace AutoMapper
             return obj is MapRequest && Equals((MapRequest) obj);
         }
 
-        public override int GetHashCode() => HashCodeCombiner.Combine(RequestedTypes, RuntimeTypes);
+        public override int GetHashCode()
+        {
+            var hashCode = HashCodeCombiner.Combine(RequestedTypes, RuntimeTypes);
+            if(PropertyMap != null)
+            {
+                hashCode = HashCodeCombiner.Combine(hashCode, PropertyMap.GetHashCode());
+            }
+            return hashCode;
+        }
 
         public static bool operator ==(MapRequest left, MapRequest right) => left.Equals(right);
 

--- a/src/AutoMapper/TypePair.cs
+++ b/src/AutoMapper/TypePair.cs
@@ -28,7 +28,8 @@ namespace AutoMapper
             PropertyMap = propertyMap;
         }
 
-        public bool Equals(MapRequest other) => RequestedTypes.Equals(other.RequestedTypes) && RuntimeTypes.Equals(other.RuntimeTypes);
+        public bool Equals(MapRequest other) => 
+            RequestedTypes.Equals(other.RequestedTypes) && RuntimeTypes.Equals(other.RuntimeTypes) && Equals(PropertyMap, other.PropertyMap);
 
         public override bool Equals(object obj)
         {

--- a/src/IntegrationTests/Inheritance/QueryableInterfaceInheritanceIssue.cs
+++ b/src/IntegrationTests/Inheritance/QueryableInterfaceInheritanceIssue.cs
@@ -2,10 +2,11 @@
 using System.Data.Entity;
 using System.Linq;
 using AutoMapper.QueryableExtensions;
+using AutoMapper.UnitTests;
 using Shouldly;
 using Xunit;
 
-namespace AutoMapper.UnitTests.Projection
+namespace AutoMapper.IntegrationTests
 {
     public class QueryableInterfaceInheritanceIssue : AutoMapperSpecBase
     {

--- a/src/UnitTests/FillingExistingDestination.cs
+++ b/src/UnitTests/FillingExistingDestination.cs
@@ -5,6 +5,37 @@ using System.Linq;
 
 namespace AutoMapper.UnitTests
 {
+    public class When_a_source_child_object_is_null : AutoMapperSpecBase
+    {
+        public class Source
+        {
+            public Child Child { get; set; }
+        }
+
+        public class Destination
+        {
+            public Child Child { get; set; } = new Child();
+        }
+
+        public class Child
+        {
+            public int Value { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>().ForMember(d => d.Child, o => o.MapAtRuntime());
+        });
+
+        [Fact]
+        public void Should_overwrite_the_existing_child_destination()
+        {
+            var destination = new Destination();
+            Mapper.Map(new Source(), destination);
+            destination.Child.ShouldBeNull();
+        }
+    }
+
     public class When_the_destination_object_is_specified : AutoMapperSpecBase
     {
         private Source _source;
@@ -122,37 +153,6 @@ namespace AutoMapper.UnitTests
         {
             _dest.Name.ShouldBe("foo");
             _dest.Child.Name.ShouldBe("bar");
-        }
-    }
-
-    public class When_a_source_child_object_is_null : AutoMapperSpecBase
-    {
-        public class Source
-        {
-            public Child Child { get; set; }
-        }
-
-        public class Destination
-        {
-            public Child Child { get; set; } = new Child();
-        }
-
-        public class Child
-        {
-            public int Value { get; set; }
-        }
-
-        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
-        {
-            cfg.CreateMap<Source, Destination>().ForMember(d=>d.Child, o=>o.MapAtRuntime());
-        });
-
-        [Fact]
-        public void Should_overwrite_the_existing_child_destination()
-        {
-            var destination = new Destination();
-            Mapper.Map(new Source(), destination);
-            destination.Child.ShouldBeNull();
         }
     }
 

--- a/src/UnitTests/FillingExistingDestination.cs
+++ b/src/UnitTests/FillingExistingDestination.cs
@@ -5,216 +5,243 @@ using System.Linq;
 
 namespace AutoMapper.UnitTests
 {
-    namespace FillingExistingDestination
+    public class When_the_destination_object_is_specified : AutoMapperSpecBase
     {
+        private Source _source;
+        private Destination _originalDest;
+        private Destination _dest;
 
-        public class When_the_destination_object_is_specified : AutoMapperSpecBase
+        public class Source
         {
-            private Source _source;
-            private Destination _originalDest;
-            private Destination _dest;
-
-            public class Source
-            {
-                public int Value { get; set; }
-            }
-
-            public class Destination
-            {
-                public int Value { get; set; }
-            }
-
-            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
-            {
-                cfg.CreateMap<Source, Destination>();
-
-            });
-
-            protected override void Because_of()
-            {
-                _source = new Source
-                {
-                    Value = 10,
-                };
-                _originalDest = new Destination { Value = 1111 };
-                _dest = Mapper.Map<Source, Destination>(_source, _originalDest);
-            }
-
-            [Fact]
-            public void Should_do_the_translation()
-            {
-                _dest.Value.ShouldBe(10);
-            }
-
-            [Fact]
-            public void Should_return_the_destination_object_that_was_passed_in()
-            {
-                _originalDest.ShouldBeSameAs(_dest);
-            }
+            public int Value { get; set; }
         }
+
+        public class Destination
+        {
+            public int Value { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>();
+
+        });
+
+        protected override void Because_of()
+        {
+            _source = new Source
+            {
+                Value = 10,
+            };
+            _originalDest = new Destination { Value = 1111 };
+            _dest = Mapper.Map<Source, Destination>(_source, _originalDest);
+        }
+
+        [Fact]
+        public void Should_do_the_translation()
+        {
+            _dest.Value.ShouldBe(10);
+        }
+
+        [Fact]
+        public void Should_return_the_destination_object_that_was_passed_in()
+        {
+            _originalDest.ShouldBeSameAs(_dest);
+        }
+    }
        
-        public class When_the_destination_object_is_specified_with_child_objects : AutoMapperSpecBase
+    public class When_the_destination_object_is_specified_with_child_objects : AutoMapperSpecBase
+    {
+        private Source _source;
+        private Destination _originalDest;
+        private Destination _dest;
+
+        public class Source
         {
-            private Source _source;
-            private Destination _originalDest;
-            private Destination _dest;
-
-            public class Source
-            {
-                public int Value { get; set; }
-                public ChildSource Child { get; set; }
-            }
-
-            public class Destination
-            {
-                public int Value { get; set; }
-                public string Name { get; set; }
-                public ChildDestination Child { get; set; }
-            }
-
-            public class ChildSource
-            {
-                public int Value { get; set; }
-            }
-
-            public class ChildDestination
-            {
-                public int Value { get; set; }
-                public string Name { get; set; }
-            }
-
-            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
-            {
-                cfg.CreateMap<Source, Destination>(MemberList.Source)
-                    .ForMember(d => d.Child, opt => opt.UseDestinationValue());
-                cfg.CreateMap<ChildSource, ChildDestination>(MemberList.Source)
-                    .ForMember(d => d.Name, opt => opt.UseDestinationValue());
-            });
-
-            protected override void Because_of()
-            {
-                _source = new Source
-                {
-                    Value = 10,
-                    Child = new ChildSource
-                    {
-                        Value = 20
-                    }
-                };
-                _originalDest = new Destination
-                {
-                    Value = 1111,
-                    Name = "foo",
-                    Child = new ChildDestination
-                    {
-                        Name = "bar"
-                    }
-                };
-                _dest = Mapper.Map<Source, Destination>(_source, _originalDest);
-            }
-
-            [Fact]
-            public void Should_do_the_translation()
-            {
-                _dest.Value.ShouldBe(10);
-                _dest.Child.Value.ShouldBe(20);
-            }
-
-            [Fact]
-            public void Should_return_the_destination_object_that_was_passed_in()
-            {
-                _dest.Name.ShouldBe("foo");
-                _dest.Child.Name.ShouldBe("bar");
-            }
+            public int Value { get; set; }
+            public ChildSource Child { get; set; }
         }
 
-        public class When_the_destination_object_has_child_objects : AutoMapperSpecBase
+        public class Destination
         {
-            private Source _source;
-            private Destination _originalDest;
-            private ChildDestination _originalDestChild;
-            private Destination _dest;
-
-            public class Source
-            {
-                public ChildSource Child { get; set; }
-            }
-
-            public class Destination
-            {
-                public ChildDestination Child { get; set; }
-            }
-
-            public class ChildSource
-            {
-                public int Value { get; set; }
-            }
-
-            public class ChildDestination
-            {
-                public int Value { get; set; }
-            }
-
-            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
-            {
-                cfg.CreateMap<Source, Destination>();
-                cfg.CreateMap<ChildSource, ChildDestination>();
-            });
-
-            protected override void Because_of()
-            {
-                _source = new Source
-                {
-                    Child = new ChildSource
-                    {
-                        Value = 20
-                    }
-                };
-                _originalDestChild = new ChildDestination
-                {
-                    Value = 10
-                };
-                _originalDest = new Destination
-                {
-                    Child = _originalDestChild
-                };
-                _dest = Mapper.Map(_source, _originalDest);
-            }
-
-            [Fact]
-            public void Should_return_the_destination_object_that_was_passed_in()
-            {
-                _dest.ShouldBeSameAs(_originalDest);
-                _dest.Child.ShouldBeSameAs(_originalDestChild);
-                _dest.Child.Value.ShouldBe(20);
-            }
+            public int Value { get; set; }
+            public string Name { get; set; }
+            public ChildDestination Child { get; set; }
         }
 
-
-        public class When_the_destination_object_is_specified_and_you_are_converting_an_enum : NonValidatingSpecBase
+        public class ChildSource
         {
-            private string _result;
+            public int Value { get; set; }
+        }
 
-            public enum SomeEnum
+        public class ChildDestination
+        {
+            public int Value { get; set; }
+            public string Name { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>(MemberList.Source)
+                .ForMember(d => d.Child, opt => opt.UseDestinationValue());
+            cfg.CreateMap<ChildSource, ChildDestination>(MemberList.Source)
+                .ForMember(d => d.Name, opt => opt.UseDestinationValue());
+        });
+
+        protected override void Because_of()
+        {
+            _source = new Source
             {
-                One,
-                Two,
-                Three
-            }
-
-            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => { });
-
-
-            protected override void Because_of()
+                Value = 10,
+                Child = new ChildSource
+                {
+                    Value = 20
+                }
+            };
+            _originalDest = new Destination
             {
-                _result = Mapper.Map<SomeEnum, string>(SomeEnum.Two, "test");
-            }
+                Value = 1111,
+                Name = "foo",
+                Child = new ChildDestination
+                {
+                    Name = "bar"
+                }
+            };
+            _dest = Mapper.Map<Source, Destination>(_source, _originalDest);
+        }
 
-            [Fact]
-            public void Should_return_the_enum_as_a_string()
+        [Fact]
+        public void Should_do_the_translation()
+        {
+            _dest.Value.ShouldBe(10);
+            _dest.Child.Value.ShouldBe(20);
+        }
+
+        [Fact]
+        public void Should_return_the_destination_object_that_was_passed_in()
+        {
+            _dest.Name.ShouldBe("foo");
+            _dest.Child.Name.ShouldBe("bar");
+        }
+    }
+
+    public class When_a_source_child_object_is_null : AutoMapperSpecBase
+    {
+        public class Source
+        {
+            public Child Child { get; set; }
+        }
+
+        public class Destination
+        {
+            public Child Child { get; set; } = new Child();
+        }
+
+        public class Child
+        {
+            public int Value { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>().ForMember(d=>d.Child, o=>o.MapAtRuntime());
+        });
+
+        [Fact]
+        public void Should_overwrite_the_existing_child_destination()
+        {
+            var destination = new Destination();
+            Mapper.Map(new Source(), destination);
+            destination.Child.ShouldBeNull();
+        }
+    }
+
+    public class When_the_destination_object_has_child_objects : AutoMapperSpecBase
+    {
+        private Source _source;
+        private Destination _originalDest;
+        private ChildDestination _originalDestChild;
+        private Destination _dest;
+
+        public class Source
+        {
+            public ChildSource Child { get; set; }
+        }
+
+        public class Destination
+        {
+            public ChildDestination Child { get; set; }
+        }
+
+        public class ChildSource
+        {
+            public int Value { get; set; }
+        }
+
+        public class ChildDestination
+        {
+            public int Value { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>();
+            cfg.CreateMap<ChildSource, ChildDestination>();
+        });
+
+        protected override void Because_of()
+        {
+            _source = new Source
             {
-                _result.ShouldBe("Two");
-            }
+                Child = new ChildSource
+                {
+                    Value = 20
+                }
+            };
+            _originalDestChild = new ChildDestination
+            {
+                Value = 10
+            };
+            _originalDest = new Destination
+            {
+                Child = _originalDestChild
+            };
+            _dest = Mapper.Map(_source, _originalDest);
+        }
+
+        [Fact]
+        public void Should_return_the_destination_object_that_was_passed_in()
+        {
+            _dest.ShouldBeSameAs(_originalDest);
+            _dest.Child.ShouldBeSameAs(_originalDestChild);
+            _dest.Child.Value.ShouldBe(20);
+        }
+    }
+
+
+    public class When_the_destination_object_is_specified_and_you_are_converting_an_enum : NonValidatingSpecBase
+    {
+        private string _result;
+
+        public enum SomeEnum
+        {
+            One,
+            Two,
+            Three
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => { });
+
+
+        protected override void Because_of()
+        {
+            _result = Mapper.Map<SomeEnum, string>(SomeEnum.Two, "test");
+        }
+
+        [Fact]
+        public void Should_return_the_enum_as_a_string()
+        {
+            _result.ShouldBe("Two");
         }
     }
 }

--- a/src/UnitTests/Mappers/CustomMapperTests.cs
+++ b/src/UnitTests/Mappers/CustomMapperTests.cs
@@ -146,7 +146,7 @@ namespace AutoMapper.UnitTests.Mappers
         {
             public override bool IsMatch(TypePair types)
             {
-                var underlyingType = Nullable.GetUnderlyingType(types.SourceType);
+                var underlyingType = Nullable.GetUnderlyingType(types.SourceType) ?? types.SourceType;
                 return underlyingType.IsEnum() && types.DestinationType == typeof(string);
             }
 

--- a/src/UnitTests/Mappers/StringDictionaryMapperTests.cs
+++ b/src/UnitTests/Mappers/StringDictionaryMapperTests.cs
@@ -133,6 +133,7 @@ namespace AutoMapper.UnitTests.Mappers
             public override int Y { get { return _y + 20; } }
             private int _z = 300;
             public int Z { get { return _z + 30; } }
+            public int Value { get; set; }
         }
 
         public class SomeOne : SomeBase
@@ -153,6 +154,34 @@ namespace AutoMapper.UnitTests.Mappers
             var someOne = new StringDictionary();
 
             Mapper.Map(someOne, someBase);
+        }
+
+        public class Destination
+        {
+            public DateTime? NullableDate { get; set; }
+            public int? NullableInt { get; set; }
+            public int Int { get; set; }
+            public SomeBody SomeBody { get; set; } = new SomeBody { Value = 15 };
+        }
+
+        [Fact]
+        public void Should_override_existing_values()
+        {
+            var source = new StringDictionary();
+            source["Int"] = 10;
+            source["NullableDate"] = null;
+            source["NullableInt"] = null;
+            source["SomeBody"] = new SomeOne();
+            var destination = new Destination { NullableInt = 1, NullableDate = DateTime.Now };
+            var someBody = destination.SomeBody;
+
+            Mapper.Map(source, destination);
+
+            destination.Int.ShouldBe(10);
+            destination.NullableInt.ShouldBeNull();
+            destination.NullableDate.ShouldBeNull();
+            destination.SomeBody.ShouldBe(someBody);
+            destination.SomeBody.Value.ShouldBe(15);
         }
     }
 

--- a/src/UnitTests/Mappers/StringDictionaryMapperTests.cs
+++ b/src/UnitTests/Mappers/StringDictionaryMapperTests.cs
@@ -162,6 +162,8 @@ namespace AutoMapper.UnitTests.Mappers
             public int? NullableInt { get; set; }
             public int Int { get; set; }
             public SomeBody SomeBody { get; set; } = new SomeBody { Value = 15 };
+            public SomeOne SomeOne { get; set; } = new SomeOne();
+            public string String { get; set; } = "value";
         }
 
         [Fact]
@@ -171,7 +173,9 @@ namespace AutoMapper.UnitTests.Mappers
             source["Int"] = 10;
             source["NullableDate"] = null;
             source["NullableInt"] = null;
+            source["String"] = null;
             source["SomeBody"] = new SomeOne();
+            source["SomeOne"] = null;
             var destination = new Destination { NullableInt = 1, NullableDate = DateTime.Now };
             var someBody = destination.SomeBody;
 
@@ -182,6 +186,8 @@ namespace AutoMapper.UnitTests.Mappers
             destination.NullableDate.ShouldBeNull();
             destination.SomeBody.ShouldBe(someBody);
             destination.SomeBody.Value.ShouldBe(15);
+            destination.String.ShouldBeNull();
+            destination.SomeOne.ShouldBeNull();
         }
     }
 

--- a/src/UnitTests/NullBehavior.cs
+++ b/src/UnitTests/NullBehavior.cs
@@ -8,6 +8,27 @@ using System;
 
 namespace AutoMapper.UnitTests.NullBehavior
 {
+    public class When_mappping_null_array_to_IEnumerable_with_MapAtRuntime : AutoMapperSpecBase
+    {
+        class Source
+        {
+            public int[] Collection { get; set; }
+        }
+
+        class Destination
+        {
+            public IEnumerable<int> Collection { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg => cfg.CreateMap<Source, Destination>().ForMember(d=>d.Collection, o=>o.MapAtRuntime()));
+
+        [Fact]
+        public void Should_map_to_non_null()
+        {
+            Mapper.Map<Destination>(new Source()).Collection.ShouldNotBeNull();
+        }
+    }
+
     public class When_mappping_null_array_to_IEnumerable : AutoMapperSpecBase
     {
         class Source
@@ -690,6 +711,89 @@ namespace AutoMapper.UnitTests.NullBehavior
         public void Should_allow_null_collections()
         {
             _dest.Values6.ShouldBeNull();
+        }
+    }
+
+    public class When_overriding_collection_null_behavior_in_profile_with_MapAtRuntime : AutoMapperSpecBase
+    {
+        private Dest _dest;
+
+        public class Source
+        {
+            public IEnumerable<int> Values1 { get; set; }
+            public List<int> Values2 { get; set; }
+            public Dictionary<string, int> Values3 { get; set; }
+            public int[] Values4 { get; set; }
+            public ReadOnlyCollection<int> Values5 { get; set; }
+            public Collection<int> Values6 { get; set; }
+            public int[,] Values7 { get; set; }
+        }
+
+        public class Dest
+        {
+            public IEnumerable<int> Values1 { get; set; }
+            public List<int> Values2 { get; set; }
+            public Dictionary<string, int> Values3 { get; set; }
+            public int[] Values4 { get; set; }
+            public ReadOnlyCollection<int> Values5 { get; set; }
+            public Collection<int> Values6 { get; set; }
+            public int[,] Values7 { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateProfile("MyProfile", p =>
+            {
+                p.CreateMap<Source, Dest>().ForAllMembers(o=>o.MapAtRuntime());
+                p.AllowNullCollections = true;
+            });
+        });
+
+        protected override void Because_of()
+        {
+            _dest = Mapper.Map<Source, Dest>(new Source());
+        }
+
+        [Fact]
+        public void Should_allow_null_ienumerables()
+        {
+            _dest.Values1.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Should_allow_null_lists()
+        {
+            _dest.Values2.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Should_allow_null_dictionaries()
+        {
+            _dest.Values3.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Should_allow_null_arrays()
+        {
+            _dest.Values4.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Should_allow_null_read_only_collections()
+        {
+            _dest.Values5.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Should_allow_null_collections()
+        {
+            _dest.Values6.ShouldBeNull();
+        }
+
+        [Fact]
+        public void Should_allow_null_multidimensional_arrays()
+        {
+            _dest.Values7.ShouldBeNull();
         }
     }
 


### PR DESCRIPTION
Fixes #2466.
The diff for FillingExistingDestination.cs is mostly whitespace. The new test is at the top.
If I change the default for Inline in PropertyMap, all tests pass, except the one assuming the default is true.