### PR TITLE
Update copy of NeinLinq.NullsafeQueryRewriter

### DIFF
--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -342,63 +342,129 @@ namespace AutoMapper.QueryableExtensions
         /// Expression visitor for making member access null-safe.
         /// </summary>
         /// <remarks>
-        /// Use <see cref="NullsafeQueryRewriter" /> to make a query null-safe.
-        /// copied from NeinLinq (MIT License): https://github.com/axelheer/nein-linq/blob/master/src/NeinLinq/NullsafeQueryRewriter.cs
+        /// Copied from NeinLinq (MIT License): https://github.com/axelheer/nein-linq/blob/master/src/NeinLinq/NullsafeQueryRewriter.cs
         /// </remarks>
         internal class NullsafeQueryRewriter : ExpressionVisitor
         {
-            static readonly LockingConcurrentDictionary<Type, Expression> Cache = new LockingConcurrentDictionary<Type, Expression>(NodeFallback);
+            static readonly LockingConcurrentDictionary<Type, Expression> Cache = new LockingConcurrentDictionary<Type, Expression>(Fallback);
 
             /// <inheritdoc />
-            protected override Expression VisitMember(MemberExpression node) => 
-                node?.Expression != null
-                    ? MakeNullsafe(node, node.Expression)
-                    : base.VisitMember(node);
-
-            /// <inheritdoc />
-            protected override Expression VisitMethodCall(MethodCallExpression node) => 
-                node?.Object != null 
-                    ? MakeNullsafe(node, node.Object) 
-                    : base.VisitMethodCall(node);
-
-            private Expression MakeNullsafe(Expression node, Expression value)
+            protected override Expression VisitMember(MemberExpression node)
             {
-                // cache "fallback expression" for performance reasons
-                var fallback = Cache.GetOrAdd(node.Type);
+                if (node == null)
+                    throw new ArgumentNullException(nameof(node));
 
-                // check value and insert additional coalesce, if fallback is not default
-                return Condition(
-                    NotEqual(Visit(value), Default(value.Type)),
-                    fallback.NodeType != ExpressionType.Default ? Coalesce(node, fallback) : node,
-                    fallback);
+                var target = Visit(node.Expression);
+
+                if (!IsSafe(target))
+                {
+                    // insert null-check before accessing property or field
+                    return BeSafe(target, node, node.Update);
+                }
+
+                return node.Update(target);
             }
 
-            private static Expression NodeFallback(Type type)
+            /// <inheritdoc />
+            protected override Expression VisitMethodCall(MethodCallExpression node)
+            {
+                if (node == null)
+                    throw new ArgumentNullException(nameof(node));
+
+                var target = Visit(node.Object);
+
+                if (!IsSafe(target))
+                {
+                    // insert null-check before invoking instance method
+                    return BeSafe(target, node, fallback => node.Update(fallback, node.Arguments));
+                }
+
+                var arguments = Visit(node.Arguments);
+
+                if (IsExtensionMethod(node.Method) && !IsSafe(arguments[0]))
+                {
+                    // insert null-check before invoking extension method
+                    return BeSafe(arguments[0], node.Update(null, arguments), fallback =>
+                    {
+                        var args = new Expression[arguments.Count];
+                        arguments.CopyTo(args, 0);
+                        args[0] = fallback;
+
+                        return node.Update(null, args);
+                    });
+                }
+
+                return node.Update(target, arguments);
+            }
+
+            static Expression BeSafe(Expression target, Expression expression, Func<Expression, Expression> update)
+            {
+                var fallback = Cache.GetOrAdd(target.Type);
+
+                if (fallback != null)
+                {
+                    // coalesce instead, a bit intrusive but fast...
+                    return update(Expression.Coalesce(target, fallback));
+                }
+
+                // target can be null, which is why we are actually here...
+                var targetFallback = Expression.Constant(null, target.Type);
+
+                // expression can be default or null, which is basically the same...
+                var expressionFallback = !IsNullableOrReferenceType(expression.Type)
+                    ? (Expression)Expression.Default(expression.Type) : Expression.Constant(null, expression.Type);
+
+                return Expression.Condition(Expression.Equal(target, targetFallback), expressionFallback, expression);
+            }
+
+            static bool IsSafe(Expression expression)
+            {
+                // in method call results and constant values we trust to avoid too much conditions...
+                return expression == null
+                    || expression.NodeType == ExpressionType.Call
+                    || expression.NodeType == ExpressionType.Constant
+                    || !IsNullableOrReferenceType(expression.Type);
+            }
+
+            static Expression Fallback(Type type)
             {
                 // default values for generic collections
                 if (type.GetIsConstructedGenericType() && type.GetTypeInfo().GenericTypeArguments.Length == 1)
                 {
-                    return GenericCollectionFallback(typeof(List<>), type)
-                        ?? GenericCollectionFallback(typeof(HashSet<>), type)
-                        ?? Default(type);
+                    return CollectionFallback(typeof(List<>), type)
+                        ?? CollectionFallback(typeof(HashSet<>), type);
                 }
 
                 // default value for arrays
                 if (type.IsArray)
                 {
-                    return NewArrayInit(type.GetElementType());
+                    return Expression.NewArrayInit(type.GetElementType());
                 }
 
-                // default value
-                return Default(type);
+                return null;
             }
 
-            private static Expression GenericCollectionFallback(Type collectionDefinition, Type type)
+            static Expression CollectionFallback(Type definition, Type type)
             {
-                var collectionType = collectionDefinition.MakeGenericType(type.GetTypeInfo().GenericTypeArguments);
+                var collection = definition.MakeGenericType(type.GetTypeInfo().GenericTypeArguments);
 
                 // try if an instance of this collection would suffice
-                return type.GetTypeInfo().IsAssignableFrom(collectionType.GetTypeInfo()) ? Convert(New(collectionType), type) : null;
+                if (type.GetTypeInfo().IsAssignableFrom(collection.GetTypeInfo()))
+                {
+                    return Expression.Convert(Expression.New(collection), type);
+                }
+
+                return null;
+            }
+
+            static bool IsExtensionMethod(MethodInfo element)
+            {
+                return element.IsDefined(typeof(ExtensionAttribute), false);
+            }
+
+            static bool IsNullableOrReferenceType(Type type)
+            {
+                return !type.GetTypeInfo().IsValueType || Nullable.GetUnderlyingType(type) != null;
             }
         }
 


### PR DESCRIPTION
I don't know how to correctly cite a license (#2235), but I can provide the current (improved) code.

It now (since Jan 2017, actually) only inserts a null-check, if some access isn't safe, and not in every possible spot like a madman. Thus, it just produces much less overhead.

I just copied the code (again), used your `LockingConcurrentDictionary`, switched to some reflection extensions (.NET 4.0?), and checked if all the tests still went green (they did).