### PR TITLE
added Is Initialized method

### DIFF
--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -194,12 +194,11 @@ namespace AutoMapper
         public ResolutionContext DefaultContext { get; }
 
         /// <summary>
-        /// Returns true if mapper is initialized, else false
+        /// Returns true if mapper is initialized else false
         /// Code taken directly from AutoMapper source code:
         /// <code>
         ///     configuration ?? throw new InvalidOperationException(InvalidOperationMessage)
         /// </code>
-        /// <see href="https://github.com/AutoMapper/AutoMapper/blob/894412e72e98cb0d6da957b5a5be52f888fc6cd5/src/AutoMapper/Mapper.cs#L23" />
         /// </summary>
         /// <param name="mapper"></param>
         /// <returns></returns>

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -200,8 +200,7 @@ namespace AutoMapper
         ///     configuration ?? throw new InvalidOperationException(InvalidOperationMessage)
         /// </code>
         /// </summary>
-        /// <param name="mapper"></param>
-        /// <returns></returns>
+        /// <returns>True if mapper instance is initialized else false</returns>
         public bool IsInitialized()
         {
             return _configuration != null;

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -193,6 +193,21 @@ namespace AutoMapper
 
         public ResolutionContext DefaultContext { get; }
 
+        /// <summary>
+        /// Returns true if mapper is initialized, else false
+        /// Code taken directly from AutoMapper source code:
+        /// <code>
+        ///     configuration ?? throw new InvalidOperationException(InvalidOperationMessage)
+        /// </code>
+        /// <see href="https://github.com/AutoMapper/AutoMapper/blob/894412e72e98cb0d6da957b5a5be52f888fc6cd5/src/AutoMapper/Mapper.cs#L23" />
+        /// </summary>
+        /// <param name="mapper"></param>
+        /// <returns></returns>
+        public bool IsInitialized()
+        {
+            return _configuration != null;
+        }
+
         Func<Type, object> IMapper.ServiceCtor => _serviceCtor;
 
         IConfigurationProvider IMapper.ConfigurationProvider => _configurationProvider;


### PR DESCRIPTION
I think AutoMapper really needs this method because currently the only way to tests whether if AutoMapper instance is initialized is to try to access Configuration and if we get an exception then it is not initialized.