### PR TITLE
Simple object mapper : When the destination object is null, it can be useful to know its type

### DIFF
--- a/src/AutoMapper/IObjectMapper.cs
+++ b/src/AutoMapper/IObjectMapper.cs
@@ -4,6 +4,7 @@ using AutoMapper.Internal;
 
 namespace AutoMapper
 {
+    using System;
     using static Expression;
     using static ExpressionFactory;
 
@@ -53,9 +54,11 @@ namespace AutoMapper
         /// </summary>
         /// <param name="source">Source object</param>
         /// <param name="destination">Destination object</param>
+        /// <param name="sourceType">The compile time type of the source object</param>
+        /// <param name="destinationType">The compile time type of the destination object</param>
         /// <param name="context">Resolution context</param>
         /// <returns>Destination object</returns>
-        public abstract TDestination Map(TSource source, TDestination destination, ResolutionContext context);
+        public abstract TDestination Map(TSource source, TDestination destination, Type sourceType, Type destinationType, ResolutionContext context);
 
         public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap,
             PropertyMap propertyMap, Expression sourceExpression, Expression destExpression,
@@ -65,6 +68,8 @@ namespace AutoMapper
                 MapMethod,
                 ToType(sourceExpression, typeof(TSource)),
                 ToType(destExpression, typeof(TDestination)),
+                Constant(sourceExpression.Type),
+                Constant(destExpression.Type),
                 contextExpression);
     }
 }

--- a/src/UnitTests/Mappers/CustomMapperTests.cs
+++ b/src/UnitTests/Mappers/CustomMapperTests.cs
@@ -93,11 +93,13 @@ namespace AutoMapper.UnitTests.Mappers
         {
             public static DestinationType Instance = new DestinationType();
 
-            public override DestinationType Map(SourceType source, DestinationType destination, ResolutionContext context)
+            public override DestinationType Map(SourceType source, DestinationType destination, Type sourceType, Type destinationType, ResolutionContext context)
             {
                 source.ShouldNotBeNull();
                 destination.ShouldNotBeNull();
                 context.ShouldNotBeNull();
+                sourceType.ShouldBe(typeof(SourceType));
+                destinationType.ShouldBe(typeof(DestinationType));
                 return Instance;
             }
 
@@ -150,8 +152,10 @@ namespace AutoMapper.UnitTests.Mappers
                 return underlyingType.IsEnum() && types.DestinationType == typeof(string);
             }
 
-            public override string Map(object source, string destination, ResolutionContext context)
+            public override string Map(object source, string destination, Type sourceType, Type destinationType, ResolutionContext context)
             {
+                sourceType.ShouldBe(typeof(ConsoleColor?));
+                destinationType.ShouldBe(typeof(string));
                 return "Test";
             }
         }


### PR DESCRIPTION
A breaking change, but it seems harmless.