### PR TITLE
#2520 - Fixed Effort- and ODataQueryTests and a bug in ExpressionVisitor 

### DIFF
--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -93,11 +93,14 @@ namespace AutoMapper.Mappers
 
                 // check if the non-string expression is a null constent
                 // as this would lead to a "null.ToString()" and thus an error when executing the expression
-                var isNullConstant = new Func<Expression, bool>(xpr => xpr is ConstantExpression c && c.Value == null);
+                bool IsNullConstant(Expression xpr)
+                {
+                    return xpr is ConstantExpression c && c.Value == null;
+                }
 
-                if (newLeft.Type != newRight.Type && newRight.Type == typeof(string) && !isNullConstant(newLeft))
+                if (newLeft.Type != newRight.Type && newRight.Type == typeof(string) && !IsNullConstant(newLeft))
                     newLeft = Call(newLeft, typeof(object).GetDeclaredMethod("ToString"));
-                if (newRight.Type != newLeft.Type && newLeft.Type == typeof(string) && !isNullConstant(newRight))
+                if (newRight.Type != newLeft.Type && newLeft.Type == typeof(string) && !IsNullConstant(newRight))
                     newRight = Call(newRight, typeof(object).GetDeclaredMethod("ToString"));
                 CheckNullableToNonNullableChanges(node.Left, node.Right, ref newLeft, ref newRight);
                 CheckNullableToNonNullableChanges(node.Right, node.Left, ref newRight, ref newLeft);

--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -91,9 +91,13 @@ namespace AutoMapper.Mappers
                 var newLeft = Visit(node.Left);
                 var newRight = Visit(node.Right);
 
-                if (newLeft.Type != newRight.Type && newRight.Type == typeof(string))
+                // check if the non-string expression is a null constent
+                // as this would lead to a "null.ToString()" and thus an error when executing the expression
+                var isNullConstant = new Func<Expression, bool>(xpr => xpr is ConstantExpression c && c.Value == null);
+
+                if (newLeft.Type != newRight.Type && newRight.Type == typeof(string) && !isNullConstant(newLeft))
                     newLeft = Call(newLeft, typeof(object).GetDeclaredMethod("ToString"));
-                if (newRight.Type != newLeft.Type && newLeft.Type == typeof(string))
+                if (newRight.Type != newLeft.Type && newLeft.Type == typeof(string) && !isNullConstant(newRight))
                     newRight = Call(newRight, typeof(object).GetDeclaredMethod("ToString"));
                 CheckNullableToNonNullableChanges(node.Left, node.Right, ref newLeft, ref newRight);
                 CheckNullableToNonNullableChanges(node.Right, node.Left, ref newRight, ref newLeft);

--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -93,11 +93,6 @@ namespace AutoMapper.Mappers
 
                 // check if the non-string expression is a null constent
                 // as this would lead to a "null.ToString()" and thus an error when executing the expression
-                bool IsNullConstant(Expression xpr)
-                {
-                    return xpr is ConstantExpression c && c.Value == null;
-                }
-
                 if (newLeft.Type != newRight.Type && newRight.Type == typeof(string) && !IsNullConstant(newLeft))
                     newLeft = Call(newLeft, typeof(object).GetDeclaredMethod("ToString"));
                 if (newRight.Type != newLeft.Type && newLeft.Type == typeof(string) && !IsNullConstant(newRight))
@@ -105,6 +100,7 @@ namespace AutoMapper.Mappers
                 CheckNullableToNonNullableChanges(node.Left, node.Right, ref newLeft, ref newRight);
                 CheckNullableToNonNullableChanges(node.Right, node.Left, ref newRight, ref newLeft);
                 return MakeBinary(node.NodeType, newLeft, newRight);
+                bool IsNullConstant(Expression expression) => expression is ConstantExpression constant && constant.Value == null;
             }
 
             private static void CheckNullableToNonNullableChanges(Expression left, Expression right, ref Expression newLeft, ref Expression newRight)

--- a/src/AutoMapperSamples.OData/ODataQueryTests.cs
+++ b/src/AutoMapperSamples.OData/ODataQueryTests.cs
@@ -35,7 +35,7 @@ namespace AutoMapperSamples.OData
             // Start OWIN host 
             _webApp = WebApp.Start<Startup>(url: _baseAddress);
         }
-        
+
         [TearDown]
         public virtual void TearDown()
         {
@@ -325,7 +325,7 @@ namespace AutoMapperSamples.OData
 
             // Act
             var response = client.GetAsync(_baseAddress + "api/Orders?$filter=OrderDate gt DateTime'2015-02-01T00:00:00'").Result;
-            
+
             // Assert
             Console.WriteLine(response);
             Console.WriteLine(response.Content.ReadAsStringAsync().Result);


### PR DESCRIPTION
Fix for #2520

The ExpressionMapper has the following bug.
In ExpressionMapper.VisitBinary, it compares the types of the two expressions.
If one is of type string and the other is not, it adds a "ToString()" to the expression.

However, it does not check for the "null Constant".

Therefore, the OData query of ODataQueryTests.CanFilter_FullNameEndsWith converts the following DTO expression:

```

.Call System.Linq.Queryable.Where(
    .Call System.Linq.Queryable.OrderBy(
        .Constant<System.Linq.EnumerableQuery`1[AutoMapperSamples.EF.Dtos.OrderDto]>(AutoMapperSamples.EF.Dtos.OrderDto[]),
        '(.Lambda #Lambda1<System.Func`2[AutoMapperSamples.EF.Dtos.OrderDto,System.Double]>)),
    '(.Lambda #Lambda2<System.Func`2[AutoMapperSamples.EF.Dtos.OrderDto,System.Boolean]>))

.Lambda #Lambda1<System.Func`2[AutoMapperSamples.EF.Dtos.OrderDto,System.Double]>(AutoMapperSamples.EF.Dtos.OrderDto $o) {
    $o.Price
}

.Lambda #Lambda2<System.Func`2[AutoMapperSamples.EF.Dtos.OrderDto,System.Boolean]>(AutoMapperSamples.EF.Dtos.OrderDto $$it)
{
    .If (
        $$it.FullName == null || .Constant<System.Web.Http.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.String]>(System.Web.Http.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.String]).TypedProperty ==
        null
    ) {
        null
    } .Else {
        (System.Nullable`1[System.Boolean]).Call ($$it.FullName).EndsWith(.Constant<System.Web.Http.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.String]>(System.Web.Http.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.String]).TypedProperty)
    } == .Constant<System.Nullable`1[System.Boolean]>(True)
}
```


to the following Entity expression:

```

.Call System.Linq.Queryable.Where(
    .Call System.Linq.Queryable.OrderBy(
        .Call (.Call .Constant<System.Data.Entity.Core.Objects.ObjectQuery`1[AutoMapperSamples.EF.Model.Order]>(System.Data.Entity.Core.Objects.ObjectQuery`1[AutoMapperSamples.EF.Model.Order]).MergeAs(.Constant<System.Data.Entity.Core.Objects.MergeOption>(AppendOnly))
        ).IncludeSpan(.Constant<System.Data.Entity.Core.Objects.Span>(System.Data.Entity.Core.Objects.Span)),
        '(.Lambda #Lambda1<System.Func`2[AutoMapperSamples.EF.Model.Order,System.Double]>)),
    '(.Lambda #Lambda2<System.Func`2[AutoMapperSamples.EF.Model.Order,System.Boolean]>))

.Lambda #Lambda1<System.Func`2[AutoMapperSamples.EF.Model.Order,System.Double]>(AutoMapperSamples.EF.Model.Order $o) {
    $o.Price
}

.Lambda #Lambda2<System.Func`2[AutoMapperSamples.EF.Model.Order,System.Boolean]>(AutoMapperSamples.EF.Model.Order $$it) {
    .If (
        $$it.Name == .Call null.ToString() || .Constant<System.Web.Http.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.String]>(System.Web.Http.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.String]).TypedProperty ==
        .Call null.ToString()
    ) {
        null
    } .Else {
        (System.Nullable`1[System.Boolean]).Call ($$it.Name).EndsWith(.Constant<System.Web.Http.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.String]>(System.Web.Http.OData.Query.Expressions.LinqParameterContainer+TypedLinqParameterContainer`1[System.String]).TypedProperty)
    } == .Constant<System.Nullable`1[System.Boolean]>(True)
}
```

As you can see, the Entity expression contains a ".Call null.ToString()" which results in an InvalidOperationException in EntityFramework.