### PR TITLE
2. Try - Added type convertion on expression projection

### DIFF
--- a/src/AutoMapper/Internal/ReflectionHelper.cs
+++ b/src/AutoMapper/Internal/ReflectionHelper.cs
@@ -187,8 +187,11 @@ namespace AutoMapper.Internal
             var simpleConvertToType = convertTo.IsNullableType() ? convertTo.GetTypeOfNullable() : convertTo;
 
             return simpleFromType.GetDeclaredMethods().Any(x => (x.Name == "op_Explicit" || x.Name == "op_Implicit")
-                && x.ReturnType == simpleConvertToType
-                && x.GetParameters().First().ParameterType == simpleFromType);
+                    && x.ReturnType == simpleConvertToType
+                    && x.GetParameters().First().ParameterType == simpleFromType)
+                || simpleConvertToType.GetDeclaredMethods().Any(x => (x.Name == "op_Explicit" || x.Name == "op_Implicit")
+                    && x.ReturnType == simpleConvertToType
+                    && x.GetParameters().First().ParameterType == simpleFromType);
         }
     }
 }

--- a/src/AutoMapper/Internal/ReflectionHelper.cs
+++ b/src/AutoMapper/Internal/ReflectionHelper.cs
@@ -180,5 +180,15 @@ namespace AutoMapper.Internal
 
             return targetType;
         }
+
+        public static bool CanImplicitConvert(this Type convertFrom, Type convertTo)
+        {
+            var simpleFromType = convertFrom.IsNullableType() ? convertFrom.GetTypeOfNullable() : convertFrom;
+            var simpleConvertToType = convertTo.IsNullableType() ? convertTo.GetTypeOfNullable() : convertTo;
+
+            return simpleFromType.GetDeclaredMethods().Any(x => (x.Name == "op_Explicit" || x.Name == "op_Implicit")
+                && x.ReturnType == simpleConvertToType
+                && x.GetParameters().First().ParameterType == simpleFromType);
+        }
     }
 }

--- a/src/AutoMapper/Mappers/ExpressionMapper.cs
+++ b/src/AutoMapper/Mappers/ExpressionMapper.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using AutoMapper.Configuration;
+using AutoMapper.Internal;
 using AutoMapper.XpressionMapper.Extensions;
 using static System.Linq.Expressions.Expression;
 
@@ -209,7 +210,12 @@ namespace AutoMapper.Mappers
                     replacedExpression = _parentMappingVisitor.Visit(node.Expression);
 
                 if (propertyMap.CustomExpression != null)
-                    return propertyMap.CustomExpression.ReplaceParameters(replacedExpression);
+				{
+					replacedExpression = propertyMap.CustomExpression.ReplaceParameters(replacedExpression);
+					replacedExpression = ExpressionFactory.ToType(replacedExpression, node.Type);
+					
+					return replacedExpression;
+				}
 
                 Func<Expression, MemberInfo, Expression> getExpression = MakeMemberAccess;
 

--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -37,10 +37,10 @@ namespace AutoMapper.QueryableExtensions
             new NullableDestinationExpressionBinder(),
             new NullableSourceExpressionBinder(),
             new AssignableExpressionBinder(),
-            new ImplicitAssignableExpressionBinder(),
             new EnumerableExpressionBinder(),
             new MappedTypeExpressionBinder(),
-            new StringExpressionBinder()
+            new StringExpressionBinder(),
+            new ImplicitAssignableExpressionBinder()
         };
 
         private readonly LockingConcurrentDictionary<ExpressionRequest, LambdaExpression[]> _expressionCache;

--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -37,6 +37,7 @@ namespace AutoMapper.QueryableExtensions
             new NullableDestinationExpressionBinder(),
             new NullableSourceExpressionBinder(),
             new AssignableExpressionBinder(),
+            new ImplicitAssignableExpressionBinder(),
             new EnumerableExpressionBinder(),
             new MappedTypeExpressionBinder(),
             new StringExpressionBinder()

--- a/src/AutoMapper/QueryableExtensions/Impl/ImplicitAssignableExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/ImplicitAssignableExpressionBinder.cs
@@ -1,0 +1,18 @@
+using AutoMapper.Internal;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace AutoMapper.QueryableExtensions.Impl
+{
+    public class ImplicitAssignableExpressionBinder : IExpressionBinder
+    {
+        public bool IsMatch(PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionResolutionResult result) 
+            => propertyMap.DestinationPropertyType.CanImplicitConvert(result.Type) && propertyTypeMap == null;
+
+        public MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, IDictionary<ExpressionRequest, int> typePairCount, LetPropertyMaps letPropertyMaps) 
+            => BindAssignableExpression(propertyMap, result);
+
+        private static MemberAssignment BindAssignableExpression(PropertyMap propertyMap, ExpressionResolutionResult result) 
+            => Expression.Bind(propertyMap.DestinationProperty, Expression.Convert(result.ResolutionExpression, propertyMap.DestinationPropertyType));
+    }
+}

--- a/src/AutoMapper/QueryableExtensions/Impl/SourceInjectedQueryProvider.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/SourceInjectedQueryProvider.cs
@@ -91,7 +91,9 @@ namespace AutoMapper.QueryableExtensions.Impl
                     var sourceResult = _dataSource.Provider.CreateQuery(sourceExpression);
                     Inspector.SourceResult(sourceExpression, sourceResult);
 
-                    destResult = new ProjectionExpression((IQueryable<TSource>)sourceResult, _mapper.ConfigurationProvider.ExpressionBuilder).To<TDestination>(_parameters, _membersToExpand);
+                    destResult = sourceResult.ElementType == typeof(TDestination)
+                        ? sourceResult
+                        : new ProjectionExpression((IQueryable<TSource>)sourceResult, _mapper.ConfigurationProvider.ExpressionBuilder).To<TDestination>(_parameters, _membersToExpand);
                 }
                 // case #2: query is arbitrary ("manual") projection
                 // exaple: users.UseAsDataSource().For<UserDto>().Select(user => user.Age).ToList()

--- a/src/IntegrationTests/AutoMapper.IntegrationTests.csproj
+++ b/src/IntegrationTests/AutoMapper.IntegrationTests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="FakeItEasy" Version="3.4.2" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="EntityFramework" Version="6.1.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/src/UnitTests/AutoMapper.UnitTests.csproj
+++ b/src/UnitTests/AutoMapper.UnitTests.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0-preview-20170810-02" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.0.0" />
     <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
     <PackageReference Include="System.Data.Common" Version="4.3.0" />

--- a/src/UnitTests/Internal/ReflectionHelperTests.cs
+++ b/src/UnitTests/Internal/ReflectionHelperTests.cs
@@ -1,0 +1,107 @@
+﻿
+
+namespace AutoMapper.UnitTests.Internal
+{
+    using AutoMapper.Internal;
+    using System.Collections.Generic;
+    using Xunit;
+
+    public class ReflectionHelperTests
+    {
+        [Fact]
+        public void IListOfString_is_assignable_from_ListOfString()
+        {
+            IList<string> list = new List<string>();
+            //Assert
+            Assert.True(typeof(List<string>).CanImplicitConvert(typeof(IList<string>)));
+        }
+
+        [Fact]
+        public void Int_is_assignable_from_short()
+        {
+            int i = (short)0;
+            //Assert
+            Assert.True(typeof(short).CanImplicitConvert(typeof(int)));
+        }
+
+        [Fact]
+        public void Nullable_custom_string_is_assignable_from_custom_string()
+        {
+            CustString? ss = new CustString("");
+            //Assert
+            Assert.True(typeof(CustString).CanImplicitConvert(typeof(CustString?)));
+        }
+
+        [Fact]
+        public void Nullable_int_digit_is_assignable_from_short()
+        {
+            IntDigit? i = (short)0;
+            //Assert
+            Assert.True(typeof(short).CanImplicitConvert(typeof(IntDigit?)));
+        }
+
+        [Fact]
+        public void Nullable_int_is_assignable_from_int()
+        {
+            int? i = int.MaxValue;
+            //Assert
+            Assert.True(typeof(int).CanImplicitConvert(typeof(int?)));
+        }
+        
+        [Fact]
+        public void Nullable_int_is_assignable_from_nullable_short()
+        {
+            int? i = new short?();
+            //Assert
+            Assert.True(typeof(short?).CanImplicitConvert(typeof(int?)));
+        }
+
+        [Fact]
+        public void Nullable_int_is_assignable_from_short()
+        {
+            int? i = (short)0;
+            //Assert
+            Assert.True(typeof(short).CanImplicitConvert(typeof(int?)));
+        }
+
+        [Fact]
+        public void Short_is_assignable_from_sbyte()
+        {
+            short s = (sbyte)0;
+            //Assert
+            Assert.True(typeof(sbyte).CanImplicitConvert(typeof(short)));
+        }
+
+        public struct CustString
+        {
+            public CustString(string i) { val = i; }
+            public string val;
+
+            public static implicit operator string(CustString i)
+            {
+                return i.val;
+            }
+
+            public static implicit operator CustString(string i)
+            {
+                return new CustString(i);
+            }
+        }
+
+        public struct IntDigit
+        {
+            public IntDigit(int i) { val = i; }
+            public int val;
+
+            public static implicit operator int(IntDigit i)
+            {
+                return i.val;
+            }
+
+            public static implicit operator IntDigit(int i)
+            {
+                return new IntDigit(i);
+            }
+        }
+    }
+}

--- a/src/UnitTests/Projection/NestedAndArraysTests.cs
+++ b/src/UnitTests/Projection/NestedAndArraysTests.cs
@@ -60,10 +60,16 @@
                 {
                     EntityID = 1,
                     SubEntities =
-                                     {
-                                         new SubEntity {Name = "First", Description = "First Description"},
-                                         new SubEntity {Name = "Second", Description = "First Description"},
-                                     },
+                    {
+                        new SubEntity {
+                            Name = "First",
+                            Description = "First Description"
+                        },
+                        new SubEntity {
+                            Name = "Second",
+                            Description = "First Description"
+                        },
+                    },
                     Title = "Entities"
                 };
 

--- a/src/UnitTests/Query/SourceInjectedQuery.cs
+++ b/src/UnitTests/Query/SourceInjectedQuery.cs
@@ -489,6 +489,33 @@ namespace AutoMapper.UnitTests.Query
         }
 
         [Fact]
+        public void Project_from_custom_struct_first()
+        {
+            // Arrange
+            var config = new MapperConfiguration(c =>
+            {
+                c.CreateMap<CustomMaster, MasterDto>()
+                    .ReverseMap();
+            });
+
+            config.AssertConfigurationIsValid();
+
+            var mapper = config.CreateMapper();
+
+            var source = new List<CustomMaster> {
+                new CustomMaster { Id = Guid.NewGuid(), Name = "Harry Marry" }
+            };
+
+            // Act
+            var masterDtoQuery = source.AsQueryable().UseAsDataSource(mapper)
+                .For<MasterDto>()
+                .First(d => d.Name == "Harry Marry");
+
+            // Assert
+            masterDtoQuery.Name.ShouldBe("Harry Marry");
+        }
+
+        [Fact]
         public void Project_from_custom_struct_with_projection()
         {
             // Arrange
@@ -1091,6 +1118,7 @@ namespace AutoMapper.UnitTests.Query
         }
         public Guid Id { get; set; }
         public string Name { get; set; }
+        
         public ICollection<Detail> Details { get; set; }
     }
 
@@ -1105,6 +1133,8 @@ namespace AutoMapper.UnitTests.Query
     {
         public Guid Id { get; set; }
         public string Name { get; set; }
+        public int Number { get; set; }
+        public int? NullableNumber { get; set; }
     }
 
     public class DetailDto
@@ -1174,6 +1204,24 @@ namespace AutoMapper.UnitTests.Query
     {
         public Guid Id { get; set; }
         public CustomString Name { get; set; }
+        public CustomDigit Number { get; set; }
+        public CustomDigit? NullableNumber { get; set; }
+    }
+
+    public struct CustomDigit
+    {
+        public CustomDigit(int i) { val = i; }
+        public int val;
+
+        public static implicit operator int(CustomDigit i)
+        {
+            return i.val;
+        }
+
+        public static implicit operator CustomDigit(int i)
+        {
+            return new CustomDigit(i);
+        }
     }
 
     public struct CustomString : IComparable, IConvertible

--- a/src/UnitTests/Query/SourceInjectedQuery.cs
+++ b/src/UnitTests/Query/SourceInjectedQuery.cs
@@ -651,6 +651,35 @@ namespace AutoMapper.UnitTests.Query
         }
 
         [Fact]
+        public void Project_from_custom_struct_orderby()
+        {
+            // Arrange
+            var config = new MapperConfiguration(c =>
+            {
+                c.CreateMap<CustomMaster, MasterDto>()
+                    .ReverseMap();
+            });
+
+            config.AssertConfigurationIsValid();
+
+            var mapper = config.CreateMapper();
+
+            var source = new List<CustomMaster> {
+                new CustomMaster { Id = Guid.NewGuid(), Name = "Marry Harry" },
+                new CustomMaster { Id = Guid.NewGuid(), Name = "Harry Marry" }
+            };
+
+            // Act
+            var masterDtoQuery = source.AsQueryable().UseAsDataSource(mapper)
+                .For<MasterDto>()
+                .OrderBy(x => x.Name)
+                .ToList();
+
+            // Assert
+            masterDtoQuery.First().Name.ShouldBe("Harry Marry");
+        }
+
+        [Fact]
         public void Project_to_custom_struct()
         {
             // Arrange
@@ -1273,6 +1302,11 @@ namespace AutoMapper.UnitTests.Query
             if (!(obj is CustomString))
                 return -1;
             return CompareTo((CustomString)obj);
+        }
+
+        public int CompareTo(CustomString val)
+        {
+            return Value.CompareTo(val.Value);
         }
 
         public TypeCode GetTypeCode()

--- a/src/UnitTests/Query/SourceInjectedQuery.cs
+++ b/src/UnitTests/Query/SourceInjectedQuery.cs
@@ -461,6 +461,41 @@ namespace AutoMapper.UnitTests.Query
             detailDtoQuery.ToList().Count().ShouldBe(1);
         }
 
+        [Fact]
+        [Description("Fix for issue #2538")]
+        public void Should_cast_expression_type_to_source_if_not_assignable()
+        {
+            // Arrange
+            var config = new MapperConfiguration(c =>
+            {
+                c.CreateMap<CustomMaster, MasterDto>()
+                    .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.NameBase))
+                    .ReverseMap();
+                c.CreateMap<CustomString, string>().ProjectUsing(x => !x.IsNull ? x.Value : string.Empty);
+            });
+
+            config.AssertConfigurationIsValid();
+
+            var mapper = config.CreateMapper();
+
+            var source = new List<CustomMaster> {
+                new CustomMaster { Id = Guid.NewGuid(), NameBase = "Harry Marry" }
+            };
+
+            // Act
+            var masterDtoQuery = source.AsQueryable().UseAsDataSource(mapper)
+                .For<MasterDto>()
+                .Where(d => d.Name == "Harry Marry")
+                .Select(x => new
+                {
+                    x.Name
+                })
+                .ToList();
+
+            // Assert
+            masterDtoQuery.ToList().Count().ShouldBe(1);
+        }
+        
         private void AssertValidDtoGraph(Detail detail, Master master, DetailCyclicDto dto)
         {
             dto.ShouldNotBeNull();
@@ -827,6 +862,240 @@ namespace AutoMapper.UnitTests.Query
     {
         public string Title { get; set; }
         public bool HasEditPermission { get; set; }
+    }
+
+    public class CustomMaster
+    {
+        public Guid Id { get; set; }
+        public CustomString NameBase { get; set; }
+    }
+
+    public struct CustomString : IComparable, IConvertible
+    {
+        private string value;
+        private bool isNull;
+
+        public CustomString(string value)
+        {
+            this.isNull = string.IsNullOrEmpty(value);
+            this.value = value ?? string.Empty;
+        }
+
+        public string Value
+        {
+            get
+            {
+                if (IsNull || value == null)
+                    return string.Empty;
+                return value;
+            }
+            set
+            {
+                if (Value == value && !IsNull)
+                    return;
+
+                if (string.IsNullOrEmpty(value) && !isNull)
+                {
+                    isNull = true;
+                }
+
+                this.value = value ?? string.Empty;
+            }
+        }
+
+        public bool IsNull
+        {
+            get
+            {
+                return isNull;
+            }
+            set
+            {
+                if (isNull == value) return;
+                isNull = value;
+            }
+        }
+
+        public static implicit operator CustomString(string a)
+        {
+            return new CustomString(a);
+        }
+
+        public static implicit operator string(CustomString a)
+        {
+            return a.Value;
+        }
+
+        public static bool operator ==(CustomString a, CustomString b)
+        {
+            return a.Value == b.Value;
+        }
+
+        public static bool operator ==(CustomString a, string b)
+        {
+            return a.Value == b;
+        }
+
+        public static bool operator ==(string a, CustomString b)
+        {
+            return a == b.Value;
+        }
+
+        public static bool operator !=(CustomString a, CustomString b)
+        {
+            return a.Value != b.Value;
+        }
+
+        public static bool operator !=(CustomString a, string b)
+        {
+            return a.Value != b;
+        }
+
+        public static bool operator !=(string a, CustomString b)
+        {
+            return a != b.Value;
+        }
+
+        public static bool operator <(CustomString a, CustomString b)
+        {
+            return a.CompareTo(b) < 0;
+        }
+
+        public static bool operator >(CustomString a, CustomString b)
+        {
+            return a.CompareTo(b) > 0;
+        }
+
+        public static bool operator <=(CustomString a, CustomString b)
+        {
+            return a.CompareTo(b) <= 0;
+        }
+
+        public static bool operator >=(CustomString a, CustomString b)
+        {
+            return a.CompareTo(b) >= 0;
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Value.GetHashCode();
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is CustomString)
+                return this == (CustomString)obj;
+            if (obj is string)
+                return this == (CustomString)((string)obj);
+            return false;
+        }
+
+
+        public int CompareTo(object obj)
+        {
+            if (!(obj is CustomString))
+                return -1;
+            return CompareTo((CustomString)obj);
+        }
+
+        public TypeCode GetTypeCode()
+        {
+            if (this.IsNull)
+                return TypeCode.String;
+            return this.Value.GetTypeCode();
+        }
+
+        public bool EqualsValue(string obj)
+        {
+            return this.Equals((object)obj);
+        }
+
+        public override string ToString()
+        {
+            if (IsNull)
+                return string.Empty;
+            return Value;
+        }
+
+        public bool ToBoolean(IFormatProvider provider)
+        {
+            return ((IConvertible)this.Value).ToBoolean(provider);
+        }
+
+        public byte ToByte(IFormatProvider provider)
+        {
+            return ((IConvertible)this.Value).ToByte(provider);
+        }
+
+        public char ToChar(IFormatProvider provider)
+        {
+            return ((IConvertible)this.Value).ToChar(provider);
+        }
+
+        public DateTime ToDateTime(IFormatProvider provider)
+        {
+            return ((IConvertible)this.Value).ToDateTime(provider);
+        }
+
+        public decimal ToDecimal(IFormatProvider provider)
+        {
+            return ((IConvertible)this.Value).ToDecimal(provider);
+        }
+
+        public double ToDouble(IFormatProvider provider)
+        {
+            return ((IConvertible)this.Value).ToDouble(provider);
+        }
+
+        public short ToInt16(IFormatProvider provider)
+        {
+            return ((IConvertible)this.Value).ToInt16(provider);
+        }
+
+        public int ToInt32(IFormatProvider provider)
+        {
+            return ((IConvertible)this.Value).ToInt32(provider);
+        }
+
+        public long ToInt64(IFormatProvider provider)
+        {
+            return ((IConvertible)this.Value).ToInt64(provider);
+        }
+
+        public sbyte ToSByte(IFormatProvider provider)
+        {
+            return ((IConvertible)this.Value).ToSByte(provider);
+        }
+
+        public float ToSingle(IFormatProvider provider)
+        {
+            return ((IConvertible)this.Value).ToSingle(provider);
+        }
+
+        public string ToString(IFormatProvider provider)
+        {
+            return ((IConvertible)this.Value).ToString(provider);
+        }
+
+        public object ToType(Type conversionType, IFormatProvider provider)
+        {
+            return ((IConvertible)this.Value).ToType(conversionType, provider);
+        }
+
+        public ushort ToUInt16(IFormatProvider provider)
+        {
+            return ((IConvertible)this.Value).ToUInt16(provider);
+        }
+
+        public uint ToUInt32(IFormatProvider provider)
+        {
+            return ((IConvertible)this.Value).ToUInt32(provider);
+        }
+
+        public ulong ToUInt64(IFormatProvider provider)
+        {
+            return ((IConvertible)this.Value).ToUInt64(provider);
+        }
     }
 }
 

--- a/src/UnitTests/Query/SourceInjectedQuery.cs
+++ b/src/UnitTests/Query/SourceInjectedQuery.cs
@@ -616,6 +616,39 @@ namespace AutoMapper.UnitTests.Query
             masterDtoProjectedQuery.First().Name.ToString().ShouldBe("Harry Marry !!!");
         }
 
+        [Fact]
+        public void Project_from_custom_struct_with_custom_mapping_and_anonymus_type()
+        {
+            // Arrange
+            var config = new MapperConfiguration(c =>
+            {
+                c.CreateMap<CustomMaster, MasterDto>()
+                    .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.Name + " !!!"))
+                    .ReverseMap();
+            });
+
+            config.AssertConfigurationIsValid();
+
+            var mapper = config.CreateMapper();
+
+            var source = new List<CustomMaster> {
+                new CustomMaster { Id = Guid.NewGuid(), Name = "Harry Marry" }
+            };
+
+            // Act
+            var masterDtoProjectedQuery = source.AsQueryable().UseAsDataSource(mapper)
+                .For<MasterDto>()
+                .Where(d => d.Name == "Harry Marry !!!")
+                .Select(x => new
+                {
+                    x.Id,
+                    x.Name
+                })
+                .ToList();
+
+            // Assert
+            masterDtoProjectedQuery.First().Name.ToString().ShouldBe("Harry Marry !!!");
+        }
 
         [Fact]
         public void Project_to_custom_struct()
@@ -700,7 +733,7 @@ namespace AutoMapper.UnitTests.Query
             // Act
             var customMasterQuery = source.AsQueryable().UseAsDataSource(mapper)
                 .For<CustomMaster>()
-                .Where(d => d.Name == "Harry Marry")
+                .Where(d => d.Name == "Harry Marry !!!")
                 .ToList();
 
             // Assert

--- a/src/UnitTests/Query/SourceInjectedQuery.cs
+++ b/src/UnitTests/Query/SourceInjectedQuery.cs
@@ -469,9 +469,10 @@ namespace AutoMapper.UnitTests.Query
             var config = new MapperConfiguration(c =>
             {
                 c.CreateMap<CustomMaster, MasterDto>()
-                    .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.NameBase))
+                    .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.CustomName))
                     .ReverseMap();
                 c.CreateMap<CustomString, string>().ProjectUsing(x => !x.IsNull ? x.Value : string.Empty);
+                c.CreateMap<string, CustomString>().ProjectUsing(x => !string.IsNullOrEmpty(x) ? null : x);
             });
 
             config.AssertConfigurationIsValid();
@@ -479,7 +480,7 @@ namespace AutoMapper.UnitTests.Query
             var mapper = config.CreateMapper();
 
             var source = new List<CustomMaster> {
-                new CustomMaster { Id = Guid.NewGuid(), NameBase = "Harry Marry" }
+                new CustomMaster { Id = Guid.NewGuid(), CustomName = "Harry Marry" }
             };
 
             // Act
@@ -495,7 +496,7 @@ namespace AutoMapper.UnitTests.Query
             // Assert
             masterDtoQuery.ToList().Count().ShouldBe(1);
         }
-        
+
         private void AssertValidDtoGraph(Detail detail, Master master, DetailCyclicDto dto)
         {
             dto.ShouldNotBeNull();
@@ -867,7 +868,7 @@ namespace AutoMapper.UnitTests.Query
     public class CustomMaster
     {
         public Guid Id { get; set; }
-        public CustomString NameBase { get; set; }
+        public CustomString CustomName { get; set; }
     }
 
     public struct CustomString : IComparable, IConvertible


### PR DESCRIPTION
Seems my last bugfix breaks some other tests. So i spent my whole day to make this working correctly.

My trouble with the testing-environment ended as soon I upgraded the xunit.runner.visualstudio to version 2.3.1

In addition to the discussed solution, i did the following changes:

ExpressionMapper.ExpressionVisitor implements now additionaly the VisitNew-Method. This was the Method causing trouble, if a projection to an anonymous method with a different type has been queried. In addition to this change, now i call a new GetConvertedArgument-Method to convert the projection-types, if possible, with the registered TypeMaps.

Because the visitor now is called for each transformed argument, the visitmember method get's called for these arguments, and returns a converted expression if the types differ. To prevent the "no coercion operator"-exception, I extended the ReflectionHelper class and added a method that checks if a type can be implicit converted. If not, the original expression is returned, if yes, an convert-expression is returned. 