### PR TITLE
Define ComVisible Attribute

### DIFF
--- a/src/AutoMapper/AssemblyInfo.cs
+++ b/src/AutoMapper/AssemblyInfo.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Resources;
-
 #if NET45 || NET40
+using System.Runtime.InteropServices;
 using System.Security;
 #endif
 
-[assembly:CLSCompliant(true)]
+[assembly: CLSCompliant(true)]
 #if NET45 || NET40
 [assembly: AllowPartiallyTrustedCallers]
+[assembly: ComVisible(false)]
 #endif
 
 [assembly: NeutralResourcesLanguage("en")]


### PR DESCRIPTION
If you do not define the ComVisible Attribute .NET uses true as the default value and compiles the assembly as com visible. Fixes #2559.