### PR TITLE
ProjectTo : Expose binders and result converters

### DIFF
--- a/src/AutoMapper/AdvancedConfiguration.cs
+++ b/src/AutoMapper/AdvancedConfiguration.cs
@@ -1,3 +1,4 @@
+using AutoMapper.QueryableExtensions;
 using System;
 using System.Collections.Generic;
 
@@ -31,5 +32,9 @@ namespace AutoMapper
         public int MaxExecutionPlanDepth { get; set; } = 1;
 
         internal Validator[] GetValidators() => _validators.ToArray();
+
+        public List<IExpressionResultConverter> QueryableResultConverters { get; } = ExpressionBuilder.DefaultResultConverters();
+
+        public List<IExpressionBinder> QueryableBinders { get; } = ExpressionBuilder.DefaultBinders();
     }
 }

--- a/src/AutoMapper/IConfigurationProvider.cs
+++ b/src/AutoMapper/IConfigurationProvider.cs
@@ -122,6 +122,10 @@ namespace AutoMapper
 
         IExpressionBuilder ExpressionBuilder { get; }
 
+        IEnumerable<IExpressionResultConverter> ResultConverters { get; }
+
+        IEnumerable<IExpressionBinder> Binders { get; }
+
         /// <summary>
         /// Create a mapper instance based on this configuration. Mapper instances are lightweight and can be created as needed.
         /// </summary>

--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -41,6 +41,8 @@ namespace AutoMapper
             ServiceCtor = configurationExpression.ServiceCtor;
             EnableNullPropagationForQueryMapping = configurationExpression.EnableNullPropagationForQueryMapping ?? false;
             MaxExecutionPlanDepth = configurationExpression.Advanced.MaxExecutionPlanDepth + 1;
+            ResultConverters = configurationExpression.Advanced.QueryableResultConverters.ToArray();
+            Binders = configurationExpression.Advanced.QueryableBinders.ToArray();
 
             Configuration = new ProfileMap(configurationExpression);
             Profiles = new[] { Configuration }.Concat(configurationExpression.Profiles.Select(p => new ProfileMap(p, configurationExpression))).ToArray();
@@ -78,6 +80,10 @@ namespace AutoMapper
         private ProfileMap Configuration { get; }
 
         public IEnumerable<ProfileMap> Profiles { get; }
+
+        public IEnumerable<IExpressionResultConverter> ResultConverters { get; }
+
+        public IEnumerable<IExpressionBinder> Binders { get; }
 
         public Func<TSource, TDestination, ResolutionContext, TDestination> GetMapperFunc<TSource, TDestination>(TypePair types, PropertyMap propertyMap)
         {

--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -25,22 +25,24 @@ namespace AutoMapper.QueryableExtensions
 
     public class ExpressionBuilder : IExpressionBuilder
     {
-        private static readonly IExpressionResultConverter[] ExpressionResultConverters =
-        {
-            new MemberResolverExpressionResultConverter(),
-            new MemberGetterExpressionResultConverter()
-        };
+        internal static List<IExpressionResultConverter> DefaultResultConverters() =>
+            new List<IExpressionResultConverter>
+            {
+                new MemberResolverExpressionResultConverter(),
+                new MemberGetterExpressionResultConverter()
+            };
 
-        private static readonly IExpressionBinder[] Binders =
-        {
-            new CustomProjectionExpressionBinder(),
-            new NullableDestinationExpressionBinder(),
-            new NullableSourceExpressionBinder(),
-            new AssignableExpressionBinder(),
-            new EnumerableExpressionBinder(),
-            new MappedTypeExpressionBinder(),
-            new StringExpressionBinder()
-        };
+        internal static List<IExpressionBinder> DefaultBinders() =>
+            new List<IExpressionBinder>
+            {
+                new CustomProjectionExpressionBinder(),
+                new NullableDestinationExpressionBinder(),
+                new NullableSourceExpressionBinder(),
+                new AssignableExpressionBinder(),
+                new EnumerableExpressionBinder(),
+                new MappedTypeExpressionBinder(),
+                new StringExpressionBinder()
+            };
 
         private readonly LockingConcurrentDictionary<ExpressionRequest, LambdaExpression[]> _expressionCache;
         private readonly IConfigurationProvider _configurationProvider;
@@ -226,7 +228,7 @@ namespace AutoMapper.QueryableExtensions
                 {
                     return;
                 }
-                var binder = Binders.FirstOrDefault(b => b.IsMatch(propertyMap, propertyTypeMap, result));
+                var binder = _configurationProvider.Binders.FirstOrDefault(b => b.IsMatch(propertyMap, propertyTypeMap, result));
                 if(binder == null)
                 {
                     var message =
@@ -250,13 +252,11 @@ namespace AutoMapper.QueryableExtensions
             }
         }
 
-        private static ExpressionResolutionResult ResolveExpression(PropertyMap propertyMap, Type currentType,
-            Expression instanceParameter, LetPropertyMaps letPropertyMaps)
+        private ExpressionResolutionResult ResolveExpression(PropertyMap propertyMap, Type currentType, Expression instanceParameter, LetPropertyMaps letPropertyMaps)
         {
             var result = new ExpressionResolutionResult(instanceParameter, currentType);
 
-            var matchingExpressionConverter =
-                ExpressionResultConverters.FirstOrDefault(c => c.CanGetExpressionResolutionResult(result, propertyMap));
+            var matchingExpressionConverter = _configurationProvider.ResultConverters.FirstOrDefault(c => c.CanGetExpressionResolutionResult(result, propertyMap));
             result = matchingExpressionConverter?.GetExpressionResolutionResult(result, propertyMap, letPropertyMaps) 
                 ?? throw new Exception("Can't resolve this to Queryable Expression");
 

--- a/src/UnitTests/Projection/BindersAndResultConverters.cs
+++ b/src/UnitTests/Projection/BindersAndResultConverters.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using AutoMapper.QueryableExtensions;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using Shouldly;
+using System.Linq.Expressions;
+
+namespace AutoMapper.UnitTests.Projection
+{
+    using static Expression;
+
+    public class QueryableBinders : AutoMapperSpecBase
+    {
+        class Source
+        {
+            public ConsoleColor Color { get; set; }
+        }
+
+        class Destination
+        {
+            public int Color { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.Advanced.QueryableBinders.Add(new EnumToUnderlyingTypeBinder());
+            cfg.CreateMap<Source, Destination>();
+        });
+
+        [Fact]
+        public void Should_work_with_projections()
+        {
+            var destination = new[] { new Source { Color = ConsoleColor.Cyan } }.AsQueryable().ProjectTo<Destination>(Configuration).First();
+            destination.Color.ShouldBe(11);
+        }
+
+        private class EnumToUnderlyingTypeBinder : IExpressionBinder
+        {
+            public MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, IDictionary<ExpressionRequest, int> typePairCount, LetPropertyMaps letPropertyMaps) =>
+                Bind(propertyMap.DestinationProperty, Convert(result.ResolutionExpression, propertyMap.DestinationPropertyType));
+
+            public bool IsMatch(PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionResolutionResult result) =>
+                propertyMap.SourceType.IsEnum && Enum.GetUnderlyingType(propertyMap.SourceType) == propertyMap.DestinationPropertyType;
+        }
+    }
+
+    public class QueryableResultConverters : AutoMapperSpecBase
+    {
+        class Source
+        {
+            public ConsoleColor Color { get; set; }
+        }
+
+        class Destination
+        {
+            public int Color { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.Advanced.QueryableResultConverters.Insert(0, new EnumToUnderlyingTypeResultConverter());
+            cfg.CreateMap<Source, Destination>();
+        });
+
+        [Fact]
+        public void Should_work_with_projections()
+        {
+            var destination = new[] { new Source { Color = ConsoleColor.Cyan } }.AsQueryable().ProjectTo<Destination>(Configuration).First();
+            destination.Color.ShouldBe(11);
+        }
+
+        private class EnumToUnderlyingTypeResultConverter : IExpressionResultConverter
+        {
+            public bool CanGetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult, PropertyMap propertyMap) =>
+                propertyMap.SourceType.IsEnum && Enum.GetUnderlyingType(propertyMap.SourceType) == propertyMap.DestinationPropertyType;
+
+            public bool CanGetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult, ConstructorParameterMap propertyMap)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ExpressionResolutionResult GetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult, PropertyMap propertyMap, LetPropertyMaps letPropertyMaps) =>
+                new ExpressionResolutionResult(
+                    Convert(MakeMemberAccess(expressionResolutionResult.ResolutionExpression, propertyMap.SourceMember), propertyMap.DestinationPropertyType), 
+                    propertyMap.DestinationPropertyType);
+
+            public ExpressionResolutionResult GetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult, ConstructorParameterMap propertyMap)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
@TylerCarlson1's [idea](https://github.com/AutoMapper/AutoMapper/pull/2542#discussion_r171872523). It seems useful. Allow customizations to ProjectTo without affecting EF6. Also stuff like #2552 could be solved this way.