### PR TITLE
Fix for Issue #2578

### DIFF
--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -284,7 +284,8 @@ namespace AutoMapper
             _orderedPropertyMaps =
                 _propertyMaps
                     .Union(_inheritedMaps)
-                    .OrderBy(map => map.MappingOrder).ToArray();
+                    .OrderBy(map => map.MappingOrder ?? int.MaxValue).ThenBy(map => map.DestinationProperty?.Name)
+                    .ToArray();
 
             MapExpression = new TypeMapPlanBuilder(configurationProvider, this).CreateMapperLambda(typeMapsPath);
         }

--- a/src/UnitTests/MappingOrder.cs
+++ b/src/UnitTests/MappingOrder.cs
@@ -167,15 +167,13 @@ namespace AutoMapper.UnitTests
             [Fact]
             public void Should_use_not_have_any_configured_mapping_orders()
             {
-                Assert.All(_propertyMaps, pm => pm.MappingOrder = null);
+                Assert.True(_propertyMaps.All(pm => pm.MappingOrder == null));
             }
 
 
             [Fact]
             public void Should_perform_mapping_ordered_by_name()
             {
-                Assert.Equal(6, _propertyMaps.Length);
-
                 Assert.Equal("A", _propertyMaps.Skip(0).Select(p => p.DestinationProperty.Name).First());
                 Assert.Equal("B", _propertyMaps.Skip(1).Select(p => p.DestinationProperty.Name).First());
                 Assert.Equal("C", _propertyMaps.Skip(2).Select(p => p.DestinationProperty.Name).First());

--- a/src/UnitTests/MappingOrder.cs
+++ b/src/UnitTests/MappingOrder.cs
@@ -1,6 +1,8 @@
 using Xunit;
 using Shouldly;
 using System;
+using System.Linq;
+using AutoMapper.QueryableExtensions.Impl;
 
 namespace AutoMapper.UnitTests
 {
@@ -119,6 +121,133 @@ namespace AutoMapper.UnitTests
             {
                 _result.Value2.ShouldBe(15);
                 _result.Value1.ShouldBe(25);
+            }
+        }
+
+        public class When_Not_Specifying_Mapping_Order : AutoMapperSpecBase
+        {
+            private PropertyMap[] _propertyMaps;
+
+            public class Destination
+            {
+                public string A { get; set; }
+                public string E { get; set; }
+                public string D { get; set; }
+                public string C { get; set; }
+                public string B { get; set; }
+                public string F { get; set; }
+            }
+
+            public class Source
+            {
+                public string A { get; set; }
+                public string B { get; set; }
+                public string C { get; set; }
+                public string D { get; set; }
+                public string E { get; set; }
+                public string F { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Source, Destination>();
+            });
+
+            protected override void Because_of()
+            {
+                _propertyMaps = Configuration.FindTypeMapFor<Source, Destination>().GetPropertyMaps();
+            }
+
+            [Fact]
+            public void Should_map_six_properties()
+            {
+                Assert.Equal(6, _propertyMaps.Length);
+            }
+
+            [Fact]
+            public void Should_use_not_have_any_configured_mapping_orders()
+            {
+                Assert.All(_propertyMaps, pm => pm.MappingOrder = null);
+            }
+
+
+            [Fact]
+            public void Should_perform_mapping_ordered_by_name()
+            {
+                Assert.Equal(6, _propertyMaps.Length);
+
+                Assert.Equal("A", _propertyMaps.Skip(0).Select(p => p.DestinationProperty.Name).First());
+                Assert.Equal("B", _propertyMaps.Skip(1).Select(p => p.DestinationProperty.Name).First());
+                Assert.Equal("C", _propertyMaps.Skip(2).Select(p => p.DestinationProperty.Name).First());
+                Assert.Equal("D", _propertyMaps.Skip(3).Select(p => p.DestinationProperty.Name).First());
+                Assert.Equal("E", _propertyMaps.Skip(4).Select(p => p.DestinationProperty.Name).First());
+                Assert.Equal("F", _propertyMaps.Skip(5).Select(p => p.DestinationProperty.Name).First());
+            }
+        }
+
+        public class When_Partial_Specifying_Mapping_Order : AutoMapperSpecBase
+        {
+            private PropertyMap[] _propertyMaps;
+
+            public class Destination
+            {
+                public string A { get; set; }
+                public string E { get; set; }
+                public string D { get; set; }
+                public string C { get; set; }
+                public string B { get; set; }
+                public string F { get; set; }
+            }
+
+            public class Source
+            {
+                public string A { get; set; }
+                public string B { get; set; }
+                public string C { get; set; }
+                public string D { get; set; }
+                public string E { get; set; }
+                public string F { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+                                                                                                    {
+                                                                                                        cfg.CreateMap<Source, Destination>()
+                                                                                                           .ForMember(dest => dest.E, opt => opt.SetMappingOrder(1))
+                                                                                                           .ForMember(dest => dest.B, opt => opt.SetMappingOrder(2))
+                                                                                                           .ForMember(dest => dest.D, opt => opt.SetMappingOrder(2));
+                                                                                                    });
+
+            protected override void Because_of()
+            {
+                _propertyMaps = Configuration.FindTypeMapFor<Source, Destination>().GetPropertyMaps();
+            }
+
+            [Fact]
+            public void Should_map_six_properties()
+            {
+                Assert.Equal(6, _propertyMaps.Length);
+            }
+
+            [Fact]
+            public void Should_use_configured_mappingOrders()
+            {
+                Assert.Equal(1, _propertyMaps.Skip(0).Select(p => p.MappingOrder).First());
+                Assert.Equal(2, _propertyMaps.Skip(1).Select(p => p.MappingOrder).First());
+                Assert.Equal(2, _propertyMaps.Skip(2).Select(p => p.MappingOrder).First());
+                Assert.Null(_propertyMaps.Skip(3).Select(p => p.MappingOrder).First());
+                Assert.Null(_propertyMaps.Skip(4).Select(p => p.MappingOrder).First());
+                Assert.Null(_propertyMaps.Skip(5).Select(p => p.MappingOrder).First());
+            }
+
+            [Fact]
+            public void Should_perform_sorting_on_mapping_order_then_name()
+            {
+                Assert.Equal("E", _propertyMaps.Skip(0).Select(p => p.DestinationProperty.Name).First());
+                Assert.Equal("B", _propertyMaps.Skip(1).Select(p => p.DestinationProperty.Name).First());
+                Assert.Equal("D", _propertyMaps.Skip(2).Select(p => p.DestinationProperty.Name).First());
+                Assert.Equal("A", _propertyMaps.Skip(3).Select(p => p.DestinationProperty.Name).First());
+                Assert.Equal("C", _propertyMaps.Skip(4).Select(p => p.DestinationProperty.Name).First());
+                Assert.Equal("F", _propertyMaps.Skip(5).Select(p => p.DestinationProperty.Name).First());
             }
         }
 


### PR DESCRIPTION
This pull request solves the issue around #2578 so that `DestinationProperty.Name` is a part of there ordering of property maps when `TypeMap.GetPropertyMaps()` is called on a sealed type map.

`PropertyMap.MappingOrder` will be primary sorting property, then `PropertyMap.DestinationProperty.Name` if any `PropertyMap.MappingOrder` are identical. 

All property maps with no `MappingOrder` will be sorted after all property maps with a valid `PropertyMap.MappingOrder` ordred by `PropertyMap.DestinationProperty.Name`.

If no property maps has `PropertyMap.MappingOrder` set, it will sort on `PropertyMap.Destinationproperty.Name` only.