### PR TITLE
Nullable untyped MapFrom

### DIFF
--- a/src/AutoMapper/Mappers/NullableDestinationMapper.cs
+++ b/src/AutoMapper/Mappers/NullableDestinationMapper.cs
@@ -16,8 +16,7 @@ namespace AutoMapper.Mappers
                 new TypePair(sourceExpression.Type, Nullable.GetUnderlyingType(destExpression.Type)),
                 sourceExpression,
                 contextExpression,
-                propertyMap,
-                Expression.Property(destExpression, destExpression.Type.GetDeclaredProperty("Value"))
+                propertyMap
             );
 
         public TypePair GetAssociatedTypes(TypePair initialTypes)

--- a/src/UnitTests/Bug/NullableUntypedMapFrom.cs
+++ b/src/UnitTests/Bug/NullableUntypedMapFrom.cs
@@ -27,7 +27,7 @@ namespace AutoMapper.UnitTests.Bug
         }
 
         [Fact]
-        public void Should_map_nullable_decimal_with_ResolveUsing()
+        public void Should_map_nullable_decimal()
         {
             _destination.OddNumber.ShouldBe(12);
         }

--- a/src/UnitTests/Bug/NullableUntypedMapFrom.cs
+++ b/src/UnitTests/Bug/NullableUntypedMapFrom.cs
@@ -18,7 +18,7 @@ namespace AutoMapper.UnitTests.Bug
 
         protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
         {
-            cfg.CreateMap<Source, Destination>().ForMember(d => d.OddNumber, o => o.ResolveUsing(s => (object)s.Number));
+            cfg.CreateMap<Source, Destination>().ForMember(d => d.OddNumber, o => o.MapFrom(s => (object)s.Number));
         });
 
         protected override void Because_of()

--- a/src/UnitTests/Bug/NullableUntypedMapFrom.cs
+++ b/src/UnitTests/Bug/NullableUntypedMapFrom.cs
@@ -1,0 +1,35 @@
+﻿using Xunit;
+using Shouldly;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public class NullableUntypedMapFrom : AutoMapperSpecBase
+    {
+        private Destination _destination;
+
+        class Source
+        {
+            public decimal? Number { get; set; }
+        }
+        class Destination
+        {
+            public decimal? OddNumber { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>().ForMember(d => d.OddNumber, o => o.ResolveUsing(s => (object)s.Number));
+        });
+
+        protected override void Because_of()
+        {
+            _destination = Mapper.Map<Destination>(new Source { Number = 12 });
+        }
+
+        [Fact]
+        public void Should_map_nullable_decimal_with_ResolveUsing()
+        {
+            _destination.OddNumber.ShouldBe(12);
+        }
+    }
+}


### PR DESCRIPTION
The test is silly, but generic mapping works with expressions based on ```object```.