### PR TITLE
Parameterized queries

### DIFF
--- a/src/AutoMapper/ExpressionExtensions.cs
+++ b/src/AutoMapper/ExpressionExtensions.cs
@@ -12,7 +12,7 @@ namespace AutoMapper
     internal static class ExpressionExtensions
     {
         public static Expression MemberAccesses(this IEnumerable<MemberInfo> members, Expression obj) =>
-            members.Aggregate(obj, (expression, member) => MakeMemberAccess(expression, member));
+            members.Aggregate(obj, MakeMemberAccess);
 
         public static IEnumerable<MemberExpression> GetMembers(this Expression expression)
         {

--- a/src/AutoMapper/QueryableExtensions/Extensions.cs
+++ b/src/AutoMapper/QueryableExtensions/Extensions.cs
@@ -60,6 +60,22 @@ namespace AutoMapper.QueryableExtensions
             => new ProjectionExpression(source, configuration.ExpressionBuilder).To(parameters, membersToExpand);
 
         /// <summary>
+        /// Extension method to project from a queryable using the provided mapping engine. This will result in a parameterized query.
+        /// </summary>
+        /// <remarks>Projections are only calculated once and cached</remarks>
+        /// <typeparam name="TDestination">Destination type</typeparam>
+        /// <param name="source">Queryable source</param>
+        /// <param name="configuration">Mapper configuration</param>
+        /// <param name="parameterExpression">Parameter expression for parameterized mapping expressions</param>
+        /// <param name="membersToExpand">Explicit members to expand</param>
+        /// <returns>Expression to project into</returns>
+        public static IQueryable<TDestination> ProjectTo<TDestination>(this IQueryable source, 
+            IConfigurationProvider configuration, 
+            Expression<Func<object>> parameterExpression, 
+            params Expression<Func<TDestination, object>>[] membersToExpand) 
+            => new ProjectionExpression(source, configuration.ExpressionBuilder).To(parameterExpression, membersToExpand);
+
+        /// <summary>
         /// Extension method to project from a queryable using the provided mapping engine
         /// </summary>
         /// <remarks>Projections are only calculated once and cached</remarks>

--- a/src/AutoMapper/QueryableExtensions/IProjectionExpression.cs
+++ b/src/AutoMapper/QueryableExtensions/IProjectionExpression.cs
@@ -23,6 +23,15 @@ namespace AutoMapper.QueryableExtensions
         /// Projects the source type to the destination type given the mapping configuration
         /// </summary>
         /// <typeparam name="TResult">Destination type to map to</typeparam>
+        /// <param name="parameterExpression">Parameter expression for parameterized mapping expressions. Will result in a parameterized query.</param>
+        /// <param name="membersToExpand">>Explicit members to expand</param>
+        /// <returns>Queryable result, use queryable extension methods to project and execute result</returns>
+        IQueryable<TResult> To<TResult>(Expression<Func<object>> parameterExpression, params Expression<Func<TResult, object>>[] membersToExpand);
+
+        /// <summary>
+        /// Projects the source type to the destination type given the mapping configuration
+        /// </summary>
+        /// <typeparam name="TResult">Destination type to map to</typeparam>
         /// <param name="parameters">Optional parameter object for parameterized mapping expressions</param>
         /// <returns>Queryable result, use queryable extension methods to project and execute result</returns>
         IQueryable<TResult> To<TResult>(IDictionary<string, object> parameters);

--- a/src/AutoMapper/QueryableExtensions/ProjectionExpression.cs
+++ b/src/AutoMapper/QueryableExtensions/ProjectionExpression.cs
@@ -32,6 +32,15 @@ namespace AutoMapper.QueryableExtensions
 
         public IQueryable<TResult> To<TResult>(object parameters = null) => To<TResult>(parameters, new string[0]);
 
+        public IQueryable<TResult> To<TResult>(Expression<Func<object>> parameterExpression, params Expression<Func<TResult, object>>[] membersToExpand)
+        {
+            var memberPathsToExpand = GetMemberPaths(membersToExpand).SelectMany(m => m).Distinct().ToArray();
+
+            var mapExpressions = _builder.GetMapExpression(_source.ElementType, typeof(TResult), parameterExpression, memberPathsToExpand);
+
+            return (IQueryable<TResult>)mapExpressions.Aggregate(_source, Select);
+        }
+
         public IQueryable<TResult> To<TResult>(object parameters = null, params string[] membersToExpand)
         {
             var paramValues = GetParameters(parameters);
@@ -75,7 +84,7 @@ namespace AutoMapper.QueryableExtensions
             parameters = parameters ?? new Dictionary<string, object>();
             var mapExpressions = _builder.GetMapExpression(_source.ElementType, typeof(TResult), parameters, membersToExpand);
 
-            return (IQueryable<TResult>)mapExpressions.Aggregate(_source, (source, lambda)=>Select(source, lambda));
+            return (IQueryable<TResult>)mapExpressions.Aggregate(_source, Select);
         }
 
         private static IQueryable Select(IQueryable source, LambdaExpression lambda)

--- a/src/IntegrationTests/Parameterization/ParameterizedQueries.cs
+++ b/src/IntegrationTests/Parameterization/ParameterizedQueries.cs
@@ -1,0 +1,82 @@
+﻿using System.Data.Entity;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper.QueryableExtensions;
+using AutoMapper.UnitTests;
+using Shouldly;
+using Xunit;
+
+namespace AutoMapper.IntegrationTests.Parameterization
+{
+    public class ParameterizedQueries : AutoMapperSpecBase
+    {
+        public class Entity
+        {
+            public int Id { get; set; }
+            public string Value { get; set; }
+        }
+
+        public class EntityDto
+        {
+            public int Id { get; set; }
+            public string Value { get; set; }
+            public string UserName { get; set; }
+        }
+
+        private class ClientContext : DbContext
+        {
+            static ClientContext()
+            {
+                Database.SetInitializer(new DatabaseInitializer());
+            }
+
+            public DbSet<Entity> Entities { get; set; }
+        }
+
+        private class DatabaseInitializer : CreateDatabaseIfNotExists<ClientContext>
+        {
+            protected override void Seed(ClientContext context)
+            {
+                context.Entities.AddRange(new[]
+                {
+                    new Entity {Value = "Value1"},
+                    new Entity {Value = "Value2"}
+                });
+                base.Seed(context);
+            }
+        }
+
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            string username = null;
+            cfg.CreateMap<Entity, EntityDto>()
+                .ForMember(d => d.UserName, opt => opt.MapFrom(s => username));
+        });
+
+        [Fact]
+        public async Task Should_parameterize_value()
+        {
+            using (var db = new ClientContext())
+            {
+                string username = "Joe";
+                var dtos = await db.Entities.ProjectTo<EntityDto>(Configuration, new {username}).ToListAsync();
+
+                dtos.All(dto => dto.UserName == username).ShouldBeTrue();
+
+                username = "Mary";
+                dtos = await db.Entities.ProjectTo<EntityDto>(Configuration, new { username }).ToListAsync();
+                dtos.All(dto => dto.UserName == username).ShouldBeTrue();
+
+                username = "Jane";
+                dtos = await db.Entities.Select(e => new EntityDto
+                {
+                    Id = e.Id,
+                    Value = e.Value,
+                    UserName = username
+                }).ToListAsync();
+                dtos.All(dto => dto.UserName == username).ShouldBeTrue();
+            }
+        }
+    }
+}

--- a/src/IntegrationTests/Parameterization/ParameterizedQueries.cs
+++ b/src/IntegrationTests/Parameterization/ParameterizedQueries.cs
@@ -1,5 +1,7 @@
-﻿using System.Data.Entity;
+﻿using System.Collections.Generic;
+using System.Data.Entity;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Threading.Tasks;
 using AutoMapper.QueryableExtensions;
 using AutoMapper.UnitTests;
@@ -47,7 +49,8 @@ namespace AutoMapper.IntegrationTests.Parameterization
         }
 
 
-        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        protected override MapperConfiguration Configuration { get; } = 
+        new MapperConfiguration(cfg =>
         {
             string username = null;
             cfg.CreateMap<Entity, EntityDto>()
@@ -57,25 +60,51 @@ namespace AutoMapper.IntegrationTests.Parameterization
         [Fact]
         public async Task Should_parameterize_value()
         {
+            List<EntityDto> dtos;
+            string username;
             using (var db = new ClientContext())
             {
-                string username = "Joe";
-                var dtos = await db.Entities.ProjectTo<EntityDto>(Configuration, new {username}).ToListAsync();
+                username = "Joe";
+                var query1 = db.Entities.ProjectTo<EntityDto>(Configuration, () => new {username});
+                var constantVisitor = new ConstantVisitor();
+                constantVisitor.Visit(query1.Expression);
+                constantVisitor.HasConstant.ShouldBeFalse();
+                dtos = await query1.ToListAsync();
 
                 dtos.All(dto => dto.UserName == username).ShouldBeTrue();
 
                 username = "Mary";
-                dtos = await db.Entities.ProjectTo<EntityDto>(Configuration, new { username }).ToListAsync();
+                var query2 = db.Entities.ProjectTo<EntityDto>(Configuration, new { username });
+                dtos = await query2.ToListAsync();
+                constantVisitor = new ConstantVisitor();
+                constantVisitor.Visit(query2.Expression);
+                constantVisitor.HasConstant.ShouldBeTrue();
                 dtos.All(dto => dto.UserName == username).ShouldBeTrue();
 
                 username = "Jane";
-                dtos = await db.Entities.Select(e => new EntityDto
+                var query3 = db.Entities.Select(e => new EntityDto
                 {
                     Id = e.Id,
                     Value = e.Value,
                     UserName = username
-                }).ToListAsync();
+                });
+                dtos = await query3.ToListAsync();
                 dtos.All(dto => dto.UserName == username).ShouldBeTrue();
+                constantVisitor = new ConstantVisitor();
+                constantVisitor.Visit(query3.Expression);
+                constantVisitor.HasConstant.ShouldBeFalse();
+            }
+        }
+
+        private class ConstantVisitor : ExpressionVisitor
+        {
+            public bool HasConstant { get; private set; }
+
+            protected override Expression VisitConstant(ConstantExpression node)
+            {
+                if (node.Type == typeof(string))
+                    HasConstant = true;
+                return base.VisitConstant(node);
             }
         }
     }


### PR DESCRIPTION
Fixes #2673

Made an additional overload to `ProjectTo` to take an expression for the parameters. The underlying expression builder then simply swaps one member access for the other based on name.