### PR TITLE
Remove package references to System.Reflection.Emit

### DIFF
--- a/src/AutoMapper/AutoMapper.csproj
+++ b/src/AutoMapper/AutoMapper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Summary>A convention-based object-object mapper.</Summary>
     <Description>A convention-based object-object mapper.</Description>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.3;net45;netcoreapp2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>AutoMapper</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\AutoMapper.snk</AssemblyOriginatorKeyFile>
@@ -19,8 +19,11 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
   </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'netcoreapp2.0'">
+    <DefineConstants>DYNAMIC_METHODS</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
@@ -31,7 +34,6 @@
     <PackageReference Include="System.Resources.ResourceManager" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Include="System.Collections.Specialized" Version="4.3.0" />
   </ItemGroup>
 

--- a/src/AutoMapper/Execution/PropertyDescription.cs
+++ b/src/AutoMapper/Execution/PropertyDescription.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace AutoMapper.Execution
+{
+    [DebuggerDisplay("{Name}-{Type.Name}")]
+    public struct PropertyDescription : IEquatable<PropertyDescription>
+    {
+        internal static PropertyDescription[] Empty = new PropertyDescription[0];
+
+        public PropertyDescription(string name, Type type, bool canWrite = true)
+        {
+            Name = name;
+            Type = type;
+            CanWrite = canWrite;
+        }
+
+        public PropertyDescription(PropertyInfo property)
+        {
+            Name = property.Name;
+            Type = property.PropertyType;
+            CanWrite = property.CanWrite;
+        }
+
+        public string Name { get; }
+
+        public Type Type { get; }
+
+        public bool CanWrite { get; }
+
+        public override int GetHashCode()
+        {
+            var code = HashCodeCombiner.Combine(Name, Type);
+            return HashCodeCombiner.CombineCodes(code, CanWrite.GetHashCode());
+        }
+
+        public override bool Equals(object other) => other is PropertyDescription description && Equals(description);
+
+        public bool Equals(PropertyDescription other) => Name == other.Name && Type == other.Type && CanWrite == other.CanWrite;
+
+        public static bool operator ==(PropertyDescription left, PropertyDescription right) => left.Equals(right);
+
+        public static bool operator !=(PropertyDescription left, PropertyDescription right) => !left.Equals(right);
+    }
+}

--- a/src/AutoMapper/Execution/PropertyEmitter.cs
+++ b/src/AutoMapper/Execution/PropertyEmitter.cs
@@ -1,3 +1,4 @@
+#if DYNAMIC_METHODS
 namespace AutoMapper.Execution
 {
     using System;
@@ -65,3 +66,4 @@ namespace AutoMapper.Execution
             : _setterBuilder;
     }
 }
+#endif

--- a/src/AutoMapper/Execution/ProxyGenerator.cs
+++ b/src/AutoMapper/Execution/ProxyGenerator.cs
@@ -1,3 +1,4 @@
+#if DYNAMIC_METHODS
 namespace AutoMapper.Execution
 {
     using System;
@@ -116,8 +117,7 @@ namespace AutoMapper.Execution
             var fieldBuilders = new Dictionary<string, PropertyEmitter>();
             foreach(var property in propertiesToImplement)
             {
-                PropertyEmitter propertyEmitter;
-                if(fieldBuilders.TryGetValue(property.Name, out propertyEmitter))
+                if(fieldBuilders.TryGetValue(property.Name, out var propertyEmitter))
                 {
                     if((propertyEmitter.PropertyType != property.Type) &&
                         ((property.CanWrite) || (!property.Type.IsAssignableFrom(propertyEmitter.PropertyType))))
@@ -130,8 +130,7 @@ namespace AutoMapper.Execution
                 else
                 {
                     fieldBuilders.Add(property.Name,
-                        propertyEmitter =
-                            new PropertyEmitter(typeBuilder, property, propertyChangedField));
+                        new PropertyEmitter(typeBuilder, property, propertyChangedField));
                 }
             }
             return typeBuilder.CreateType();
@@ -161,83 +160,5 @@ namespace AutoMapper.Execution
             return bytes;
         }
     }
-
-    public struct TypeDescription : IEquatable<TypeDescription>
-    {
-        public TypeDescription(Type type) : this(type, PropertyDescription.Empty)
-        {
-        }
-
-        public TypeDescription(Type type, IEnumerable<PropertyDescription> additionalProperties)
-        {
-            Type = type ?? throw new ArgumentNullException(nameof(type));
-            if(additionalProperties == null)
-            {
-                throw new ArgumentNullException(nameof(additionalProperties));
-            }
-            AdditionalProperties = additionalProperties.OrderBy(p => p.Name).ToArray();
-        }
-
-        public Type Type { get; }
-
-        public PropertyDescription[] AdditionalProperties { get; }
-
-        public override int GetHashCode()
-        {
-            var hashCode = Type.GetHashCode();
-            foreach(var property in AdditionalProperties)
-            {
-                hashCode = HashCodeCombiner.CombineCodes(hashCode, property.GetHashCode());
-            }
-            return hashCode;
-        }
-
-        public override bool Equals(object other) => other is TypeDescription && Equals((TypeDescription)other);
-
-        public bool Equals(TypeDescription other) => Type == other.Type && AdditionalProperties.SequenceEqual(other.AdditionalProperties);
-
-        public static bool operator ==(TypeDescription left, TypeDescription right) => left.Equals(right);
-
-        public static bool operator !=(TypeDescription left, TypeDescription right) => !left.Equals(right);
-    }
-
-    [DebuggerDisplay("{Name}-{Type.Name}")]
-    public struct PropertyDescription : IEquatable<PropertyDescription>
-    {
-        internal static PropertyDescription[] Empty = new PropertyDescription[0];
-
-        public PropertyDescription(string name, Type type, bool canWrite = true)
-        {
-            Name = name;
-            Type = type;
-            CanWrite = canWrite;
-        }
-
-        public PropertyDescription(PropertyInfo property)
-        {
-            Name = property.Name;
-            Type = property.PropertyType;
-            CanWrite = property.CanWrite;
-        }
-
-        public string Name { get; }
-
-        public Type Type { get; }
-
-        public bool CanWrite { get; }
-
-        public override int GetHashCode()
-        {
-            var code = HashCodeCombiner.Combine(Name, Type);
-            return HashCodeCombiner.CombineCodes(code, CanWrite.GetHashCode());
-        }
-
-        public override bool Equals(object other) => other is PropertyDescription && Equals((PropertyDescription)other);
-
-        public bool Equals(PropertyDescription other) => Name == other.Name && Type == other.Type && CanWrite == other.CanWrite;
-
-        public static bool operator ==(PropertyDescription left, PropertyDescription right) => left.Equals(right);
-
-        public static bool operator !=(PropertyDescription left, PropertyDescription right) => !left.Equals(right);
-    }
 }
+#endif

--- a/src/AutoMapper/Execution/TypeDescription.cs
+++ b/src/AutoMapper/Execution/TypeDescription.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AutoMapper.Execution
+{
+    public struct TypeDescription : IEquatable<TypeDescription>
+    {
+        public TypeDescription(Type type) : this(type, PropertyDescription.Empty)
+        {
+        }
+
+        public TypeDescription(Type type, IEnumerable<PropertyDescription> additionalProperties)
+        {
+            Type = type ?? throw new ArgumentNullException(nameof(type));
+            if(additionalProperties == null)
+            {
+                throw new ArgumentNullException(nameof(additionalProperties));
+            }
+            AdditionalProperties = additionalProperties.OrderBy(p => p.Name).ToArray();
+        }
+
+        public Type Type { get; }
+
+        public PropertyDescription[] AdditionalProperties { get; }
+
+        public override int GetHashCode()
+        {
+            var hashCode = Type.GetHashCode();
+            foreach(var property in AdditionalProperties)
+            {
+                hashCode = HashCodeCombiner.CombineCodes(hashCode, property.GetHashCode());
+            }
+            return hashCode;
+        }
+
+        public override bool Equals(object other) => other is TypeDescription description && Equals(description);
+
+        public bool Equals(TypeDescription other) => Type == other.Type && AdditionalProperties.SequenceEqual(other.AdditionalProperties);
+
+        public static bool operator ==(TypeDescription left, TypeDescription right) => left.Equals(right);
+
+        public static bool operator !=(TypeDescription left, TypeDescription right) => !left.Equals(right);
+    }
+}

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -14,19 +14,19 @@ namespace AutoMapper.Execution
     public class TypeMapPlanBuilder
     {
         private static readonly Expression<Func<AutoMapperMappingException>> CtorExpression =
-            () => new AutoMapperMappingException(null, null, default(TypePair), null, null);
+            () => new AutoMapperMappingException(null, null, default, null, null);
 
         private static readonly Expression<Action<ResolutionContext>> IncTypeDepthInfo =
-            ctxt => ctxt.IncrementTypeDepth(default(TypePair));
+            ctxt => ctxt.IncrementTypeDepth(default);
 
         private static readonly Expression<Action<ResolutionContext>> ValidateMap =
-            ctxt => ctxt.ValidateMap(default(TypeMap));
+            ctxt => ctxt.ValidateMap(default);
 
         private static readonly Expression<Action<ResolutionContext>> DecTypeDepthInfo =
-            ctxt => ctxt.DecrementTypeDepth(default(TypePair));
+            ctxt => ctxt.DecrementTypeDepth(default);
 
         private static readonly Expression<Func<ResolutionContext, int>> GetTypeDepthInfo =
-            ctxt => ctxt.GetTypeDepth(default(TypePair));
+            ctxt => ctxt.GetTypeDepth(default);
 
         private readonly IConfigurationProvider _configurationProvider;
         private readonly ParameterExpression _destination;
@@ -322,6 +322,7 @@ namespace AutoMapper.Execution
             {
                 return CreateNewDestinationExpression(_typeMap.ConstructorMap);
             }
+#if DYNAMIC_METHODS
             if(_typeMap.DestinationTypeToUse.IsInterface())
             {
                 var ctor = Call(null,
@@ -332,6 +333,7 @@ namespace AutoMapper.Execution
                 // We're invoking a delegate here to make it have the right accessibility
                 return Invoke(ctor);
             }
+#endif
             return DelegateFactory.GenerateConstructorExpression(_typeMap.DestinationTypeToUse);
         }
 

--- a/src/AutoMapper/LockingConcurrentDictionary.cs
+++ b/src/AutoMapper/LockingConcurrentDictionary.cs
@@ -31,7 +31,7 @@ namespace AutoMapper
                 value = lazy.Value;
                 return true;
             }
-            value = default(TValue);
+            value = default;
             return false;
         }
 

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -200,7 +200,7 @@ namespace AutoMapper
         TDestination IMapper.Map<TDestination>(object source)
         {
             if (source == null)
-                return default(TDestination);
+                return default;
 
             var types = new TypePair(source.GetType(), typeof(TDestination));
 

--- a/src/AutoMapper/Mappers/TypeConverterMapper.cs
+++ b/src/AutoMapper/Mappers/TypeConverterMapper.cs
@@ -24,7 +24,7 @@ namespace AutoMapper.Mappers
                 return (TDestination)typeConverter.ConvertFrom(source);
             }
 
-            return default(TDestination);
+            return default;
         }
 
         private static readonly MethodInfo MapMethodInfo = typeof(TypeConverterMapper).GetDeclaredMethod(nameof(Map));

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -17,7 +17,7 @@ namespace AutoMapper
         private readonly List<MemberInfo> _memberChain = new List<MemberInfo>();
         private readonly List<ValueTransformerConfiguration> _valueTransformerConfigs = new List<ValueTransformerConfiguration>();
 
-        internal static PropertyMap Default { get; } = new PropertyMap(default(MemberInfo), default(TypeMap));
+        internal static PropertyMap Default { get; } = new PropertyMap(default(MemberInfo), default);
         
         public PropertyMap(PathMap pathMap)
         {

--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -142,7 +142,13 @@ namespace AutoMapper.QueryableExtensions
             return result;
         }
 
-        private LambdaExpression[] CreateMapExpression(ExpressionRequest request) => CreateMapExpression(request, new Dictionary<ExpressionRequest, int>(), new FirstPassLetPropertyMaps(_configurationProvider));
+        private LambdaExpression[] CreateMapExpression(ExpressionRequest request) => CreateMapExpression(request, new Dictionary<ExpressionRequest, int>(),
+#if DYNAMIC_METHODS
+            new FirstPassLetPropertyMaps(_configurationProvider)
+#else
+            LetPropertyMaps.Default
+#endif
+            );
 
         public LambdaExpression[] CreateMapExpression(ExpressionRequest request, TypePairCount typePairCount, LetPropertyMaps letPropertyMaps)
         {
@@ -547,7 +553,7 @@ namespace AutoMapper.QueryableExtensions
         public virtual LetPropertyMaps New() => Default;
 
         public virtual QueryExpressions GetSubQueryExpression(ExpressionBuilder builder, Expression projection, TypeMap typeMap, ExpressionRequest request, Expression instanceParameter, TypePairCount typePairCount)
-            => throw new NotImplementedException("Cannot generate let expression on this platform to handle complex projections where an expression refers to a parameter in an outer scope.");
+            => new QueryExpressions(projection);
 
         public struct PropertyPath
         {

--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -434,6 +434,7 @@ namespace AutoMapper.QueryableExtensions
 
             public override LetPropertyMaps New() => new FirstPassLetPropertyMaps(_configurationProvider);
 
+#if DYNAMIC_METHODS
             public override QueryExpressions GetSubQueryExpression(ExpressionBuilder builder, Expression projection, TypeMap typeMap, ExpressionRequest request, Expression instanceParameter, TypePairCount typePairCount)
             {
                 var letMapInfos = _savedPaths.Select(path => new
@@ -449,6 +450,7 @@ namespace AutoMapper.QueryableExtensions
                 }).ToArray();
 
                 var properties = letMapInfos.Select(m => m.Property).Concat(GetMemberAccessesVisitor.Retrieve(projection, instanceParameter));
+
                 var letType = ProxyGenerator.GetSimilarType(typeof(object), properties);
                 var typeMapFactory = new TypeMapFactory();
                 TypeMap firstTypeMap;
@@ -476,6 +478,7 @@ namespace AutoMapper.QueryableExtensions
                     projection = new ReplaceMemberAccessesVisitor(instanceParameter, secondParameter).Visit(projection);
                 }
             }
+#endif
 
             class GetMemberAccessesVisitor : ExpressionVisitor
             {
@@ -544,7 +547,7 @@ namespace AutoMapper.QueryableExtensions
         public virtual LetPropertyMaps New() => Default;
 
         public virtual QueryExpressions GetSubQueryExpression(ExpressionBuilder builder, Expression projection, TypeMap typeMap, ExpressionRequest request, Expression instanceParameter, TypePairCount typePairCount)
-            => throw new NotImplementedException();
+            => throw new NotImplementedException("Cannot generate let expression on this platform to handle complex projections where an expression refers to a parameter in an outer scope.");
 
         public struct PropertyPath
         {

--- a/src/AutoMapper/TypeExtensions.cs
+++ b/src/AutoMapper/TypeExtensions.cs
@@ -2,11 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Reflection.Emit;
 
 namespace AutoMapper
 {
-#if NET45
+#if DYNAMIC_METHODS
     using System.Reflection.Emit;
 #endif
 
@@ -22,16 +21,12 @@ namespace AutoMapper
 
         public static IEnumerable<ConstructorInfo> GetDeclaredConstructors(this Type type) => type.GetTypeInfo().DeclaredConstructors;
 
-#if !NET45
-        public static MethodInfo GetAddMethod(this EventInfo eventInfo) => eventInfo.AddMethod;
-
-        public static MethodInfo GetRemoveMethod(this EventInfo eventInfo) => eventInfo.RemoveMethod;
-#endif
-
+#if DYNAMIC_METHODS
         public static Type CreateType(this TypeBuilder type)
         {
             return type.CreateTypeInfo().AsType();
         }
+#endif
 
         public static IEnumerable<MemberInfo> GetDeclaredMembers(this Type type) => type.GetTypeInfo().DeclaredMembers;
 

--- a/src/UnitTests/AutoMapper.UnitTests.csproj
+++ b/src/UnitTests/AutoMapper.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0;netcoreapp1.1;</TargetFrameworks>
     <AssemblyName>AutoMapper.UnitTests</AssemblyName>
     <PackageId>AutoMapper.UnitTests</PackageId>
     <NoWarn>$(NoWarn);0649</NoWarn>

--- a/src/UnitTests/AutoMapper.UnitTests.csproj
+++ b/src/UnitTests/AutoMapper.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>AutoMapper.UnitTests</AssemblyName>
     <PackageId>AutoMapper.UnitTests</PackageId>
     <NoWarn>$(NoWarn);0649</NoWarn>
@@ -9,6 +9,10 @@
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <DefineConstants>NET45</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' OR '$(TargetFramework)' == 'netcoreapp2.0'">
+    <DefineConstants>DYNAMIC_METHODS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/UnitTests/Bug/MapAtRuntimeWithCollections/EntityDTO20.cs
+++ b/src/UnitTests/Bug/MapAtRuntimeWithCollections/EntityDTO20.cs
@@ -8,7 +8,6 @@ namespace OmmitedDTOModel3WithCollections
 {
     public class EntityDTO20 : BaseEntity
     {
-        //TODO Remove comments
         public EntityDTO20()
         {
             this.Entities8 = new List<EntityDTO8>();

--- a/src/UnitTests/DynamicMapping.cs
+++ b/src/UnitTests/DynamicMapping.cs
@@ -306,6 +306,7 @@ namespace AutoMapper.UnitTests.DynamicMapping
         }
     }
 
+#if DYNAMIC_METHODS
     public class When_mapping_from_an_anonymous_type_to_an_interface : NonValidatingSpecBase
     {
         private IDestination _result;
@@ -328,6 +329,7 @@ namespace AutoMapper.UnitTests.DynamicMapping
 
         protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => { });
     }
+#endif
 
     public class When_dynamically_mapping_a_badly_configured_map : NonValidatingSpecBase
     {

--- a/src/UnitTests/InterfaceMapping.cs
+++ b/src/UnitTests/InterfaceMapping.cs
@@ -1,3 +1,4 @@
+#if DYNAMIC_METHODS
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -612,3 +613,4 @@ namespace AutoMapper.UnitTests.InterfaceMapping
 
     }
 }
+#endif

--- a/src/UnitTests/Internal/CreateProxyThreading.cs
+++ b/src/UnitTests/Internal/CreateProxyThreading.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if DYNAMIC_METHODS
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper.Execution;
@@ -35,3 +36,4 @@ namespace AutoMapper.UnitTests
 
     }
 }
+#endif

--- a/src/UnitTests/Projection/ProjectionTests.cs
+++ b/src/UnitTests/Projection/ProjectionTests.cs
@@ -5,6 +5,65 @@
     using Shouldly;
     using AutoMapper;
     using QueryableExtensions;
+    using System.Collections.Generic;
+    using System.Linq.Expressions;
+
+    public class InMemoryMapObjectPropertyFromSubQuery : AutoMapperSpecBase
+    {
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Product, ProductModel>()
+                .ForMember(d => d.Price, o => o.MapFrom(source => source.Articles.Where(x => x.IsDefault && x.NationId == 1 && source.ECommercePublished).FirstOrDefault()));
+            cfg.CreateMap<Article, PriceModel>()
+                .ForMember(d => d.RegionId, o => o.MapFrom(s => s.NationId));
+        });
+
+        [Fact]
+        public void Should_cache_the_subquery()
+        {
+            var products = new[] { new Product { Id = 1, ECommercePublished = true, Articles = new[] { new Article { Id = 1, IsDefault = true, NationId = 1, ProductId = 1 } } } }.AsQueryable();
+            var projection = products.ProjectTo<ProductModel>(Configuration);
+            var productModel = projection.First();
+            productModel.Price.RegionId.ShouldBe((short)1);
+            productModel.Price.IsDefault.ShouldBeTrue();
+            productModel.Price.Id.ShouldBe(1);
+            productModel.Id.ShouldBe(1);
+        }
+
+        public partial class Article
+        {
+            public int Id { get; set; }
+            public int ProductId { get; set; }
+            public bool IsDefault { get; set; }
+            public short NationId { get; set; }
+            public virtual Product Product { get; set; }
+        }
+
+        public partial class Product
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public bool ECommercePublished { get; set; }
+            public virtual ICollection<Article> Articles { get; set; }
+            public int Value { get; }
+            public int NotMappedValue { get; set; }
+            public virtual List<Article> OtherArticles { get; }
+        }
+
+        public class PriceModel
+        {
+            public int Id { get; set; }
+            public short RegionId { get; set; }
+            public bool IsDefault { get; set; }
+        }
+
+        public class ProductModel
+        {
+            public int Id { get; set; }
+            public PriceModel Price { get; set; }
+        }
+    }
+
 
     public class ProjectionTests
     {


### PR DESCRIPTION
Fixes #2680 

I had to target `netcoreapp2.0` directly. This will be an issue for folks using referencing AutoMapper transitively.

See https://github.com/dotnet/corefx/issues/29365

I think based on this we may want to consider removing any references to `System.Reflection.Emit`. This would mean losing support for mapping to interfaces, as well as the way we're doing `let` expressions for complex MapFrom's.