### PR TITLE
fix PropertiesWithAnInaccessibleSetter

### DIFF
--- a/src/AutoMapper/TypeExtensions.cs
+++ b/src/AutoMapper/TypeExtensions.cs
@@ -81,7 +81,7 @@ namespace AutoMapper
 
         public static IEnumerable<PropertyInfo> PropertiesWithAnInaccessibleSetter(this Type type)
         {
-            return type.GetDeclaredProperties().Where(pm => pm.HasAnInaccessibleSetter());
+            return type.GetRuntimeProperties().Where(pm => pm.HasAnInaccessibleSetter());
         }
 
         public static bool HasAnInaccessibleSetter(this PropertyInfo property)

--- a/src/UnitTests/IgnoreAllPropertiesWithAnInaccessibleSetterTests.cs
+++ b/src/UnitTests/IgnoreAllPropertiesWithAnInaccessibleSetterTests.cs
@@ -1,0 +1,43 @@
+﻿using Xunit;
+
+namespace AutoMapper.UnitTests
+{
+    public class SomeSource
+    {
+        public int IgnoreMe { get; set; }
+    }
+
+    public class Destination : DestinationBase
+    {
+    }
+
+    public class DestinationBase
+    {
+        public int IgnoreMe { get; private set; }
+    }
+
+    public class IgnoreAllPropertiesWithAnInaccessibleSetterTests
+    {
+        [Fact]
+        public void AutoMapper_SimpleObject_IgnoresPrivateSettersInBaseClasses()
+        {
+            // Arrange
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<SomeSource, Destination>()
+                    .IgnoreAllPropertiesWithAnInaccessibleSetter();
+            });
+            var mapper = config.CreateMapper();
+
+            var source = new SomeSource { IgnoreMe = 666 };
+            var destination = new Destination();
+
+            // Act
+            mapper.Map(source, destination);
+
+            // Assert
+            config.AssertConfigurationIsValid();
+            Assert.Equal(0, destination.IgnoreMe);
+        }
+    }
+}


### PR DESCRIPTION
Fix PropertiesWithAnInaccessibleSetter so that it also respects inherited properties, not only declared ones.
Fixes #2740.