### PR TITLE
Fix #2753

### DIFF
--- a/src/UnitTests/Bug/ObjectSubstitutionFailure.cs
+++ b/src/UnitTests/Bug/ObjectSubstitutionFailure.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    namespace ObjectSubstitutionFailure
+    {
+        using Shouldly;
+        using Xunit;
+
+        public class Parent
+        {
+            public IEnumerable<Child> Children => new[] { new Child() };
+        }
+
+        public class Child
+        {
+
+        }
+
+        public class ChildDto
+        {
+
+        }
+
+        public class OverrideExample : AutoMapperSpecBase
+        {
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg
+                    .CreateMap<Parent, IEnumerable<ChildDto>>()
+                    .Substitute(x => x.Children);
+
+                cfg
+                    .CreateMap<Child, ChildDto>();
+            });
+
+            [Fact]
+            public void Should_substitute_correct_object()
+            {
+                Mapper
+                    .Map<IEnumerable<ChildDto>>(new Parent())
+                    .ShouldNotBeNull();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This fixes #2753. The docs on `Substitute` say: "Replace the original runtime instance with a new source instance. [...] The returned source object will be mapped instead of what was supplied in the original source object."

This would only work if `TSubstitute` would cast to `TDestination`. This fix enables the feature for arbitrary `TDestination`s.