### PR TITLE
Value converters

### DIFF
--- a/default.ps1
+++ b/default.ps1
@@ -4,12 +4,18 @@ properties {
 	$source_dir = "$base_dir\src"
 	$result_dir = "$build_dir\results"
 	$global:config = "debug"
+	$tag = $(git tag -l --points-at HEAD)
+	$revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
+	$suffix = @{ $true = ""; $false = "ci-$revision"}[$tag -ne $NULL -and $revision -ne "local"]
+	$commitHash = $(git rev-parse --short HEAD)
+	$buildSuffix = @{ $true = "$($suffix)-$($commitHash)"; $false = "$($branch)-$($commitHash)" }[$suffix -ne ""]
+    $versionSuffix = @{ $true = "--version-suffix=$($suffix)"; $false = ""}[$suffix -ne ""]
 }
 
 
 task default -depends local
 task local -depends compile, test
-task ci -depends clean, release, local, benchmark
+task ci -depends clean, release, local, pack, benchmark
 
 task clean {
 	rd "$source_dir\artifacts" -recurse -force  -ErrorAction SilentlyContinue | out-null
@@ -21,14 +27,6 @@ task release {
 }
 
 task compile -depends clean {
-
-	$tag = $(git tag -l --points-at HEAD)
-	$revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
-	$suffix = @{ $true = ""; $false = "ci-$revision"}[$tag -ne $NULL -and $revision -ne "local"]
-	$commitHash = $(git rev-parse --short HEAD)
-	$buildSuffix = @{ $true = "$($suffix)-$($commitHash)"; $false = "$($branch)-$($commitHash)" }[$suffix -ne ""]
-    $versionSuffix = @{ $true = "--version-suffix=$($suffix)"; $false = ""}[$suffix -ne ""]
-
 	echo "build: Tag is $tag"
 	echo "build: Package version suffix is $suffix"
 	echo "build: Build version suffix is $buildSuffix" 
@@ -37,7 +35,9 @@ task compile -depends clean {
 	exec { dotnet --info }
 
     exec { dotnet build -c $config --version-suffix=$buildSuffix }
+}
 
+task pack -depends compile {
 	exec { dotnet pack $source_dir\AutoMapper\AutoMapper.csproj -c $config --include-symbols --no-build $versionSuffix }
 }
 

--- a/docs/Dependency-injection.md
+++ b/docs/Dependency-injection.md
@@ -1,6 +1,6 @@
 # Dependency Injection
 
-AutoMapper supports the ability to construct [Custom Value Resolvers](Custom-value-resolvers.html) and [Custom Type Converters](Custom-type-converters.html) using static service location:
+AutoMapper supports the ability to construct [Custom Value Resolvers](Custom-value-resolvers.html), [Custom Type Converters](Custom-type-converters.html), and [Value Converters](Value-converters.html) using static service location:
 
 ```c#
 Mapper.Initialize(cfg =>

--- a/docs/Value-converters.md
+++ b/docs/Value-converters.md
@@ -1,0 +1,76 @@
+# Value Converters
+
+Value converters are a cross between [Type Converters](Custom-type-converters.html) and [Value Resolvers](Custom-value-resolvers.html). Type converters are globally scoped, so that any time you map from type `Foo` to type `Bar` in any mapping, the type converter will be used. Value resolvers are scoped to a single map, and receive the source and destination objects to resolve to a value to map to the destination member. Optionally value resolvers can receive the source member as well.
+
+In simplified syntax:
+
+ - Type converter = `Func<TSource, TDestination, TDestination>`
+ - Value resolver = `Func<TSource, TDestination, TDestinationMember>`
+ - Member value resolver = `Func<TSource, TDestination, TSourceMember, TDestinationMember>`
+ - Value converter = `Func<TSourceMember, TDestinationMember>`
+
+ To configure a value converter, use at the member level:
+
+ ```c#
+ public class CurrencyFormatter : IValueConverter<decimal, string> {
+     public decimal Convert(decimal source)
+         => source.ToString("c");
+ }
+
+ Mapper.Initialize(cfg => {
+    cfg.CreateMap<Order, OrderDto>()
+        .ForMember(d => d.Amount, opt => opt.ConvertUsing(new CurrencyFormatter()));
+    cfg.CreateMap<OrderLineItem, OrderLineItemDto>()
+        .ForMember(d => d.Total, opt => opt.ConvertUsing(new CurrencyFormatter()));
+ });
+ ```
+
+You can customize the source member when the source member name does not match:
+
+ ```c#
+ public class CurrencyFormatter : IValueConverter<decimal, string> {
+     public decimal Convert(decimal source)
+         => source.ToString("c");
+ }
+
+ Mapper.Initialize(cfg => {
+    cfg.CreateMap<Order, OrderDto>()
+        .ForMember(d => d.Amount, opt => opt.ConvertUsing(new CurrencyFormatter(), src => src.OrderAmount));
+    cfg.CreateMap<OrderLineItem, OrderLineItemDto>()
+        .ForMember(d => d.Total, opt => opt.ConvertUsing(new CurrencyFormatter(), src => src.LITotal));
+ });
+ ```
+
+If you need the value converters instantiated by the [service locator](Dependency-injection.html), you can specify the type instead:
+
+ ```c#
+ public class CurrencyFormatter : IValueConverter<decimal, string> {
+     public decimal Convert(decimal source)
+         => source.ToString("c");
+ }
+
+ Mapper.Initialize(cfg => {
+    cfg.CreateMap<Order, OrderDto>()
+        .ForMember(d => d.Amount, opt => opt.ConvertUsing<CurrencyFormatter, decimal>());
+    cfg.CreateMap<OrderLineItem, OrderLineItemDto>()
+        .ForMember(d => d.Total, opt => opt.ConvertUsing<CurrencyFormatter, decimal>());
+ });
+ ```
+
+If you do not know the types or member names at runtime, use the various overloads that accept `System.Type` and `string`-based members:
+
+ ```c#
+ public class CurrencyFormatter : IValueConverter<decimal, string> {
+     public decimal Convert(decimal source)
+         => source.ToString("c");
+ }
+
+ Mapper.Initialize(cfg => {
+    cfg.CreateMap(typeof(Order), typeof(OrderDto))
+        .ForMember("Amount", opt => opt.ConvertUsing(new CurrencyFormatter(), "OrderAmount"));
+    cfg.CreateMap(typeof(OrderLineItem), typeof(OrderLineItemDto))
+        .ForMember("Total", opt => opt.ConvertUsing(new CurrencyFormatter(), "LITotal"));
+ });
+ ```
+
+ Value converters are only used for in-memory mapping execution. They will not work for [`ProjectTo`](Queryable-Extensions.html).

--- a/docs/Value-converters.md
+++ b/docs/Value-converters.md
@@ -1,6 +1,6 @@
 # Value Converters
 
-Value converters are a cross between [Type Converters](Custom-type-converters.html) and [Value Resolvers](Custom-value-resolvers.html). Type converters are globally scoped, so that any time you map from type `Foo` to type `Bar` in any mapping, the type converter will be used. Value resolvers are scoped to a single map, and receive the source and destination objects to resolve to a value to map to the destination member. Optionally value resolvers can receive the source member as well.
+Value converters are a cross between [Type Converters](Custom-type-converters.html) and [Value Resolvers](Custom-value-resolvers.html). Type converters are globally scoped, so that any time you map from type `Foo` to type `Bar` in any mapping, the type converter will be used. Value converters are scoped to a single map, and receive the source and destination objects to resolve to a value to map to the destination member. Optionally value converters can receive the source member as well.
 
 In simplified syntax:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,7 @@ New to AutoMapper? Check out the :doc:`Getting-started` page first.
    Nested-mappings
    Custom-type-converters
    Custom-value-resolvers
+   Value-converters
    Value-transformers
    Null-substitution
    Before-and-after-map-actions

--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -128,28 +128,11 @@ namespace AutoMapper.Configuration
                 PropertyMapActions.Add(pm => pm.ValueResolverConfig = config);
             }
 
-            public void ConvertUsing(Type valueConverterType)
-            {
-                PropertyMapActions.Add(pm =>
-                {
-                    var config = new ValueConverterConfiguration(valueConverterType, valueConverterType.GetGenericInterface(typeof(IValueConverter<,>)));
+            public void ConvertUsing(Type valueConverterType) 
+                => PropertyMapActions.Add(pm => ConvertUsing(pm, valueConverterType));
 
-                    pm.ValueConverterConfig = config;
-                });
-            }
-
-            public void ConvertUsing(Type valueConverterType, string sourceMemberName)
-            {
-                PropertyMapActions.Add(pm =>
-                {
-                    var config = new ValueConverterConfiguration(valueConverterType, valueConverterType.GetGenericInterface(typeof(IValueConverter<,>)))
-                    {
-                        SourceMemberName = sourceMemberName
-                    };
-
-                    pm.ValueConverterConfig = config;
-                });
-            }
+            public void ConvertUsing(Type valueConverterType, string sourceMemberName) 
+                => PropertyMapActions.Add(pm => ConvertUsing(pm, valueConverterType, sourceMemberName));
 
             public void ConvertUsing<TSourceMember, TDestinationMember>(IValueConverter<TSourceMember, TDestinationMember> valueConverter, string sourceMemberName)
             {
@@ -162,6 +145,16 @@ namespace AutoMapper.Configuration
 
                     pm.ValueConverterConfig = config;
                 });
+            }
+
+            private static void ConvertUsing(PropertyMap propertyMap, Type valueConverterType, string sourceMemberName = null)
+            {
+                var config = new ValueConverterConfiguration(valueConverterType, valueConverterType.GetGenericInterface(typeof(IValueConverter<,>)))
+                {
+                    SourceMemberName = sourceMemberName
+                };
+
+                propertyMap.ValueConverterConfig = config;
             }
         }
 

--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -127,6 +127,42 @@ namespace AutoMapper.Configuration
 
                 PropertyMapActions.Add(pm => pm.ValueResolverConfig = config);
             }
+
+            public void ConvertUsing(Type valueConverterType)
+            {
+                PropertyMapActions.Add(pm =>
+                {
+                    var config = new ValueConverterConfiguration(valueConverterType, valueConverterType.GetGenericInterface(typeof(IValueConverter<,>)));
+
+                    pm.ValueConverterConfig = config;
+                });
+            }
+
+            public void ConvertUsing(Type valueConverterType, string sourceMemberName)
+            {
+                PropertyMapActions.Add(pm =>
+                {
+                    var config = new ValueConverterConfiguration(valueConverterType, valueConverterType.GetGenericInterface(typeof(IValueConverter<,>)))
+                    {
+                        SourceMemberName = sourceMemberName
+                    };
+
+                    pm.ValueConverterConfig = config;
+                });
+            }
+
+            public void ConvertUsing<TSourceMember, TDestinationMember>(IValueConverter<TSourceMember, TDestinationMember> valueConverter, string sourceMemberName)
+            {
+                PropertyMapActions.Add(pm =>
+                {
+                    var config = new ValueConverterConfiguration(valueConverter, typeof(IValueConverter<TSourceMember, TDestinationMember>))
+                    {
+                        SourceMemberName = sourceMemberName
+                    };
+
+                    pm.ValueConverterConfig = config;
+                });
+            }
         }
 
     }

--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -310,6 +310,30 @@ namespace AutoMapper.Configuration
             });
         }
 
+        public void ConvertUsing<TSourceMember>(IValueConverter<TSourceMember, TMember> valueConverter)
+        {
+            PropertyMapActions.Add(pm =>
+            {
+                var config = new ValueConverterConfiguration(valueConverter,
+                    typeof(IValueConverter<TSourceMember, TMember>));
+
+                pm.ValueConverterConfig = config;
+            });
+        }
+
+        public void ConvertUsing<TSourceMember>(IValueConverter<TSourceMember, TMember> valueConverter, Expression<Func<TSource, TSourceMember>> sourceMember)
+        {
+            PropertyMapActions.Add(pm =>
+            {
+                var config = new ValueConverterConfiguration(valueConverter, typeof(IValueConverter<TSourceMember, TMember>))
+                {
+                    SourceMember = sourceMember
+                };
+
+                pm.ValueConverterConfig = config;
+            });
+        }
+
         public void Configure(TypeMap typeMap)
         {
             var destMember = DestinationMember;

--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -284,6 +284,18 @@ namespace AutoMapper.Configuration
             PropertyMapActions.Add(pm => pm.MappingOrder = mappingOrder);
         }
 
+        public void ConvertUsing<TValueConverter, TSourceMember>()
+            where TValueConverter : IValueConverter<TSourceMember, TMember>
+        {
+            PropertyMapActions.Add(pm =>
+            {
+                var config = new ValueConverterConfiguration(typeof(TValueConverter),
+                    typeof(IValueConverter<TSourceMember, TMember>));
+
+                pm.ValueConverterConfig = config;
+            });
+        }
+
         public void Configure(TypeMap typeMap)
         {
             var destMember = _destinationMember;

--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -310,6 +310,21 @@ namespace AutoMapper.Configuration
             });
         }
 
+        public void ConvertUsing<TValueConverter, TSourceMember>(string sourceMemberName)
+            where TValueConverter : IValueConverter<TSourceMember, TMember>
+        {
+            PropertyMapActions.Add(pm =>
+            {
+                var config = new ValueConverterConfiguration(typeof(TValueConverter),
+                    typeof(IValueConverter<TSourceMember, TMember>))
+                {
+                    SourceMemberName = sourceMemberName
+                };
+
+                pm.ValueConverterConfig = config;
+            });
+        }
+
         public void ConvertUsing<TSourceMember>(IValueConverter<TSourceMember, TMember> valueConverter)
         {
             PropertyMapActions.Add(pm =>
@@ -328,6 +343,19 @@ namespace AutoMapper.Configuration
                 var config = new ValueConverterConfiguration(valueConverter, typeof(IValueConverter<TSourceMember, TMember>))
                 {
                     SourceMember = sourceMember
+                };
+
+                pm.ValueConverterConfig = config;
+            });
+        }
+
+        public void ConvertUsing<TSourceMember>(IValueConverter<TSourceMember, TMember> valueConverter, string sourceMemberName)
+        {
+            PropertyMapActions.Add(pm =>
+            {
+                var config = new ValueConverterConfiguration(valueConverter, typeof(IValueConverter<TSourceMember, TMember>))
+                {
+                    SourceMemberName = sourceMemberName
                 };
 
                 pm.ValueConverterConfig = config;

--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -285,81 +285,50 @@ namespace AutoMapper.Configuration
 
         public void ConvertUsing<TValueConverter, TSourceMember>()
             where TValueConverter : IValueConverter<TSourceMember, TMember>
-        {
-            PropertyMapActions.Add(pm =>
-            {
-                var config = new ValueConverterConfiguration(typeof(TValueConverter),
-                    typeof(IValueConverter<TSourceMember, TMember>));
-
-                pm.ValueConverterConfig = config;
-            });
-        }
+            => PropertyMapActions.Add(pm => ConvertUsing<TValueConverter, TSourceMember>(pm));
 
         public void ConvertUsing<TValueConverter, TSourceMember>(Expression<Func<TSource, TSourceMember>> sourceMember)
             where TValueConverter : IValueConverter<TSourceMember, TMember>
-        {
-            PropertyMapActions.Add(pm =>
-            {
-                var config = new ValueConverterConfiguration(typeof(TValueConverter),
-                    typeof(IValueConverter<TSourceMember, TMember>))
-                {
-                    SourceMember = sourceMember
-                };
-
-                pm.ValueConverterConfig = config;
-            });
-        }
+            => PropertyMapActions.Add(pm => ConvertUsing<TValueConverter, TSourceMember>(pm, sourceMember));
 
         public void ConvertUsing<TValueConverter, TSourceMember>(string sourceMemberName)
             where TValueConverter : IValueConverter<TSourceMember, TMember>
-        {
-            PropertyMapActions.Add(pm =>
-            {
-                var config = new ValueConverterConfiguration(typeof(TValueConverter),
-                    typeof(IValueConverter<TSourceMember, TMember>))
-                {
-                    SourceMemberName = sourceMemberName
-                };
-
-                pm.ValueConverterConfig = config;
-            });
-        }
+            => PropertyMapActions.Add(pm => ConvertUsing<TValueConverter, TSourceMember>(pm, sourceMemberName: sourceMemberName));
 
         public void ConvertUsing<TSourceMember>(IValueConverter<TSourceMember, TMember> valueConverter)
-        {
-            PropertyMapActions.Add(pm =>
-            {
-                var config = new ValueConverterConfiguration(valueConverter,
-                    typeof(IValueConverter<TSourceMember, TMember>));
-
-                pm.ValueConverterConfig = config;
-            });
-        }
+            => PropertyMapActions.Add(pm => ConvertUsing(pm, valueConverter));
 
         public void ConvertUsing<TSourceMember>(IValueConverter<TSourceMember, TMember> valueConverter, Expression<Func<TSource, TSourceMember>> sourceMember)
-        {
-            PropertyMapActions.Add(pm =>
-            {
-                var config = new ValueConverterConfiguration(valueConverter, typeof(IValueConverter<TSourceMember, TMember>))
-                {
-                    SourceMember = sourceMember
-                };
+            => PropertyMapActions.Add(pm => ConvertUsing(pm, valueConverter, sourceMember));
 
-                pm.ValueConverterConfig = config;
-            });
+        public void ConvertUsing<TSourceMember>(IValueConverter<TSourceMember, TMember> valueConverter, string sourceMemberName) 
+            => PropertyMapActions.Add(pm => ConvertUsing(pm, valueConverter, sourceMemberName: sourceMemberName));
+
+        private static void ConvertUsing<TValueConverter, TSourceMember>(PropertyMap propertyMap,
+            Expression<Func<TSource, TSourceMember>> sourceMember = null,
+            string sourceMemberName = null)
+        {
+            var config = new ValueConverterConfiguration(typeof(TValueConverter),
+                typeof(IValueConverter<TSourceMember, TMember>))
+            {
+                SourceMember = sourceMember,
+                SourceMemberName = sourceMemberName
+            };
+
+            propertyMap.ValueConverterConfig = config;
         }
 
-        public void ConvertUsing<TSourceMember>(IValueConverter<TSourceMember, TMember> valueConverter, string sourceMemberName)
+        private static void ConvertUsing<TSourceMember>(PropertyMap propertyMap, IValueConverter<TSourceMember, TMember> valueConverter,
+            Expression<Func<TSource, TSourceMember>> sourceMember = null, string sourceMemberName = null)
         {
-            PropertyMapActions.Add(pm =>
+            var config = new ValueConverterConfiguration(valueConverter,
+                typeof(IValueConverter<TSourceMember, TMember>))
             {
-                var config = new ValueConverterConfiguration(valueConverter, typeof(IValueConverter<TSourceMember, TMember>))
-                {
-                    SourceMemberName = sourceMemberName
-                };
+                SourceMember = sourceMember,
+                SourceMemberName = sourceMemberName
+            };
 
-                pm.ValueConverterConfig = config;
-            });
+            propertyMap.ValueConverterConfig = config;
         }
 
         public void Configure(TypeMap typeMap)

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -499,17 +499,15 @@ namespace AutoMapper.Execution
         {
             Expression valueResolverFunc;
             var destinationPropertyType = propertyMap.DestinationPropertyType;
-            var valueResolverConfig = propertyMap.ValueResolverConfig;
-            var typeMap = propertyMap.TypeMap;
 
             if (propertyMap.ValueConverterConfig != null)
             {
                 valueResolverFunc = ToType(BuildConvertCall(propertyMap),
                     destinationPropertyType);
             }
-            else if (valueResolverConfig != null)
+            else if (propertyMap.ValueResolverConfig != null)
             {
-                valueResolverFunc = ToType(BuildResolveCall(destValueExpr, valueResolverConfig),
+                valueResolverFunc = ToType(BuildResolveCall(destValueExpr, propertyMap.ValueResolverConfig),
                     destinationPropertyType);
             }
             else if (propertyMap.CustomResolver != null)
@@ -555,7 +553,7 @@ namespace AutoMapper.Execution
                 var nullSubstitute = Constant(propertyMap.NullSubstitute);
                 valueResolverFunc = Coalesce(valueResolverFunc, ToType(nullSubstitute, valueResolverFunc.Type));
             }
-            else if (!typeMap.Profile.AllowNullDestinationValues)
+            else if (!propertyMap.TypeMap.Profile.AllowNullDestinationValues)
             {
                 var toCreate = propertyMap.SourceType ?? destinationPropertyType;
                 if (!toCreate.IsAbstract() && toCreate.IsClass())

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -614,10 +614,19 @@ namespace AutoMapper.Execution
             var sourceMember = valueConverterConfig.SourceMember?.ReplaceParameters(Source) ??
                                (valueConverterConfig.SourceMemberName != null
                                    ? PropertyOrField(Source, valueConverterConfig.SourceMemberName)
-                                   : Chain(propertyMap.SourceMembers, iResolverTypeArgs[1]));
+                                   : propertyMap.SourceMembers.Any()
+                                       ? Chain(propertyMap.SourceMembers, iResolverTypeArgs[1])
+                                       : Block(
+                                           Throw(Constant(BuildExceptionMessage())),
+                                           Default(iResolverTypeArgs[0])
+                                       )
+                               );
 
             return Call(ToType(resolverInstance, iResolverType), iResolverType.GetDeclaredMethod("Convert"),
                 ToType(sourceMember, iResolverTypeArgs[0]), Context);
+
+            AutoMapperConfigurationException BuildExceptionMessage() 
+                => new AutoMapperConfigurationException($"Cannot find a source member to pass to the value converter of type {valueConverterConfig.ConcreteType.FullName}. Configure a source member to map from.");
         }
     }
 }

--- a/src/AutoMapper/IMemberConfigurationExpression.cs
+++ b/src/AutoMapper/IMemberConfigurationExpression.cs
@@ -212,16 +212,17 @@ namespace AutoMapper
         /// <param name="transformer">Transformation expression</param>
         void AddTransform(Expression<Func<TMember, TMember>> transformer);
 
-        void ConvertUsing<TValueConverter, TSourceMember>()
-            where TValueConverter : IValueConverter<TSourceMember, TMember>;
+        void ConvertUsing<TValueConverter, TSourceMember>() where TValueConverter : IValueConverter<TSourceMember, TMember>;
 
-        void ConvertUsing<TValueConverter, TSourceMember>(Expression<Func<TSource, TSourceMember>> sourceMember)
-            where TValueConverter : IValueConverter<TSourceMember, TMember>;
+        void ConvertUsing<TValueConverter, TSourceMember>(Expression<Func<TSource, TSourceMember>> sourceMember) where TValueConverter : IValueConverter<TSourceMember, TMember>;
+
+        void ConvertUsing<TValueConverter, TSourceMember>(string sourceMemberName) where TValueConverter : IValueConverter<TSourceMember, TMember>;
 
         void ConvertUsing<TSourceMember>(IValueConverter<TSourceMember, TMember> valueConverter);
 
         void ConvertUsing<TSourceMember>(IValueConverter<TSourceMember, TMember> valueConverter, Expression<Func<TSource, TSourceMember>> sourceMember);
 
+        void ConvertUsing<TSourceMember>(IValueConverter<TSourceMember, TMember> valueConverter, string sourceMemberName);
     }
 
     /// <summary>
@@ -251,5 +252,9 @@ namespace AutoMapper
         /// <param name="memberName">Source member to supply to value resolver</param>
         /// <returns>Resolution expression</returns>
         void ResolveUsing<TSource, TDestination, TSourceMember, TDestMember>(IMemberValueResolver<TSource, TDestination, TSourceMember, TDestMember> valueResolver, string memberName);
+
+        void ConvertUsing(Type valueConverterType);
+        void ConvertUsing(Type valueConverterType, string sourceMemberName);
+        void ConvertUsing<TSourceMember, TDestinationMember>(IValueConverter<TSourceMember, TDestinationMember> valueConverter, string sourceMemberName);
     }
 }

--- a/src/AutoMapper/IMemberConfigurationExpression.cs
+++ b/src/AutoMapper/IMemberConfigurationExpression.cs
@@ -214,6 +214,9 @@ namespace AutoMapper
 
         void ConvertUsing<TValueConverter, TSourceMember>()
             where TValueConverter : IValueConverter<TSourceMember, TMember>;
+
+        void ConvertUsing<TValueConverter, TSourceMember>(Expression<Func<TSource, TSourceMember>> sourceMember)
+            where TValueConverter : IValueConverter<TSourceMember, TMember>;
     }
 
     /// <summary>

--- a/src/AutoMapper/IMemberConfigurationExpression.cs
+++ b/src/AutoMapper/IMemberConfigurationExpression.cs
@@ -217,6 +217,11 @@ namespace AutoMapper
 
         void ConvertUsing<TValueConverter, TSourceMember>(Expression<Func<TSource, TSourceMember>> sourceMember)
             where TValueConverter : IValueConverter<TSourceMember, TMember>;
+
+        void ConvertUsing<TSourceMember>(IValueConverter<TSourceMember, TMember> valueConverter);
+
+        void ConvertUsing<TSourceMember>(IValueConverter<TSourceMember, TMember> valueConverter, Expression<Func<TSource, TSourceMember>> sourceMember);
+
     }
 
     /// <summary>

--- a/src/AutoMapper/IMemberConfigurationExpression.cs
+++ b/src/AutoMapper/IMemberConfigurationExpression.cs
@@ -211,6 +211,9 @@ namespace AutoMapper
         /// </summary>
         /// <param name="transformer">Transformation expression</param>
         void AddTransform(Expression<Func<TMember, TMember>> transformer);
+
+        void ConvertUsing<TValueConverter, TSourceMember>()
+            where TValueConverter : IValueConverter<TSourceMember, TMember>;
     }
 
     /// <summary>

--- a/src/AutoMapper/IMemberConfigurationExpression.cs
+++ b/src/AutoMapper/IMemberConfigurationExpression.cs
@@ -212,16 +212,74 @@ namespace AutoMapper
         /// <param name="transformer">Transformation expression</param>
         void AddTransform(Expression<Func<TMember, TMember>> transformer);
 
+        /// <summary>
+        /// Specify a value converter to convert from the matching source member to the destination member
+        /// </summary>
+        /// <remarks>
+        /// Value converters are similar to type converters, but scoped to a single member. Value resolvers receive the enclosed source/destination objects as parameters.
+        /// Value converters do not. This makes it possible to reuse value converters across multiple members and multiple maps.
+        /// </remarks>
+        /// <typeparam name="TValueConverter">Value converter type</typeparam>
+        /// <typeparam name="TSourceMember">Source member type</typeparam>
         void ConvertUsing<TValueConverter, TSourceMember>() where TValueConverter : IValueConverter<TSourceMember, TMember>;
 
+        /// <summary>
+        /// Specify a value converter to convert from the specified source member to the destination member
+        /// </summary>
+        /// <remarks>
+        /// Value converters are similar to type converters, but scoped to a single member. Value resolvers receive the enclosed source/destination objects as parameters.
+        /// Value converters do not. This makes it possible to reuse value converters across multiple members and multiple maps.
+        /// </remarks>
+        /// <typeparam name="TValueConverter">Value converter type</typeparam>
+        /// <typeparam name="TSourceMember">Source member type</typeparam>
+        /// <param name="sourceMember">Source member to supply to the value converter</param>
         void ConvertUsing<TValueConverter, TSourceMember>(Expression<Func<TSource, TSourceMember>> sourceMember) where TValueConverter : IValueConverter<TSourceMember, TMember>;
 
+        /// <summary>
+        /// Specify a value converter to convert from the specified source member name to the destination member
+        /// </summary>
+        /// <remarks>
+        /// Value converters are similar to type converters, but scoped to a single member. Value resolvers receive the enclosed source/destination objects as parameters.
+        /// Value converters do not. This makes it possible to reuse value converters across multiple members and multiple maps.
+        /// </remarks>
+        /// <typeparam name="TValueConverter">Value converter type</typeparam>
+        /// <typeparam name="TSourceMember">Source member type</typeparam>
+        /// <param name="sourceMemberName">Source member name to supply to the value converter</param>
         void ConvertUsing<TValueConverter, TSourceMember>(string sourceMemberName) where TValueConverter : IValueConverter<TSourceMember, TMember>;
 
+        /// <summary>
+        /// Specify a value converter instance to convert from the matching source member to the destination member
+        /// </summary>
+        /// <remarks>
+        /// Value converters are similar to type converters, but scoped to a single member. Value resolvers receive the enclosed source/destination objects as parameters.
+        /// Value converters do not. This makes it possible to reuse value converters across multiple members and multiple maps.
+        /// </remarks>
+        /// <typeparam name="TSourceMember">Source member type</typeparam>
+        /// <param name="valueConverter">Value converter instance</param>
         void ConvertUsing<TSourceMember>(IValueConverter<TSourceMember, TMember> valueConverter);
 
+        /// <summary>
+        /// Specify a value converter instance from the specified source member to the destination member
+        /// </summary>
+        /// <remarks>
+        /// Value converters are similar to type converters, but scoped to a single member. Value resolvers receive the enclosed source/destination objects as parameters.
+        /// Value converters do not. This makes it possible to reuse value converters across multiple members and multiple maps.
+        /// </remarks>
+        /// <typeparam name="TSourceMember">Source member type</typeparam>
+        /// <param name="valueConverter">Value converter instance</param>
+        /// <param name="sourceMember">Source member to supply to the value converter</param>
         void ConvertUsing<TSourceMember>(IValueConverter<TSourceMember, TMember> valueConverter, Expression<Func<TSource, TSourceMember>> sourceMember);
 
+        /// <summary>
+        /// Specify a value converter instance to convert from the specified source member name to the destination member
+        /// </summary>
+        /// <remarks>
+        /// Value converters are similar to type converters, but scoped to a single member. Value resolvers receive the enclosed source/destination objects as parameters.
+        /// Value converters do not. This makes it possible to reuse value converters across multiple members and multiple maps.
+        /// </remarks>
+        /// <typeparam name="TSourceMember">Source member type</typeparam>
+        /// <param name="valueConverter">Value converter instance</param>
+        /// <param name="sourceMemberName">Source member name to supply to the value converter</param>
         void ConvertUsing<TSourceMember>(IValueConverter<TSourceMember, TMember> valueConverter, string sourceMemberName);
     }
 
@@ -253,8 +311,38 @@ namespace AutoMapper
         /// <returns>Resolution expression</returns>
         void ResolveUsing<TSource, TDestination, TSourceMember, TDestMember>(IMemberValueResolver<TSource, TDestination, TSourceMember, TDestMember> valueResolver, string memberName);
 
+        /// <summary>
+        /// Specify a value converter type to convert from the matching source member to the destination member
+        /// </summary>
+        /// <remarks>
+        /// Value converters are similar to type converters, but scoped to a single member. Value resolvers receive the enclosed source/destination objects as parameters.
+        /// Value converters do not. This makes it possible to reuse value converters across multiple members and multiple maps.
+        /// </remarks>
+        /// <param name="valueConverterType">Value converter type</param>
         void ConvertUsing(Type valueConverterType);
+
+        /// <summary>
+        /// Specify a value converter type to convert from the specified source member name to the destination member
+        /// </summary>
+        /// <remarks>
+        /// Value converters are similar to type converters, but scoped to a single member. Value resolvers receive the enclosed source/destination objects as parameters.
+        /// Value converters do not. This makes it possible to reuse value converters across multiple members and multiple maps.
+        /// </remarks>
+        /// <param name="valueConverterType">Value converter type</param>
+        /// <param name="sourceMemberName">Source member name to supply to the value converter</param>
         void ConvertUsing(Type valueConverterType, string sourceMemberName);
+
+        /// <summary>
+        /// Specify a value converter instance to convert from the specified source member name to the destination member
+        /// </summary>
+        /// <remarks>
+        /// Value converters are similar to type converters, but scoped to a single member. Value resolvers receive the enclosed source/destination objects as parameters.
+        /// Value converters do not. This makes it possible to reuse value converters across multiple members and multiple maps.
+        /// </remarks>
+        /// <typeparam name="TSourceMember">Source member type</typeparam>
+        /// <typeparam name="TDestinationMember">Destination member type</typeparam>
+        /// <param name="valueConverter">Value converter instance</param>
+        /// <param name="sourceMemberName">Source member name to supply to the value converter</param>
         void ConvertUsing<TSourceMember, TDestinationMember>(IValueConverter<TSourceMember, TDestinationMember> valueConverter, string sourceMemberName);
     }
 }

--- a/src/AutoMapper/IValueConverter.cs
+++ b/src/AutoMapper/IValueConverter.cs
@@ -1,7 +1,18 @@
 ﻿namespace AutoMapper
 {
+    /// <summary>
+    /// Converts a source member value to a destination member value
+    /// </summary>
+    /// <typeparam name="TSourceMember">Source member type</typeparam>
+    /// <typeparam name="TDestinationMember">Destination member type</typeparam>
     public interface IValueConverter<in TSourceMember, out TDestinationMember>
     {
+        /// <summary>
+        /// Perform conversion from source member value to destination member value
+        /// </summary>
+        /// <param name="sourceMember">Source member object</param>
+        /// <param name="context">Resolution context</param>
+        /// <returns>Destination member value</returns>
         TDestinationMember Convert(TSourceMember sourceMember, ResolutionContext context);
     }
 }

--- a/src/AutoMapper/IValueConverter.cs
+++ b/src/AutoMapper/IValueConverter.cs
@@ -1,0 +1,7 @@
+﻿namespace AutoMapper
+{
+    public interface IValueConverter<in TSourceMember, out TDestinationMember>
+    {
+        TDestinationMember Convert(TSourceMember sourceMember, ResolutionContext context);
+    }
+}

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -80,10 +80,10 @@ namespace AutoMapper
             }
         }
 
-        public Type SourceType => CustomExpression?.ReturnType
-                                  ?? CustomResolver?.ReturnType
+        public Type SourceType => ValueConverterConfig?.SourceMember?.ReturnType
                                   ?? ValueResolverConfig?.SourceMember?.ReturnType
-                                  ?? ValueConverterConfig?.SourceMember?.ReturnType
+                                  ?? CustomResolver?.ReturnType
+                                  ?? CustomExpression?.ReturnType
                                   ?? SourceMember?.GetMemberType();
 
         public void ChainMembers(IEnumerable<MemberInfo> members)

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -136,6 +136,11 @@ namespace AutoMapper
             _valueTransformerConfigs.Add(valueTransformerConfiguration);
         }
 
+        public void ApplyValueConverter()
+        {
+
+        }
+
         private class MemberFinderVisitor : ExpressionVisitor
         {
             public MemberExpression Member { get; private set; }

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -58,6 +58,7 @@ namespace AutoMapper
         public bool ExplicitExpansion { get; set; }
         public object NullSubstitute { get; set; }
         public ValueResolverConfiguration ValueResolverConfig { get; set; }
+        public ValueConverterConfiguration ValueConverterConfig { get; set; }
         public IEnumerable<ValueTransformerConfiguration> ValueTransformers => _valueTransformerConfigs;
 
         public MemberInfo SourceMember
@@ -94,6 +95,7 @@ namespace AutoMapper
         }
 
 
+
         public void ChainMembers(IEnumerable<MemberInfo> members)
         {
             var getters = members as IList<MemberInfo> ?? members.ToList();
@@ -113,6 +115,7 @@ namespace AutoMapper
             NullSubstitute = NullSubstitute ?? inheritedMappedProperty.NullSubstitute;
             MappingOrder = MappingOrder ?? inheritedMappedProperty.MappingOrder;
             ValueResolverConfig = ValueResolverConfig ?? inheritedMappedProperty.ValueResolverConfig;
+            ValueConverterConfig = ValueConverterConfig ?? inheritedMappedProperty.ValueConverterConfig;
         }
 
         public bool IsMapped() => HasSource() || Ignored;

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -80,21 +80,11 @@ namespace AutoMapper
             }
         }
 
-        public Type SourceType
-        {
-            get
-            {
-                if (CustomExpression != null)
-                    return CustomExpression.ReturnType;
-                if (CustomResolver != null)
-                    return CustomResolver.ReturnType;
-                if(ValueResolverConfig != null)
-                    return typeof(object);
-                return SourceMember?.GetMemberType();
-            }
-        }
-
-
+        public Type SourceType => CustomExpression?.ReturnType
+                                  ?? CustomResolver?.ReturnType
+                                  ?? ValueResolverConfig?.SourceMember?.ReturnType
+                                  ?? ValueConverterConfig?.SourceMember?.ReturnType
+                                  ?? SourceMember?.GetMemberType();
 
         public void ChainMembers(IEnumerable<MemberInfo> members)
         {
@@ -124,7 +114,7 @@ namespace AutoMapper
 
         public bool HasSource() => _memberChain.Count > 0 || ResolveConfigured();
 
-        public bool ResolveConfigured() => ValueResolverConfig != null || CustomResolver != null || CustomExpression != null;
+        public bool ResolveConfigured() => ValueResolverConfig != null || CustomResolver != null || CustomExpression != null || ValueConverterConfig != null;
 
         public void MapFrom(LambdaExpression sourceMember)
         {

--- a/src/AutoMapper/ValueConverterConfiguration.cs
+++ b/src/AutoMapper/ValueConverterConfiguration.cs
@@ -20,6 +20,7 @@ namespace AutoMapper
         public ValueConverterConfiguration(object instance, Type interfaceType)
         {
             Instance = instance;
+            ConcreteType = instance.GetType();
             InterfaceType = interfaceType;
         }
     }

--- a/src/AutoMapper/ValueConverterConfiguration.cs
+++ b/src/AutoMapper/ValueConverterConfiguration.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Linq.Expressions;
+
+namespace AutoMapper
+{
+    public class ValueConverterConfiguration
+    {
+        public object Instance { get; }
+        public Type ConcreteType { get; }
+        public Type InterfaceType { get; }
+        public LambdaExpression SourceMember { get; set; }
+        public string SourceMemberName { get; set; }
+
+        public ValueConverterConfiguration(Type concreteType, Type interfaceType)
+        {
+            ConcreteType = concreteType;
+            InterfaceType = interfaceType;
+        }
+
+        public ValueConverterConfiguration(object instance, Type interfaceType)
+        {
+            Instance = instance;
+            InterfaceType = interfaceType;
+        }
+    }
+}

--- a/src/UnitTests/ValueConverters.cs
+++ b/src/UnitTests/ValueConverters.cs
@@ -1,0 +1,66 @@
+﻿using Shouldly;
+using Xunit;
+
+namespace AutoMapper.UnitTests
+{
+    public class ValueConverters
+    {
+        public class When_specifying_value_converter_for_matching_member : AutoMapperSpecBase
+        {
+            public class EightDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d8");
+            }
+            public class FourDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d4");
+            }
+
+            public class Source
+            {
+                public int Value1 { get; set; }
+                public int Value2 { get; set; }
+                public int Value3 { get; set; }
+                public int Value4 { get; set; }
+            }
+
+            public class Dest
+            {
+                public string Value1 { get; set; }
+                public string Value2 { get; set; }
+                public string Value3 { get; set; }
+                public string Value4 { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Source, Dest>()
+                    .ForMember(d => d.Value1, opt => opt.ConvertUsing<EightDigitIntToStringConverter, int>())
+                    .ForMember(d => d.Value2, opt => opt.ConvertUsing<EightDigitIntToStringConverter, int>())
+                    .ForMember(d => d.Value3, opt => opt.ConvertUsing<FourDigitIntToStringConverter, int>())
+                    .ForMember(d => d.Value4, opt => opt.ConvertUsing<FourDigitIntToStringConverter, int>());
+            });
+
+            [Fact]
+            public void Should_apply_converters()
+            {
+                var source = new Source
+                {
+                    Value1 = 1,
+                    Value2 = 2,
+                    Value3 = 3,
+                    Value4 = 4
+                };
+
+                var dest = Mapper.Map<Source, Dest>(source);
+
+                dest.Value1.ShouldBe("00000001");
+                dest.Value2.ShouldBe("00000002");
+                dest.Value3.ShouldBe("0003");
+                dest.Value4.ShouldBe("0004");
+            }
+        }
+    }
+}

--- a/src/UnitTests/ValueConverters.cs
+++ b/src/UnitTests/ValueConverters.cs
@@ -62,5 +62,62 @@ namespace AutoMapper.UnitTests
                 dest.Value4.ShouldBe("0004");
             }
         }
+        public class When_specifying_value_converter_for_non_matching_member : AutoMapperSpecBase
+        {
+            public class EightDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d8");
+            }
+            public class FourDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d4");
+            }
+
+            public class Source
+            {
+                public int Value1 { get; set; }
+                public int Value2 { get; set; }
+                public int Value3 { get; set; }
+                public int Value4 { get; set; }
+            }
+
+            public class Dest
+            {
+                public string ValueFoo1 { get; set; }
+                public string ValueFoo2 { get; set; }
+                public string ValueFoo3 { get; set; }
+                public string ValueFoo4 { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Source, Dest>()
+                    .ForMember(d => d.ValueFoo1, opt => opt.ConvertUsing<EightDigitIntToStringConverter, int>(src => src.Value1))
+                    .ForMember(d => d.ValueFoo2, opt => opt.ConvertUsing<EightDigitIntToStringConverter, int>(src => src.Value2))
+                    .ForMember(d => d.ValueFoo3, opt => opt.ConvertUsing<FourDigitIntToStringConverter, int>(src => src.Value3))
+                    .ForMember(d => d.ValueFoo4, opt => opt.ConvertUsing<FourDigitIntToStringConverter, int>(src => src.Value4));
+            });
+
+            [Fact]
+            public void Should_apply_converters()
+            {
+                var source = new Source
+                {
+                    Value1 = 1,
+                    Value2 = 2,
+                    Value3 = 3,
+                    Value4 = 4
+                };
+
+                var dest = Mapper.Map<Source, Dest>(source);
+
+                dest.ValueFoo1.ShouldBe("00000001");
+                dest.ValueFoo2.ShouldBe("00000002");
+                dest.ValueFoo3.ShouldBe("0003");
+                dest.ValueFoo4.ShouldBe("0004");
+            }
+        }
     }
 }

--- a/src/UnitTests/ValueConverters.cs
+++ b/src/UnitTests/ValueConverters.cs
@@ -119,5 +119,122 @@ namespace AutoMapper.UnitTests
                 dest.ValueFoo4.ShouldBe("0004");
             }
         }
+
+        public class When_specifying_value_converter_instance_for_matching_member : AutoMapperSpecBase
+        {
+            public class EightDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d8");
+            }
+            public class FourDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d4");
+            }
+
+            public class Source
+            {
+                public int Value1 { get; set; }
+                public int Value2 { get; set; }
+                public int Value3 { get; set; }
+                public int Value4 { get; set; }
+            }
+
+            public class Dest
+            {
+                public string Value1 { get; set; }
+                public string Value2 { get; set; }
+                public string Value3 { get; set; }
+                public string Value4 { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Source, Dest>()
+                    .ForMember(d => d.Value1, opt => opt.ConvertUsing(new EightDigitIntToStringConverter()))
+                    .ForMember(d => d.Value2, opt => opt.ConvertUsing(new EightDigitIntToStringConverter()))
+                    .ForMember(d => d.Value3, opt => opt.ConvertUsing(new FourDigitIntToStringConverter()))
+                    .ForMember(d => d.Value4, opt => opt.ConvertUsing(new FourDigitIntToStringConverter()));
+            });
+
+            [Fact]
+            public void Should_apply_converters()
+            {
+                var source = new Source
+                {
+                    Value1 = 1,
+                    Value2 = 2,
+                    Value3 = 3,
+                    Value4 = 4
+                };
+
+                var dest = Mapper.Map<Source, Dest>(source);
+
+                dest.Value1.ShouldBe("00000001");
+                dest.Value2.ShouldBe("00000002");
+                dest.Value3.ShouldBe("0003");
+                dest.Value4.ShouldBe("0004");
+            }
+        }
+
+        public class When_specifying_value_converter_instance_for_non_matching_member : AutoMapperSpecBase
+        {
+            public class EightDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d8");
+            }
+            public class FourDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d4");
+            }
+
+            public class Source
+            {
+                public int Value1 { get; set; }
+                public int Value2 { get; set; }
+                public int Value3 { get; set; }
+                public int Value4 { get; set; }
+            }
+
+            public class Dest
+            {
+                public string ValueFoo1 { get; set; }
+                public string ValueFoo2 { get; set; }
+                public string ValueFoo3 { get; set; }
+                public string ValueFoo4 { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Source, Dest>()
+                    .ForMember(d => d.ValueFoo1, opt => opt.ConvertUsing(new EightDigitIntToStringConverter(), src => src.Value1))
+                    .ForMember(d => d.ValueFoo2, opt => opt.ConvertUsing(new EightDigitIntToStringConverter(), src => src.Value2))
+                    .ForMember(d => d.ValueFoo3, opt => opt.ConvertUsing(new FourDigitIntToStringConverter(), src => src.Value3))
+                    .ForMember(d => d.ValueFoo4, opt => opt.ConvertUsing(new FourDigitIntToStringConverter(), src => src.Value4));
+            });
+
+            [Fact]
+            public void Should_apply_converters()
+            {
+                var source = new Source
+                {
+                    Value1 = 1,
+                    Value2 = 2,
+                    Value3 = 3,
+                    Value4 = 4
+                };
+
+                var dest = Mapper.Map<Source, Dest>(source);
+
+                dest.ValueFoo1.ShouldBe("00000001");
+                dest.ValueFoo2.ShouldBe("00000002");
+                dest.ValueFoo3.ShouldBe("0003");
+                dest.ValueFoo4.ShouldBe("0004");
+            }
+        }
+
     }
 }

--- a/src/UnitTests/ValueConverters.cs
+++ b/src/UnitTests/ValueConverters.cs
@@ -62,6 +62,7 @@ namespace AutoMapper.UnitTests
                 dest.Value4.ShouldBe("0004");
             }
         }
+
         public class When_specifying_value_converter_for_non_matching_member : AutoMapperSpecBase
         {
             public class EightDigitIntToStringConverter : IValueConverter<int, string>
@@ -98,6 +99,238 @@ namespace AutoMapper.UnitTests
                     .ForMember(d => d.ValueFoo2, opt => opt.ConvertUsing<EightDigitIntToStringConverter, int>(src => src.Value2))
                     .ForMember(d => d.ValueFoo3, opt => opt.ConvertUsing<FourDigitIntToStringConverter, int>(src => src.Value3))
                     .ForMember(d => d.ValueFoo4, opt => opt.ConvertUsing<FourDigitIntToStringConverter, int>(src => src.Value4));
+            });
+
+            [Fact]
+            public void Should_apply_converters()
+            {
+                var source = new Source
+                {
+                    Value1 = 1,
+                    Value2 = 2,
+                    Value3 = 3,
+                    Value4 = 4
+                };
+
+                var dest = Mapper.Map<Source, Dest>(source);
+
+                dest.ValueFoo1.ShouldBe("00000001");
+                dest.ValueFoo2.ShouldBe("00000002");
+                dest.ValueFoo3.ShouldBe("0003");
+                dest.ValueFoo4.ShouldBe("0004");
+            }
+        }
+
+        public class When_specifying_value_converter_for_string_based_matching_member : AutoMapperSpecBase
+        {
+            public class EightDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d8");
+            }
+            public class FourDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d4");
+            }
+
+            public class Source
+            {
+                public int Value1 { get; set; }
+                public int Value2 { get; set; }
+                public int Value3 { get; set; }
+                public int Value4 { get; set; }
+            }
+
+            public class Dest
+            {
+                public string Value1 { get; set; }
+                public string Value2 { get; set; }
+                public string Value3 { get; set; }
+                public string Value4 { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Source, Dest>()
+                    .ForMember("Value1", opt => opt.ConvertUsing<EightDigitIntToStringConverter, int>())
+                    .ForMember("Value2", opt => opt.ConvertUsing<EightDigitIntToStringConverter, int>())
+                    .ForMember("Value3", opt => opt.ConvertUsing<FourDigitIntToStringConverter, int>())
+                    .ForMember("Value4", opt => opt.ConvertUsing<FourDigitIntToStringConverter, int>());
+            });
+
+            [Fact]
+            public void Should_apply_converters()
+            {
+                var source = new Source
+                {
+                    Value1 = 1,
+                    Value2 = 2,
+                    Value3 = 3,
+                    Value4 = 4
+                };
+
+                var dest = Mapper.Map<Source, Dest>(source);
+
+                dest.Value1.ShouldBe("00000001");
+                dest.Value2.ShouldBe("00000002");
+                dest.Value3.ShouldBe("0003");
+                dest.Value4.ShouldBe("0004");
+            }
+        }
+
+        public class When_specifying_value_converter_for_string_based_non_matching_member : AutoMapperSpecBase
+        {
+            public class EightDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d8");
+            }
+            public class FourDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d4");
+            }
+
+            public class Source
+            {
+                public int Value1 { get; set; }
+                public int Value2 { get; set; }
+                public int Value3 { get; set; }
+                public int Value4 { get; set; }
+            }
+
+            public class Dest
+            {
+                public string ValueFoo1 { get; set; }
+                public string ValueFoo2 { get; set; }
+                public string ValueFoo3 { get; set; }
+                public string ValueFoo4 { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Source, Dest>()
+                    .ForMember("ValueFoo1", opt => opt.ConvertUsing<EightDigitIntToStringConverter, int>("Value1"))
+                    .ForMember("ValueFoo2", opt => opt.ConvertUsing<EightDigitIntToStringConverter, int>("Value2"))
+                    .ForMember("ValueFoo3", opt => opt.ConvertUsing<FourDigitIntToStringConverter, int>("Value3"))
+                    .ForMember("ValueFoo4", opt => opt.ConvertUsing<FourDigitIntToStringConverter, int>("Value4"));
+            });
+
+            [Fact]
+            public void Should_apply_converters()
+            {
+                var source = new Source
+                {
+                    Value1 = 1,
+                    Value2 = 2,
+                    Value3 = 3,
+                    Value4 = 4
+                };
+
+                var dest = Mapper.Map<Source, Dest>(source);
+
+                dest.ValueFoo1.ShouldBe("00000001");
+                dest.ValueFoo2.ShouldBe("00000002");
+                dest.ValueFoo3.ShouldBe("0003");
+                dest.ValueFoo4.ShouldBe("0004");
+            }
+        }
+
+        public class When_specifying_value_converter_for_type_and_string_based_matching_member : AutoMapperSpecBase
+        {
+            public class EightDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d8");
+            }
+            public class FourDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d4");
+            }
+
+            public class Source
+            {
+                public int Value1 { get; set; }
+                public int Value2 { get; set; }
+                public int Value3 { get; set; }
+                public int Value4 { get; set; }
+            }
+
+            public class Dest
+            {
+                public string Value1 { get; set; }
+                public string Value2 { get; set; }
+                public string Value3 { get; set; }
+                public string Value4 { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap(typeof(Source), typeof(Dest))
+                    .ForMember("Value1", opt => opt.ConvertUsing(typeof(EightDigitIntToStringConverter)))
+                    .ForMember("Value2", opt => opt.ConvertUsing(typeof(EightDigitIntToStringConverter)))
+                    .ForMember("Value3", opt => opt.ConvertUsing(typeof(FourDigitIntToStringConverter)))
+                    .ForMember("Value4", opt => opt.ConvertUsing(typeof(FourDigitIntToStringConverter)));
+            });
+
+            [Fact]
+            public void Should_apply_converters()
+            {
+                var source = new Source
+                {
+                    Value1 = 1,
+                    Value2 = 2,
+                    Value3 = 3,
+                    Value4 = 4
+                };
+
+                var dest = Mapper.Map<Source, Dest>(source);
+
+                dest.Value1.ShouldBe("00000001");
+                dest.Value2.ShouldBe("00000002");
+                dest.Value3.ShouldBe("0003");
+                dest.Value4.ShouldBe("0004");
+            }
+        }
+
+        public class When_specifying_value_converter_for_type_and_string_based_non_matching_member : AutoMapperSpecBase
+        {
+            public class EightDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d8");
+            }
+            public class FourDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d4");
+            }
+
+            public class Source
+            {
+                public int Value1 { get; set; }
+                public int Value2 { get; set; }
+                public int Value3 { get; set; }
+                public int Value4 { get; set; }
+            }
+
+            public class Dest
+            {
+                public string ValueFoo1 { get; set; }
+                public string ValueFoo2 { get; set; }
+                public string ValueFoo3 { get; set; }
+                public string ValueFoo4 { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap(typeof(Source), typeof(Dest))
+                    .ForMember("ValueFoo1", opt => opt.ConvertUsing(typeof(EightDigitIntToStringConverter), "Value1"))
+                    .ForMember("ValueFoo2", opt => opt.ConvertUsing(typeof(EightDigitIntToStringConverter), "Value2"))
+                    .ForMember("ValueFoo3", opt => opt.ConvertUsing(typeof(FourDigitIntToStringConverter), "Value3"))
+                    .ForMember("ValueFoo4", opt => opt.ConvertUsing(typeof(FourDigitIntToStringConverter), "Value4"));
             });
 
             [Fact]
@@ -236,5 +469,120 @@ namespace AutoMapper.UnitTests
             }
         }
 
+        public class When_specifying_value_converter_instance_for_string_based_matching_member : AutoMapperSpecBase
+        {
+            public class EightDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d8");
+            }
+            public class FourDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d4");
+            }
+
+            public class Source
+            {
+                public int Value1 { get; set; }
+                public int Value2 { get; set; }
+                public int Value3 { get; set; }
+                public int Value4 { get; set; }
+            }
+
+            public class Dest
+            {
+                public string Value1 { get; set; }
+                public string Value2 { get; set; }
+                public string Value3 { get; set; }
+                public string Value4 { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Source, Dest>()
+                    .ForMember("Value1", opt => opt.ConvertUsing(new EightDigitIntToStringConverter()))
+                    .ForMember("Value2", opt => opt.ConvertUsing(new EightDigitIntToStringConverter()))
+                    .ForMember("Value3", opt => opt.ConvertUsing(new FourDigitIntToStringConverter()))
+                    .ForMember("Value4", opt => opt.ConvertUsing(new FourDigitIntToStringConverter()));
+            });
+
+            [Fact]
+            public void Should_apply_converters()
+            {
+                var source = new Source
+                {
+                    Value1 = 1,
+                    Value2 = 2,
+                    Value3 = 3,
+                    Value4 = 4
+                };
+
+                var dest = Mapper.Map<Source, Dest>(source);
+
+                dest.Value1.ShouldBe("00000001");
+                dest.Value2.ShouldBe("00000002");
+                dest.Value3.ShouldBe("0003");
+                dest.Value4.ShouldBe("0004");
+            }
+        }
+
+        public class When_specifying_value_converter_instance_for_string_based_non_matching_member : AutoMapperSpecBase
+        {
+            public class EightDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d8");
+            }
+            public class FourDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d4");
+            }
+
+            public class Source
+            {
+                public int Value1 { get; set; }
+                public int Value2 { get; set; }
+                public int Value3 { get; set; }
+                public int Value4 { get; set; }
+            }
+
+            public class Dest
+            {
+                public string ValueFoo1 { get; set; }
+                public string ValueFoo2 { get; set; }
+                public string ValueFoo3 { get; set; }
+                public string ValueFoo4 { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Source, Dest>()
+                    .ForMember("ValueFoo1", opt => opt.ConvertUsing(new EightDigitIntToStringConverter(), "Value1"))
+                    .ForMember("ValueFoo2", opt => opt.ConvertUsing(new EightDigitIntToStringConverter(), "Value2"))
+                    .ForMember("ValueFoo3", opt => opt.ConvertUsing(new FourDigitIntToStringConverter(), "Value3"))
+                    .ForMember("ValueFoo4", opt => opt.ConvertUsing(new FourDigitIntToStringConverter(), "Value4"));
+            });
+
+            [Fact]
+            public void Should_apply_converters()
+            {
+                var source = new Source
+                {
+                    Value1 = 1,
+                    Value2 = 2,
+                    Value3 = 3,
+                    Value4 = 4
+                };
+
+                var dest = Mapper.Map<Source, Dest>(source);
+
+                dest.ValueFoo1.ShouldBe("00000001");
+                dest.ValueFoo2.ShouldBe("00000002");
+                dest.ValueFoo3.ShouldBe("0003");
+                dest.ValueFoo4.ShouldBe("0004");
+            }
+        }
     }
 }

--- a/src/UnitTests/ValueConverters.cs
+++ b/src/UnitTests/ValueConverters.cs
@@ -584,5 +584,61 @@ namespace AutoMapper.UnitTests
                 dest.ValueFoo4.ShouldBe("0004");
             }
         }
+
+        public class When_specifying_value_converter_for_all_members : AutoMapperSpecBase
+        {
+            public class EightDigitIntToStringConverter : IValueConverter<int, string>
+            {
+                public string Convert(int sourceMember, ResolutionContext context)
+                    => sourceMember.ToString("d8");
+            }
+
+            public class Source
+            {
+                public int Value { get; set; }
+            }
+
+            public class OtherSource
+            {
+                public int Value { get; set; }
+            }
+
+            public class Dest
+            {
+                public string Value { get; set; }
+            }
+
+            public class OtherDest
+            {
+                public string Value { get; set; }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.ForAllPropertyMaps
+                    (pm => pm.SourceType == typeof(int) && pm.DestinationPropertyType == typeof(string), 
+                    (pm, opt) => opt.ConvertUsing(new EightDigitIntToStringConverter()));
+            });
+
+            [Fact]
+            public void Should_apply_converters()
+            {
+                var source = new Source
+                {
+                    Value = 1,
+                };
+                var otherSource = new OtherSource
+                {
+                    Value = 2,
+                };
+
+                var dest = Mapper.Map<Source, Dest>(source);
+                var otherDest = Mapper.Map<OtherSource, OtherDest>(otherSource);
+
+                dest.Value.ShouldBe("00000001");
+                otherDest.Value.ShouldBe("00000002");
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Fixes #2773 

This adds a new interface:

```c#
public interface IValueConverter<in TSourceMember, out TDestinationMember>
{
    TDestinationMember Convert(TSourceMember sourceMember, ResolutionContext context);
}
```

Value converters are a cross between type converters and value resolvers. Because value converters are only scoped to members, this makes it much, much easier to reuse them across maps. These are the effective replacement for the old value formatters, minus the weird stacking of value formatters.

Unlike type converters, value converters are just another kind of value resolver, rather than something that completely overrides every other option. The precedence is:

 - Value converter
 - Value resolver
 - Resolving func
 - MapFrom expression
 - Member matching

I thought this simplified things rather than having a one-off for value converters.

Open question - should the value converters also receive the destination member, like the type converter, value resolver, and member value resolver? Right now it doesn't, but it'd be trivial to add it. If I did, it'd lose the variance for that parameter (not sure that's an issue).

Once this gets released, we'll need to update the DI project to scan for these types for registration.