### PR TITLE
Set ignored in the property map constructed from a path map

### DIFF
--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -25,6 +25,7 @@ namespace AutoMapper
             DestinationProperty = pathMap.DestinationMember;
             CustomExpression = pathMap.SourceExpression;
             TypeMap = pathMap.TypeMap;
+            Ignored = pathMap.Ignored;
         }
 
         public PropertyMap(MemberInfo destinationProperty, TypeMap typeMap)


### PR DESCRIPTION
If you think the right fix is to introduce a complete interface implemented by both, I can do that. I wasn't convinced, so I didn't go that way.