### PR TITLE
Contextual exceptions for path maps

### DIFF
--- a/src/AutoMapper/AutoMapperMappingException.cs
+++ b/src/AutoMapper/AutoMapperMappingException.cs
@@ -32,12 +32,12 @@ namespace AutoMapper
         public AutoMapperMappingException(string message, Exception innerException, TypePair types, TypeMap typeMap)
             : this(message, innerException, types) => TypeMap = typeMap;
 
-        public AutoMapperMappingException(string message, Exception innerException, TypePair types, TypeMap typeMap, PropertyMap propertyMap)
-            : this(message, innerException, types, typeMap) => PropertyMap = propertyMap;
+        public AutoMapperMappingException(string message, Exception innerException, TypePair types, TypeMap typeMap, IMemberMap memberMap)
+            : this(message, innerException, types, typeMap) => MemberMap = memberMap;
 
         public TypePair? Types { get; set; }
         public TypeMap TypeMap { get; set; }
-        public PropertyMap PropertyMap { get; set; }
+        public IMemberMap MemberMap { get; set; }
 
         public override string Message
         {
@@ -48,24 +48,19 @@ namespace AutoMapper
                 if (Types?.SourceType != null && Types?.DestinationType != null)
                 {
                     message = message + newLine + newLine + "Mapping types:";
-                    message += newLine +
-                               $"{Types?.SourceType.Name} -> {Types?.DestinationType.Name}";
-                    message += newLine +
-                               $"{Types?.SourceType.FullName} -> {Types?.DestinationType.FullName}";
+                    message += newLine + $"{Types?.SourceType.Name} -> {Types?.DestinationType.Name}";
+                    message += newLine + $"{Types?.SourceType.FullName} -> {Types?.DestinationType.FullName}";
                 }
                 if (TypeMap != null)
                 {
                     message = message + newLine + newLine + "Type Map configuration:";
-                    message += newLine +
-                               $"{TypeMap.SourceType.Name} -> {TypeMap.DestinationType.Name}";
-                    message += newLine +
-                               $"{TypeMap.SourceType.FullName} -> {TypeMap.DestinationType.FullName}";
+                    message += newLine + $"{TypeMap.SourceType.Name} -> {TypeMap.DestinationType.Name}";
+                    message += newLine + $"{TypeMap.SourceType.FullName} -> {TypeMap.DestinationType.FullName}";
                 }
-                if (PropertyMap != null)
+                if (MemberMap != null)
                 {
-                    message = message + newLine + newLine + "Property:";
-                    message += newLine +
-                               $"{PropertyMap.DestinationMember.Name}";
+                    message = message + newLine + newLine + "Destination Member:";
+                    message += newLine + $"{MemberMap.DestinationName}" + newLine;
                 }
 
                 return message;

--- a/src/UnitTests/ForPath.cs
+++ b/src/UnitTests/ForPath.cs
@@ -143,8 +143,8 @@ namespace AutoMapper.UnitTests
         [Fact]
         public void Should_unflatten()
         {
-            new Action(() => Mapper.Map<Order>(new OrderDto())).ShouldThrowException<NullReferenceException>(ex =>
-                  ex.Message.ShouldBe("typeMapDestination.CustomerHolder.Customer cannot be null because it's used by ForPath."));
+            new Action(() => Mapper.Map<Order>(new OrderDto())).ShouldThrowException<AutoMapperMappingException>(ex =>
+                  ex.InnerException?.Message.ShouldBe("typeMapDestination.CustomerHolder.Customer cannot be null because it's used by ForPath."));
         }
     }
 

--- a/src/UnitTests/MappingExceptions.cs
+++ b/src/UnitTests/MappingExceptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using Xunit;
 using Shouldly;
 
@@ -42,6 +43,57 @@ namespace AutoMapper.UnitTests.MappingExceptions
                 thrown = ex;
             }
             thrown.ShouldNotBeNull();
+            thrown.TypeMap.ShouldNotBeNull();
+            thrown.MemberMap.ShouldNotBeNull();
+        }
+    }
+
+    public class When_encountering_a_path_mapping_problem_during_mapping : NonValidatingSpecBase
+    {
+        public class Source
+        {
+            public string Value { get; set; }
+        }
+
+        public class Dest
+        {
+            public Sub SubValue { get; set; }
+
+            public class Sub
+            {
+                public int Value { get; set; }
+            }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Dest>()
+                .ForPath(d => d.SubValue.Value, opt => opt.MapFrom(src => src.Value));
+        });
+
+        [Fact]
+        public void Should_provide_a_contextual_exception()
+        {
+            var source = new Source { Value = "adsf" };
+            typeof(AutoMapperMappingException).ShouldBeThrownBy(() => Mapper.Map<Source, Dest>(source));
+        }
+
+        [Fact]
+        public void Should_have_contextual_mapping_information()
+        {
+            var source = new Source { Value = "adsf" };
+            AutoMapperMappingException thrown = null;
+            try
+            {
+                Mapper.Map<Source, Dest>(source);
+            }
+            catch (AutoMapperMappingException ex)
+            {
+                thrown = ex;
+            }
+            thrown.ShouldNotBeNull();
+            thrown.TypeMap.ShouldNotBeNull();
+            thrown.MemberMap.ShouldNotBeNull();
         }
     }
 }


### PR DESCRIPTION
No longer restricted to property maps. Changes the exception object to include `IMemberMap` instead of just `PropertyMap`