### PR TITLE
Replace all .DestinationMember.Name with .DestinationName and revert …

### DIFF
--- a/src/AutoMapper/AutoMapperConfigurationException.cs
+++ b/src/AutoMapper/AutoMapperConfigurationException.cs
@@ -48,7 +48,7 @@ namespace AutoMapper
                         string.Format(
                             "The following property on {0} cannot be mapped: \n\t{2} \nAdd a custom mapping expression, ignore, add a custom resolver, or modify the destination type {1}.",
                             Types?.DestinationType.FullName, Types?.DestinationType.FullName,
-                            PropertyMap?.DestinationMember.Name);
+                            PropertyMap?.DestinationName);
 
                     message += "\nContext:";
 
@@ -59,7 +59,7 @@ namespace AutoMapper
                         {
                             message += configExc.PropertyMap == null
                               ? $"\n\tMapping from type {configExc.Types?.SourceType.FullName} to {configExc.Types?.DestinationType.FullName}"
-                              : $"\n\tMapping to property {configExc.PropertyMap.DestinationMember.Name} from {configExc.Types?.SourceType.FullName} to {configExc.Types?.DestinationType.FullName}";
+                              : $"\n\tMapping to property {configExc.PropertyMap.DestinationName} from {configExc.Types?.SourceType.FullName} to {configExc.Types?.DestinationType.FullName}";
                         }
 
                         exToUse = exToUse.InnerException;

--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -590,7 +590,7 @@ namespace AutoMapper.Configuration
                 ReverseSourceMembers(typeMap);
                 foreach(var destProperty in typeMap.PropertyMaps.Where(pm => pm.Ignored))
                 {
-                    _reverseMap.ForSourceMember(destProperty.DestinationMember.Name, opt => opt.Ignore());
+                    _reverseMap.ForSourceMember(destProperty.DestinationName, opt => opt.Ignore());
                 }
                 foreach(var includedDerivedType in typeMap.IncludedDerivedTypes)
                 {

--- a/src/AutoMapper/ConstructorParameterMap.cs
+++ b/src/AutoMapper/ConstructorParameterMap.cs
@@ -32,7 +32,7 @@ namespace AutoMapper
         public TypePair Types => new TypePair(SourceType, DestinationType);
 
         public IEnumerable<MemberInfo> SourceMembers { get; }
-        public string DestinationName => Parameter.Name;
+        public string DestinationName => Parameter.Member.DeclaringType + "." + Parameter.Member + ".parameter " + Parameter.Name;
 
         public bool HasDefaultValue => Parameter.IsOptional;
 

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -199,7 +199,7 @@ namespace AutoMapper.Execution
             foreach (var propertyMap in _typeMap.PropertyMaps.Where(pm => pm.CanResolveValue))
             {
                 var property = TryPropertyMap(propertyMap);
-                if (isConstructorMapping && _typeMap.ConstructorParameterMatches(propertyMap.DestinationMember.Name))
+                if (isConstructorMapping && _typeMap.ConstructorParameterMatches(propertyMap.DestinationName))
                     property = _initialDestination.IfNullElse(Empty(), property);
                 actions.Add(property);
             }

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -200,7 +200,7 @@ namespace AutoMapper.Execution
             {
                 var property = TryPropertyMap(propertyMap);
                 if (isConstructorMapping && _typeMap.ConstructorParameterMatches(propertyMap.DestinationName))
-                    property = _initialDestination.IfNullElse(Empty(), property);
+                    property = _initialDestination.IfNullElse(Default(property.Type), property);
                 actions.Add(property);
             }
             foreach (var pathMap in _typeMap.PathMaps.Where(pm => !pm.Ignored))
@@ -357,9 +357,10 @@ namespace AutoMapper.Execution
         {
             var resolvedExpression = ResolveSource(ctorParamMap);
             var resolvedValue = Variable(resolvedExpression.Type, "resolvedValue");
-            return Block(new[] {resolvedValue},
+            var tryMap = Block(new[] {resolvedValue},
                 Assign(resolvedValue, resolvedExpression),
                 MapExpression(_configurationProvider, _typeMap.Profile, new TypePair(resolvedExpression.Type, ctorParamMap.DestinationType), resolvedValue, Context));
+            return TryMemberMap(ctorParamMap, tryMap);
         }
 
         private Expression TryPropertyMap(PropertyMap propertyMap)
@@ -378,11 +379,13 @@ namespace AutoMapper.Execution
 
             var mappingExceptionCtor = ((NewExpression) CtorExpression.Body).Constructor;
 
-            return TryCatch(Block(typeof(void), memberMapExpression),
-                MakeCatchBlock(typeof(Exception), exception,
-                    Throw(New(mappingExceptionCtor, Constant("Error mapping types."), exception,
-                        Constant(memberMap.TypeMap.Types), Constant(memberMap.TypeMap), Constant(memberMap))),
-                    null));
+            return TryCatch(memberMapExpression,
+                        MakeCatchBlock(typeof(Exception), exception,
+                            Block(
+                                Throw(New(mappingExceptionCtor, Constant("Error mapping types."), exception,
+                                    Constant(memberMap.TypeMap.Types), Constant(memberMap.TypeMap), Constant(memberMap))),
+                                Default(memberMapExpression.Type))
+                            , null));
         }
 
         private Expression CreatePropertyMapFunc(IMemberMap memberMap, Expression destination, MemberInfo destinationMember)

--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -257,7 +257,7 @@ namespace AutoMapper.QueryableExtensions
             foreach (var propertyMap in typeMap.PropertyMaps
                                                .Where(pm => (!pm.ExplicitExpansion || request.MembersToExpand.Contains(pm.DestinationMember)) && 
                                                             pm.CanResolveValue && ReflectionHelper.CanBeSet(pm.DestinationMember))
-                                               .OrderBy(pm => pm.DestinationMember.Name))
+                                               .OrderBy(pm => pm.DestinationName))
             {
                 letPropertyMaps.Push(propertyMap);
 
@@ -280,7 +280,7 @@ namespace AutoMapper.QueryableExtensions
                 if(binder == null)
                 {
                     var message =
-                        $"Unable to create a map expression from {propertyMap.SourceMember?.DeclaringType?.Name}.{propertyMap.SourceMember?.Name} ({result.Type}) to {propertyMap.DestinationMember.DeclaringType?.Name}.{propertyMap.DestinationMember.Name} ({propertyMap.DestinationType})";
+                        $"Unable to create a map expression from {propertyMap.SourceMember?.DeclaringType?.Name}.{propertyMap.SourceMember?.Name} ({result.Type}) to {propertyMap.DestinationMember.DeclaringType?.Name}.{propertyMap.DestinationName} ({propertyMap.DestinationType})";
                     throw new AutoMapperMappingException(message, null, typeMap.Types, typeMap, propertyMap);
                 }
                 var bindExpression = binder.Build(_configurationProvider, propertyMap, propertyTypeMap, propertyRequest, result, typePairCount, letPropertyMaps);
@@ -444,7 +444,7 @@ namespace AutoMapper.QueryableExtensions
                     MapFromSource = path.PropertyMaps.Take(path.PropertyMaps.Length - 1).Select(pm=>pm.SourceMember).MemberAccesses(instanceParameter),
                     Property = new PropertyDescription
                     (
-                        "__"+string.Join("#", path.PropertyMaps.Select(pm => pm.DestinationMember.Name)),
+                        "__"+string.Join("#", path.PropertyMaps.Select(pm => pm.DestinationName)),
                         path.Last.SourceType
                     ),
                     path.Marker

--- a/src/AutoMapper/QueryableExtensions/Impl/QueryMapperHelper.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/QueryMapperHelper.cs
@@ -22,7 +22,7 @@ namespace AutoMapper.QueryableExtensions.Impl
 
         public static PropertyMap GetPropertyMapByDestinationProperty(this TypeMap typeMap, string destinationPropertyName)
         {
-            var propertyMap = typeMap.PropertyMaps.SingleOrDefault(item => item.DestinationMember.Name == destinationPropertyName);
+            var propertyMap = typeMap.PropertyMaps.SingleOrDefault(item => item.DestinationName == destinationPropertyName);
             if (propertyMap == null)
                 throw PropertyConfigurationException(typeMap, destinationPropertyName);
 

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -143,10 +143,10 @@ namespace AutoMapper
         public string[] GetUnmappedPropertyNames()
         {
             string GetPropertyName(PropertyMap pm) => ConfiguredMemberList == MemberList.Destination
-                ? pm.DestinationMember.Name
+                ? pm.DestinationName
                 : pm.SourceMember != null
                     ? pm.SourceMember.Name
-                    : pm.DestinationMember.Name;
+                    : pm.DestinationName;
             string[] GetPropertyNames(IEnumerable<PropertyMap> propertyMaps) => propertyMaps.Where(pm => pm.IsMapped).Select(GetPropertyName).ToArray();
 
             var autoMappedProperties = GetPropertyNames(_propertyMaps);
@@ -164,7 +164,7 @@ namespace AutoMapper
             else
             {
                 var redirectedSourceMembers = _propertyMaps
-                    .Where(pm => pm.IsMapped && pm.SourceMember != null && pm.SourceMember.Name != pm.DestinationMember.Name)
+                    .Where(pm => pm.IsMapped && pm.SourceMember != null && pm.SourceMember.Name != pm.DestinationName)
                     .Select(pm => pm.SourceMember.Name);
 
                 var ignoredSourceMembers = _sourceMemberConfigs
@@ -289,13 +289,13 @@ namespace AutoMapper
             if (!destinationProperty.DeclaringType.IsAssignableFrom(DestinationType))
                 return null;
             var propertyMap =
-                _propertyMaps.FirstOrDefault(pm => pm.DestinationMember.Name == destinationProperty.Name);
+                _propertyMaps.FirstOrDefault(pm => pm.DestinationName == destinationProperty.Name);
 
             if (propertyMap != null)
                 return propertyMap;
 
             propertyMap =
-                _inheritedMaps.FirstOrDefault(pm => pm.DestinationMember.Name == destinationProperty.Name);
+                _inheritedMaps.FirstOrDefault(pm => pm.DestinationName == destinationProperty.Name);
 
             if (propertyMap == null)
                 return null;
@@ -341,7 +341,7 @@ namespace AutoMapper
             {
                 var conventionPropertyMap = PropertyMaps
                     .SingleOrDefault(m =>
-                        m.DestinationMember.Name == inheritedMappedProperty.DestinationMember.Name);
+                        m.DestinationName == inheritedMappedProperty.DestinationName);
 
                 if (conventionPropertyMap != null)
                 {

--- a/src/UnitTests/ConfigurationValidation.cs
+++ b/src/UnitTests/ConfigurationValidation.cs
@@ -52,7 +52,7 @@ namespace AutoMapper.UnitTests.ConfigurationValidation
             else
             {
                 context.PropertyMap.SourceMember.Name.ShouldBe("Values");
-                context.PropertyMap.DestinationMember.Name.ShouldBe("Values");
+                context.PropertyMap.DestinationName.ShouldBe("Values");
                 if(context.Types.Equals(new TypePair(typeof(int), typeof(int))))
                 {
                     _calledForInt = true;

--- a/src/UnitTests/Constructors.cs
+++ b/src/UnitTests/Constructors.cs
@@ -893,6 +893,45 @@ namespace AutoMapper.UnitTests.Constructors
         }
     }
 
+    public class When_mapping_constructor_argument_fails : AutoMapperSpecBase
+    {
+        public class Source
+        {
+            public int Foo { get; set; }
+            public int Bar { get; set; }
+        }
+
+        public class Dest
+        {
+            private readonly int _foo;
+
+            public int Foo
+            {
+                get { return _foo; }
+            }
+
+            public int Bar { get; set; }
+
+            public Dest(DateTime foo)
+            {
+                _foo = foo.Day;
+            }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMissingTypeMaps = false;
+            cfg.CreateMap<Source, Dest>();
+        });
+
+        [Fact]
+        public void Should_say_what_parameter_fails()
+        {
+            new Action(() => Mapper.Map<Source, Dest>(new Source { Foo = 5, Bar = 10 })).ShouldThrowException<AutoMapperMappingException>(ex =>
+                  ex.MemberMap.DestinationName.ShouldBe("AutoMapper.UnitTests.Constructors.When_mapping_constructor_argument_fails+Dest.Void .ctor(System.DateTime).parameter foo"));
+        }
+    }
+
     public class When_mapping_to_an_object_with_a_constructor_with_a_matching_argument : AutoMapperSpecBase
     {
         private Dest _dest;

--- a/src/UnitTests/ForAllMembers.cs
+++ b/src/UnitTests/ForAllMembers.cs
@@ -22,7 +22,7 @@
 
             protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
             {
-                cfg.ForAllPropertyMaps(pm => pm.DestinationMember.Name.StartsWith("Other"), 
+                cfg.ForAllPropertyMaps(pm => pm.DestinationName.StartsWith("Other"), 
                     (pm, opt) => opt.MapFrom(typeof(ConditionalValueResolver), pm.SourceMember.Name));
 
                 cfg.CreateMap<Source, Dest>();

--- a/src/UnitTests/TypeConverters.cs
+++ b/src/UnitTests/TypeConverters.cs
@@ -301,7 +301,16 @@ namespace AutoMapper.UnitTests.CustomMapping
     public class When_specifying_mapping_with_the_BCL_type_converter_class : NonValidatingSpecBase
     {
         protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => { });
-
+#if NET461
+        public When_specifying_mapping_with_the_BCL_type_converter_class()
+        {
+            // only needed for the xUnitRunner without AppDomains
+            AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
+            {
+                return args.Name == typeof(CustomTypeConverter).Assembly.FullName ? typeof(CustomTypeConverter).Assembly : null;
+            };
+        }
+#endif
         [TypeConverter(typeof(CustomTypeConverter))]
         public class Source
         {


### PR DESCRIPTION
…some recent test changes. Changed the exception message for constructor mapping. I'm probably abusing DestinationName here. Maybe I should switch to ToString or smth.