### PR TITLE
Check for null reference

### DIFF
--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -204,6 +204,11 @@ namespace AutoMapper
 
             var types = new TypePair(source.GetType(), typeof(TDestination));
 
+            if(_configurationProvider == null)
+            {
+                throw new Exception("Mapping configuration not provided.");
+            }
+
             var func = _configurationProvider.GetUntypedMapperFunc(new MapRequest(types, types));
 
             return (TDestination) func(source, null, DefaultContext);

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -186,6 +186,11 @@ namespace AutoMapper
 
         public Mapper(IConfigurationProvider configurationProvider, Func<Type, object> serviceCtor)
         {
+            if(configurationProvider == null)
+            {
+                throw new ArgumentNullException(nameof(configurationProvider));
+            }
+            
             _configurationProvider = configurationProvider;
             _serviceCtor = serviceCtor;
             DefaultContext = new ResolutionContext(new ObjectMappingOperationOptions(serviceCtor), this);
@@ -203,11 +208,6 @@ namespace AutoMapper
                 return default;
 
             var types = new TypePair(source.GetType(), typeof(TDestination));
-
-            if(_configurationProvider == null)
-            {
-                throw new Exception("Mapping configuration not provided.");
-            }
 
             var func = _configurationProvider.GetUntypedMapperFunc(new MapRequest(types, types));
 

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -186,13 +186,8 @@ namespace AutoMapper
 
         public Mapper(IConfigurationProvider configurationProvider, Func<Type, object> serviceCtor)
         {
-            if(configurationProvider == null)
-            {
-                throw new ArgumentNullException(nameof(configurationProvider));
-            }
-            
-            _configurationProvider = configurationProvider;
-            _serviceCtor = serviceCtor;
+            _configurationProvider = configurationProvider ?? throw new ArgumentNullException(nameof(configurationProvider));
+            _serviceCtor = serviceCtor ?? throw new ArgumentNullException(nameof(serviceCtor));
             DefaultContext = new ResolutionContext(new ObjectMappingOperationOptions(serviceCtor), this);
         }
 


### PR DESCRIPTION
I kept getting a null reference exception in unit tests when the configuration wasn't supplied to the mapper. (I'm migrating from the static methods to the instance-based ones). This should give a more meaningful message.