### PR TITLE
Added IMapper.ProjectTo

### DIFF
--- a/docs/Queryable-Extensions.md
+++ b/docs/Queryable-Extensions.md
@@ -59,6 +59,10 @@ The `.ProjectTo<OrderLineDTO>()` will tell AutoMapper's mapping engine to emit a
 
 Note that for this feature to work, all type conversions must be explicitly handled in your Mapping. For example, you can not rely on the `ToString()` override of the `Item` class to inform entity framework to only select from the `Name` column, and any data type changes, such as `Double` to `Decimal` must be explicitly handled as well.
 
+### The instance API
+
+Starting with 8.0 there are similar ProjectTo methods on IMapper that feel more natural when you use IMapper with DI.
+
 ### Preventing lazy loading/SELECT N+1 problems
 
 Because the LINQ projection built by AutoMapper is translated directly to a SQL query by the query provider, the mapping occurs at the SQL/ADO.NET level, and not touching your entities. All data is eagerly fetched and loaded into your DTOs.

--- a/src/AutoMapper/IMapper.cs
+++ b/src/AutoMapper/IMapper.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 
 namespace AutoMapper
 {
@@ -115,6 +118,27 @@ namespace AutoMapper
         /// Factory method for creating runtime instances of converters, resolvers etc.
         /// </summary>
         Func<Type, object> ServiceCtor { get; }
+
+        /// <summary>
+        /// Project the input queryable.
+        /// </summary>
+        /// <remarks>Projections are only calculated once and cached</remarks>
+        /// <typeparam name="TDestination">Destination type</typeparam>
+        /// <param name="source">Queryable source</param>
+        /// <param name="parameters">Optional parameter object for parameterized mapping expressions</param>
+        /// <param name="membersToExpand">Explicit members to expand</param>
+        /// <returns>Queryable result, use queryable extension methods to project and execute result</returns>
+        IQueryable<TDestination> ProjectTo<TDestination>(IQueryable source, object parameters = null, params Expression<Func<TDestination, object>>[] membersToExpand);
+
+        /// <summary>
+        /// Project the input queryable.
+        /// </summary>
+        /// <typeparam name="TDestination">Destination type to map to</typeparam>
+        /// <param name="source">Queryable source</param>
+        /// <param name="parameters">Optional parameter object for parameterized mapping expressions</param>
+        /// <param name="membersToExpand">Explicit members to expand</param>
+        /// <returns>Queryable result, use queryable extension methods to project and execute result</returns>
+        IQueryable<TDestination> ProjectTo<TDestination>(IQueryable source, IDictionary<string, object> parameters, params string[] membersToExpand);
     }
 
     public interface IRuntimeMapper : IMapper

--- a/src/AutoMapper/Mapper.cs
+++ b/src/AutoMapper/Mapper.cs
@@ -3,7 +3,11 @@ using AutoMapper.Configuration;
 
 namespace AutoMapper
 {
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
     using ObjectMappingOperationOptions = MappingOperationOptions<object, object>;
+    using QueryableExtensions;
 
     public class Mapper : IRuntimeMapper
     {
@@ -373,5 +377,11 @@ namespace AutoMapper
 
             return func(source, destination, context);
         }
+
+        IQueryable<TDestination> IMapper.ProjectTo<TDestination>(IQueryable source, object parameters, params Expression<Func<TDestination, object>>[] membersToExpand)
+            => source.ProjectTo(_configurationProvider, parameters, membersToExpand);
+
+        IQueryable<TDestination> IMapper.ProjectTo<TDestination>(IQueryable source, IDictionary<string, object> parameters, params string[] membersToExpand)
+            => source.ProjectTo<TDestination>(_configurationProvider, parameters, membersToExpand);
     }
 }

--- a/src/IntegrationTests/BuiltInTypes/ByteArray.cs
+++ b/src/IntegrationTests/BuiltInTypes/ByteArray.cs
@@ -64,7 +64,7 @@ namespace AutoMapper.IntegrationTests
         {
             using (var context = new Context())
             {
-                var customerVms = context.Customers.ProjectTo<CustomerViewModel>(Configuration).ToList();
+                var customerVms = ProjectTo<CustomerViewModel>(context.Customers).ToList();
                 customerVms.ForEach(x =>
                 {
                     x.RowVersion.SequenceEqual(new byte[] { 1, 2, 3 }).ShouldBeTrue();

--- a/src/IntegrationTests/BuiltInTypes/NullableToNonNullable.cs
+++ b/src/IntegrationTests/BuiltInTypes/NullableToNonNullable.cs
@@ -61,7 +61,7 @@ namespace AutoMapper.IntegrationTests
         {
             using (var context = new Context())
             {
-                var model = context.Customers.ProjectTo<CustomerViewModel>(Configuration).Single();
+                var model = ProjectTo<CustomerViewModel>(context.Customers).Single();
                 model.Id.ShouldBe(1);
                 model.FirstName.ShouldBe("Bob");
                 model.LastName.ShouldBe("Smith");
@@ -121,7 +121,7 @@ namespace AutoMapper.IntegrationTests
         {
             using(var context = new Context())
             {
-                var model = context.Customers.ProjectTo<CustomerViewModel>(Configuration).Single();
+                var model = ProjectTo<CustomerViewModel>(context.Customers).Single();
                 model.Id.ShouldBe(1);
                 model.FirstName.ShouldBe("Bob");
                 model.LastName.ShouldBe("Smith");

--- a/src/IntegrationTests/BuiltInTypes/ProjectEnumerableOfIntToList.cs
+++ b/src/IntegrationTests/BuiltInTypes/ProjectEnumerableOfIntToList.cs
@@ -69,7 +69,7 @@ namespace AutoMapper.IntegrationTests
         {
             using(var context = new Context())
             {
-                var customer = context.Customers.ProjectTo<CustomerViewModel>(Configuration).Single();
+                var customer = ProjectTo<CustomerViewModel>(context.Customers).Single();
                 customer.ItemsIds.SequenceEqual(new int[] { 1, 2, 3 }).ShouldBeTrue();
             }
         }

--- a/src/IntegrationTests/BuiltInTypes/ProjectUsing.cs
+++ b/src/IntegrationTests/BuiltInTypes/ProjectUsing.cs
@@ -69,7 +69,7 @@ namespace AutoMapper.IntegrationTests.Net4
         {
             using(var context = new TestContext())
             {
-                var results = context.MyTable.ProjectTo<MyTableModel>(Configuration).ToList();
+                var results = ProjectTo<MyTableModel>(context.MyTable).ToList();
                 results[0].Id.ShouldBe(1);
                 results[0].EnumValue.ShouldBe(MyEnum.Value2);
                 results[0].EnumValueNullable.ShouldBe(MyEnum.Value1);
@@ -134,7 +134,7 @@ namespace AutoMapper.IntegrationTests.Net4
         {
             using (var db = new ApplicationDBContext())
             {
-                var result = db.Parents.ProjectTo<ParentVM>(Configuration);
+                var result = ProjectTo<ParentVM>(db.Parents);
             }
         }
     }

--- a/src/IntegrationTests/ChildClassTests.cs
+++ b/src/IntegrationTests/ChildClassTests.cs
@@ -102,7 +102,7 @@ namespace AutoMapper.IntegrationTests.Net4
                     baseDTO.Sub.Sub1.ShouldBe("sub1");
 
 
-                    baseDTO = context.Bases.ProjectTo<BaseDTO>(Configuration).FirstOrDefault();
+                    baseDTO = ProjectTo<BaseDTO>(context.Bases).FirstOrDefault();
                     baseDTO.ShouldNotBeNull();
                     baseDTO.BaseID.ShouldBe(1);
                     baseDTO.Sub.Sub1.ShouldBe("sub1");

--- a/src/IntegrationTests/CustomMapFrom/CustomMapFromTest.cs
+++ b/src/IntegrationTests/CustomMapFrom/CustomMapFromTest.cs
@@ -102,7 +102,7 @@ namespace AutoMapper.IntegrationTests.Net4
                         x.FullAddress.ShouldNotBeEmpty();
                     });
 
-                    customerVms = context.Customers.ProjectTo<CustomerViewModel>(Configuration).ToList();
+                    customerVms = ProjectTo<CustomerViewModel>(context.Customers).ToList();
                     customerVms.ForEach(x =>
                     {
                         x.FullAddress.ShouldNotBeNull();

--- a/src/IntegrationTests/CustomMapFrom/MapObjectPropertyFromSubQuery.cs
+++ b/src/IntegrationTests/CustomMapFrom/MapObjectPropertyFromSubQuery.cs
@@ -28,7 +28,7 @@ namespace AutoMapper.IntegrationTests
         {
             using(var context = new ClientContext())
             {
-                var projection = context.Products.ProjectTo<ProductModel>(Configuration);
+                var projection = ProjectTo<ProductModel>(context.Products);
                 var counter = new FirstOrDefaultCounter();
                 counter.Visit(projection.Expression);
                 counter.Count.ShouldBe(1);
@@ -148,7 +148,7 @@ namespace AutoMapper.IntegrationTests
         {
             using(var context = new ClientContext())
             {
-                var projection = context.Products.ProjectTo<ProductModel>(Configuration);
+                var projection = ProjectTo<ProductModel>(context.Products);
                 var counter = new FirstOrDefaultCounter();
                 counter.Visit(projection.Expression);
                 counter.Count.ShouldBe(0);
@@ -238,7 +238,7 @@ namespace AutoMapper.IntegrationTests
         {
             using(var context = new ClientContext())
             {
-                var projection = context.Products.ProjectTo<ProductModel>(Configuration);
+                var projection = ProjectTo<ProductModel>(context.Products);
                 var counter = new FirstOrDefaultCounter();
                 counter.Visit(projection.Expression);
                 counter.Count.ShouldBe(1);
@@ -333,7 +333,7 @@ namespace AutoMapper.IntegrationTests
         {
             using(var context = new ClientContext())
             {
-                var projection = context.ProductArticles.ProjectTo<ProductArticleModel>(Configuration);
+                var projection = ProjectTo<ProductArticleModel>(context.ProductArticles);
                 var counter = new FirstOrDefaultCounter();
                 counter.Visit(projection.Expression);
                 counter.Count.ShouldBe(2);
@@ -447,7 +447,7 @@ namespace AutoMapper.IntegrationTests
         {
             using(var context = new ClientContext())
             {
-                var projection = context.ProductArticles.ProjectTo<ProductArticleModel>(Configuration);
+                var projection = ProjectTo<ProductArticleModel>(context.ProductArticles);
                 var counter = new FirstOrDefaultCounter();
                 counter.Visit(projection.Expression);
                 counter.Count.ShouldBe(1);
@@ -553,7 +553,7 @@ namespace AutoMapper.IntegrationTests
         {
             using(var context = new ClientContext())
             {
-                var projection = context.ProductArticles.ProjectTo<ProductArticleModel>(Configuration);
+                var projection = ProjectTo<ProductArticleModel>(context.ProductArticles);
                 var counter = new FirstOrDefaultCounter();
                 counter.Visit(projection.Expression);
                 counter.Count.ShouldBe(1);
@@ -752,7 +752,7 @@ namespace AutoMapper.IntegrationTests
         {
             using(var context = new ClientContext())
             {
-                var projection = context.Cables.ProjectTo<CableListModel>(Configuration);
+                var projection = ProjectTo<CableListModel>(context.Cables);
                 var result = projection.Single();
                 result.AEnd.DataHallId.ShouldBe(10);
                 result.AnotherEnd.DataHallId.ShouldBeNull();

--- a/src/IntegrationTests/ExplicitExpansion/ExpandCollections.cs
+++ b/src/IntegrationTests/ExplicitExpansion/ExpandCollections.cs
@@ -26,7 +26,7 @@ namespace AutoMapper.IntegrationTests.Net4
             using(var context = new ClientContext())
             {
                 context.Database.Log = s => Trace.WriteLine(s);
-                _course = context.TrainingCourses.ProjectTo<TrainingCourseDto>(Configuration, c => c.Content.Select(co => co.Category)).FirstOrDefault(n => n.CourseName == "Course 1");
+                _course = ProjectTo<TrainingCourseDto>(context.TrainingCourses, null, c => c.Content.Select(co => co.Category)).FirstOrDefault(n => n.CourseName == "Course 1");
             }
         }
 

--- a/src/IntegrationTests/ExplicitExpansion/ExpandCollectionsWithStrings.cs
+++ b/src/IntegrationTests/ExplicitExpansion/ExpandCollectionsWithStrings.cs
@@ -26,7 +26,7 @@ namespace AutoMapper.IntegrationTests.Net4
             using(var context = new ClientContext())
             {
                 context.Database.Log = s => Trace.WriteLine(s);
-                _course = context.TrainingCourses.ProjectTo<TrainingCourseDto>(Configuration, null, "Content.Category").FirstOrDefault(n => n.CourseName == "Course 1");
+                _course = ProjectTo<TrainingCourseDto>(context.TrainingCourses, null, "Content.Category").FirstOrDefault(n => n.CourseName == "Course 1");
             }
         }
 

--- a/src/IntegrationTests/ExplicitExpansion/ExpandMembersPath.cs
+++ b/src/IntegrationTests/ExplicitExpansion/ExpandMembersPath.cs
@@ -51,7 +51,7 @@ namespace AutoMapper.IntegrationTests.Net4
             using(TestContext context = new TestContext())
             {
                 context.Database.Log = s => Debug.WriteLine(s);
-                dtos = context.Class1Set.ProjectTo<Class1DTO>(Configuration, r => r.Class2DTO.Class3DTO).ToArray();                
+                dtos = ProjectTo<Class1DTO>(context.Class1Set, null, r => r.Class2DTO.Class3DTO).ToArray();                
             }
             Check(dtos);
         }
@@ -63,7 +63,7 @@ namespace AutoMapper.IntegrationTests.Net4
             using(TestContext context = new TestContext())
             {
                 context.Database.Log = s => Debug.WriteLine(s);
-                dtos = context.Class1Set.ProjectTo<Class1DTO>(Configuration, null, "Class2DTO.Class3DTO").ToArray();
+                dtos = ProjectTo<Class1DTO>(context.Class1Set, null, "Class2DTO.Class3DTO").ToArray();
             }
             Check(dtos);
         }

--- a/src/IntegrationTests/ExplicitExpansion/NestedExplicitExpand.cs
+++ b/src/IntegrationTests/ExplicitExpansion/NestedExplicitExpand.cs
@@ -52,7 +52,7 @@ namespace AutoMapper.IntegrationTests.Net4
             using(TestContext context = new TestContext())
             {
                 context.Database.Log = s => Debug.WriteLine(s);
-                dtos = context.Class1Set.ProjectTo<Class1DTO>(Configuration, r => r.Class2DTO, r => r.Class2DTO.Class3DTO).ToArray();                
+                dtos = ProjectTo<Class1DTO>(context.Class1Set, null, r => r.Class2DTO, r => r.Class2DTO.Class3DTO).ToArray();                
             }
             Check(dtos);
         }
@@ -64,7 +64,7 @@ namespace AutoMapper.IntegrationTests.Net4
             using(TestContext context = new TestContext())
             {
                 context.Database.Log = s => Debug.WriteLine(s);
-                dtos = context.Class1Set.ProjectTo<Class1DTO>(Configuration, null, "Class2DTO", "Class2DTO.Class3DTO").ToArray();
+                dtos = ProjectTo<Class1DTO>(context.Class1Set, null, "Class2DTO", "Class2DTO.Class3DTO").ToArray();
             }
             Check(dtos);
         }

--- a/src/IntegrationTests/ExplicitExpansion/NestedExplicitExpandWithFields.cs
+++ b/src/IntegrationTests/ExplicitExpansion/NestedExplicitExpandWithFields.cs
@@ -52,7 +52,7 @@ namespace AutoMapper.IntegrationTests.Net4
             using(TestContext context = new TestContext())
             {
                 context.Database.Log = s => Debug.WriteLine(s);
-                dtos = context.Class1Set.ProjectTo<Class1DTO>(Configuration, r => r.Class2DTO, r => r.Class2DTO.Class3DTO).ToArray();                
+                dtos = ProjectTo<Class1DTO>(context.Class1Set, null, r => r.Class2DTO, r => r.Class2DTO.Class3DTO).ToArray();                
             }
             Check(dtos);
         }
@@ -64,7 +64,7 @@ namespace AutoMapper.IntegrationTests.Net4
             using(TestContext context = new TestContext())
             {
                 context.Database.Log = s => Debug.WriteLine(s);
-                dtos = context.Class1Set.ProjectTo<Class1DTO>(Configuration, null, "Class2DTO", "Class2DTO.Class3DTO").ToArray();
+                dtos = ProjectTo<Class1DTO>(context.Class1Set, null, "Class2DTO", "Class2DTO.Class3DTO").ToArray();
             }
             Check(dtos);
         }

--- a/src/IntegrationTests/ExplicitExpansion/ProjectAndAllowNullCollections.cs
+++ b/src/IntegrationTests/ExplicitExpansion/ProjectAndAllowNullCollections.cs
@@ -138,7 +138,7 @@ namespace AutoMapper.IntegrationTests.Net4
         {
             using(var context = new MyContext())
             {
-                var foos = context.Foos.AsNoTracking().ProjectTo<FooDto>(Configuration, m => m.Bars).ToList();
+                var foos = ProjectTo<FooDto>(context.Foos.AsNoTracking(), null, m => m.Bars).ToList();
 
                 foos[0].Bars.ShouldNotBeNull();
                 foos[0].Bazs.ShouldBeNull();

--- a/src/IntegrationTests/ExplicitExpansion/ProjectionWithExplicitExpansion.cs
+++ b/src/IntegrationTests/ExplicitExpansion/ProjectionWithExplicitExpansion.cs
@@ -109,7 +109,7 @@ namespace AutoMapper.IntegrationTests
         {
             using (var ctx = new Context())
             {
-                var dto = ctx.Sources.ProjectTo<Dto>(Configuration).ToList().First();
+                var dto = ProjectTo<Dto>(ctx.Sources).ToList().First();
                 var sqlSelect = ctx.GetLastSelectSqlLogEntry();
                 sqlSelect.SqlFromShouldStartWith(nameof(ctx.Sources));
                 sqlSelect.ShouldNotContain("JOIN");
@@ -125,7 +125,7 @@ namespace AutoMapper.IntegrationTests
         {
             using (var ctx = new Context())
             {
-                var dto = ctx.Sources.ProjectTo<Dto>(Configuration, _ => _.Name).First();
+                var dto = ProjectTo<Dto>(ctx.Sources, null,  _ => _.Name).First();
                 var sqlSelect = ctx.GetLastSelectSqlLogEntry();
                 sqlSelect.SqlFromShouldStartWith(nameof(ctx.Sources));
                 sqlSelect.ShouldNotContain("JOIN");
@@ -140,7 +140,7 @@ namespace AutoMapper.IntegrationTests
         {
             using (var ctx = new Context())
             {
-                var dto = ctx.Sources.ProjectTo<Dto>(Configuration, _ => _.Desc).First();
+                var dto = ProjectTo<Dto>(ctx.Sources, null,  _ => _.Desc).First();
 
                 var sqlSelect = ctx.GetLastSelectSqlLogEntry();
                 sqlSelect.SqlFromShouldStartWith(nameof(ctx.Sources));
@@ -157,7 +157,7 @@ namespace AutoMapper.IntegrationTests
         {
             using (var ctx = new Context())
             {
-                var dto = ctx.Sources.ProjectTo<Dto>(Configuration, _ => _.Name, _ => _.Desc).First();
+                var dto = ProjectTo<Dto>(ctx.Sources, null,  _ => _.Name, _ => _.Desc).First();
 
                 var sqlSelect = ctx.GetLastSelectSqlLogEntry();
                 sqlSelect.SqlFromShouldStartWith(nameof(ctx.Sources));
@@ -174,7 +174,7 @@ namespace AutoMapper.IntegrationTests
         {
             using (var ctx = new Context())
             {
-                var dto = ctx.Sources.ProjectTo<Dto>(Configuration, _ => _.InnerDescFlattened).ToList().First();
+                var dto = ProjectTo<Dto>(ctx.Sources, null,  _ => _.InnerDescFlattened).ToList().First();
 
                 dto.InnerDescFlattened.ShouldBe(_iqf.Inner.Ides);
                 dto.InnerFlattenedNonKey.ShouldBeNull();
@@ -194,7 +194,7 @@ namespace AutoMapper.IntegrationTests
         {
             using (var ctx = new Context())
             {
-                var dto = ctx.Sources.ProjectTo<Dto>(Configuration, _ => _.InnerFlattenedNonKey).ToList().First();
+                var dto = ProjectTo<Dto>(ctx.Sources, null,  _ => _.InnerFlattenedNonKey).ToList().First();
 
                 dto.InnerFlattenedNonKey.ShouldBe(_iqf.Inner.Ide1);
                 dto.InnerDescFlattened.ShouldBeNull();
@@ -215,7 +215,7 @@ namespace AutoMapper.IntegrationTests
         {
             using (var ctx = new Context())
             {
-                var dto = ctx.Sources.ProjectTo<Dto>(Configuration, _ => _.DeepFlattened).ToList().First();
+                var dto = ProjectTo<Dto>(ctx.Sources, null,  _ => _.DeepFlattened).ToList().First();
                 var sqlSelect = ctx.GetLastSelectSqlLogEntry();
                 sqlSelect.SqlFromShouldStartWith(nameof(ctx.Sources));
 

--- a/src/IntegrationTests/ICollectionAggregateProjections.cs
+++ b/src/IntegrationTests/ICollectionAggregateProjections.cs
@@ -68,10 +68,10 @@ namespace AutoMapper.IntegrationTests
         {
             using (var context = new Context())
             {
-                var result = context.Customers.Select(customer => new
+                var result = ProjectTo<CustomerViewModel>(context.Customers.Select(customer => new
                 {
                     ItemCodes = (ICollection<int>)customer.Items.Select(item => item.Code).ToList()
-                }).ProjectTo<CustomerViewModel>(Configuration).Single();
+                })).Single();
 
                 result.ItemCodesCount.ShouldBe(3);
                 result.ItemCodesMin.ShouldBe(1);

--- a/src/IntegrationTests/IEnumerableAggregateProjections.cs
+++ b/src/IntegrationTests/IEnumerableAggregateProjections.cs
@@ -68,10 +68,10 @@ namespace AutoMapper.IntegrationTests
         {
             using (var context = new Context())
             {
-                var result = context.Customers.Select(customer => new
+                var result = ProjectTo<CustomerViewModel>(context.Customers.Select(customer => new
                 {
                     ItemCodes = customer.Items.Select(item => item.Code)
-                }).ProjectTo<CustomerViewModel>(Configuration).Single();
+                })).Single();
 
                 result.ItemCodesCount.ShouldBe(3);
                 result.ItemCodesMin.ShouldBe(1);

--- a/src/IntegrationTests/Inheritance/DerivedComplexTypes.cs
+++ b/src/IntegrationTests/Inheritance/DerivedComplexTypes.cs
@@ -80,7 +80,7 @@ namespace AutoMapper.IntegrationTests
         {
             using (var context = new Context())
             {
-                var customerVm = context.Customers.ProjectTo<CustomerViewModel>(Configuration).First();
+                var customerVm = ProjectTo<CustomerViewModel>(context.Customers).First();
                 customerVm.Address.ShouldBe("home");
             }
         }

--- a/src/IntegrationTests/Inheritance/ProjectToAbstractType.cs
+++ b/src/IntegrationTests/Inheritance/ProjectToAbstractType.cs
@@ -66,7 +66,7 @@ namespace AutoMapper.IntegrationTests.Net4
         {
             using(var context = new Context())
             {
-                _destinations = context.EntityA.ProjectTo<ITypeA>(Configuration).ToArray();
+                _destinations = ProjectTo<ITypeA>(context.EntityA).ToArray();
             }
             _destinations.Length.ShouldBe(3);
             _destinations[2].Name.ShouldBe("Bill Gates");
@@ -323,7 +323,7 @@ namespace AutoMapper.IntegrationTests.Net4
         {
             using(var context = new Context())
             {
-                var domainCalendars = context.Calendars.ProjectTo<ICalendar>(Configuration).ToList();
+                var domainCalendars = ProjectTo<ICalendar>(context.Calendars).ToList();
                 domainCalendars.Count.ShouldBe(2);
             }
         }

--- a/src/IntegrationTests/Inheritance/QueryableInterfaceInheritanceIssue.cs
+++ b/src/IntegrationTests/Inheritance/QueryableInterfaceInheritanceIssue.cs
@@ -52,7 +52,7 @@ namespace AutoMapper.IntegrationTests
         {
             using(var context = new ClientContext())
             {
-                _result = context.Entities.ProjectTo<QueryableDto>(ConfigProvider).ToArray();
+                _result = ProjectTo<QueryableDto>(context.Entities).ToArray();
             }
         }
 

--- a/src/IntegrationTests/MaxDepth/MaxDepthWithCollections.cs
+++ b/src/IntegrationTests/MaxDepth/MaxDepthWithCollections.cs
@@ -24,7 +24,7 @@ namespace AutoMapper.IntegrationTests.Net4
         {
             using(var context = new ClientContext())
             {
-                _course = context.TrainingCourses.ProjectTo<TrainingCourseDto>(Configuration).FirstOrDefault(n => n.CourseName == "Course 1");
+                _course = ProjectTo<TrainingCourseDto>(context.TrainingCourses).FirstOrDefault(n => n.CourseName == "Course 1");
             }
         }
 

--- a/src/IntegrationTests/MaxDepth/NavigationPropertySO.cs
+++ b/src/IntegrationTests/MaxDepth/NavigationPropertySO.cs
@@ -99,7 +99,7 @@ namespace AutoMapper.IntegrationTests.Net4
         {
             using(var context = new Context())
             {
-                _destination = context.Customers.ProjectTo<CustomerDTO>(Configuration).Single();
+                _destination = ProjectTo<CustomerDTO>(context.Customers).Single();
                 _destination.Id.ShouldBe(1);
                 _destination.Name1.SequenceEqual("Bob");
                 _destination.Cust.CustomerID.ShouldBe(1);

--- a/src/IntegrationTests/MaxDepth/NestedDtos.cs
+++ b/src/IntegrationTests/MaxDepth/NestedDtos.cs
@@ -81,7 +81,7 @@ namespace AutoMapper.IntegrationTests.Net4
         {
             using(var context = new TestContext())
             {
-                _destination = context.Arts.ProjectTo<ArtDto>(Configuration).FirstOrDefault();
+                _destination = ProjectTo<ArtDto>(context.Arts).FirstOrDefault();
             }
         }
 

--- a/src/IntegrationTests/NullSubstitute.cs
+++ b/src/IntegrationTests/NullSubstitute.cs
@@ -63,7 +63,7 @@ namespace AutoMapper.IntegrationTests
         {
             using (var context = new Context())
             {
-                context.Customers.ProjectTo<CustomerViewModel>(Configuration).ToList()[0].Value.ShouldBe(5);
+                ProjectTo<CustomerViewModel>(context.Customers).ToList()[0].Value.ShouldBe(5);
             }
         }
     }

--- a/src/IntegrationTests/Parameterization/ParameterizedQueries.cs
+++ b/src/IntegrationTests/Parameterization/ParameterizedQueries.cs
@@ -66,7 +66,7 @@ namespace AutoMapper.IntegrationTests.Parameterization
             using (var db = new ClientContext())
             {
                 username = "Mary";
-                var query = db.Entities.ProjectTo<EntityDto>(Configuration, new { username });
+                var query = ProjectTo<EntityDto>(db.Entities, new { username });
                 dtos = await query.ToListAsync();
                 var constantVisitor = new ConstantVisitor();
                 constantVisitor.Visit(query.Expression);
@@ -74,7 +74,7 @@ namespace AutoMapper.IntegrationTests.Parameterization
                 dtos.All(dto => dto.UserName == username).ShouldBeTrue();
 
                 username = "Joe";
-                query = db.Entities.ProjectTo<EntityDto>(Configuration, new Dictionary<string, object> { { "username", username }});
+                query = ProjectTo<EntityDto>(db.Entities, new Dictionary<string, object> { { "username", username }});
                 dtos = await query.ToListAsync();
                 constantVisitor = new ConstantVisitor();
                 constantVisitor.Visit(query.Expression);

--- a/src/IntegrationTests/ProjectionOrder/ProjectionOrderTest.cs
+++ b/src/IntegrationTests/ProjectionOrder/ProjectionOrderTest.cs
@@ -71,7 +71,7 @@ namespace AutoMapper.IntegrationTests.ProjectionOrder
         {
             using (var context = new ClientContext())
             {
-                context.Source1.ProjectTo<Destination>(Configuration).Union(context.Source2.ProjectTo<Destination>(Configuration)).ToString();
+                ProjectTo<Destination>(context.Source1).Union(ProjectTo<Destination>(context.Source2)).ToString();
             }
         }
     }

--- a/src/IntegrationTests/ValueTransformers/ValueTransformerTests.cs
+++ b/src/IntegrationTests/ValueTransformers/ValueTransformerTests.cs
@@ -56,7 +56,7 @@ namespace AutoMapper.IntegrationTests.ValueTransformers
             {
                 using (var context = new Context())
                 {
-                    var dest = await context.Sources.ProjectTo<Dest>(Configuration).SingleAsync();
+                    var dest = await ProjectTo<Dest>(context.Sources).SingleAsync();
 
                     dest.Value.ShouldBe("Jimmy is straight up dope");
                 }
@@ -110,7 +110,7 @@ namespace AutoMapper.IntegrationTests.ValueTransformers
             {
                 using (var context = new Context())
                 {
-                    var dest = await context.Sources.ProjectTo<Dest>(Configuration).SingleAsync();
+                    var dest = await ProjectTo<Dest>(context.Sources).SingleAsync();
 
                     dest.Value.ShouldBe("Jimmy is straight up dope! No joke!");
                 }
@@ -164,7 +164,7 @@ namespace AutoMapper.IntegrationTests.ValueTransformers
             {
                 using (var context = new Context())
                 {
-                    var dest = await context.Sources.ProjectTo<Dest>(Configuration).SingleAsync();
+                    var dest = await ProjectTo<Dest>(context.Sources).SingleAsync();
 
                     dest.Value.ShouldBe("Jimmy is straight up dope");
                 }
@@ -220,7 +220,7 @@ namespace AutoMapper.IntegrationTests.ValueTransformers
             {
                 using (var context = new Context())
                 {
-                    var dest = await context.Sources.ProjectTo<Dest>(Configuration).SingleAsync();
+                    var dest = await ProjectTo<Dest>(context.Sources).SingleAsync();
 
                     dest.Value.ShouldBe("Jimmy is straight up dope! No joke!");
                 }
@@ -276,7 +276,7 @@ namespace AutoMapper.IntegrationTests.ValueTransformers
             {
                 using (var context = new Context())
                 {
-                    var dest = await context.Sources.ProjectTo<Dest>(Configuration).SingleAsync();
+                    var dest = await ProjectTo<Dest>(context.Sources).SingleAsync();
 
                     dest.Value.ShouldBe((5 + 3) * 2);
                 }
@@ -334,7 +334,7 @@ namespace AutoMapper.IntegrationTests.ValueTransformers
             {
                 using (var context = new Context())
                 {
-                    var dest = await context.Sources.ProjectTo<Dest>(Configuration).SingleAsync();
+                    var dest = await ProjectTo<Dest>(context.Sources).SingleAsync();
 
                     dest.Value.ShouldBe("Jimmy, for real, is straight up dope! No joke!");
                 }
@@ -392,7 +392,7 @@ namespace AutoMapper.IntegrationTests.ValueTransformers
             {
                 using (var context = new Context())
                 {
-                    var dest = await context.Sources.ProjectTo<Dest>(Configuration).SingleAsync();
+                    var dest = await ProjectTo<Dest>(context.Sources).SingleAsync();
 
                     dest.Value.ShouldBe("Jimmy, seriously, for real, is straight up dope! No joke!");
                 }

--- a/src/UnitTests/AutoMapperSpecBase.cs
+++ b/src/UnitTests/AutoMapperSpecBase.cs
@@ -4,6 +4,9 @@ using Xunit;
 namespace AutoMapper.UnitTests
 {
     using QueryableExtensions;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
 
     public abstract class AutoMapperSpecBase : NonValidatingSpecBase
     {
@@ -23,6 +26,12 @@ namespace AutoMapper.UnitTests
         protected IConfigurationProvider ConfigProvider => Configuration;
 
         protected IMapper Mapper => mapper ?? (mapper = Configuration.CreateMapper());
+
+        protected IQueryable<TDestination> ProjectTo<TDestination>(IQueryable source, object parameters = null, params Expression<Func<TDestination, object>>[] membersToExpand) => 
+            Mapper.ProjectTo(source, parameters, membersToExpand);
+
+        protected IQueryable<TDestination> ProjectTo<TDestination>(IQueryable source, IDictionary<string, object> parameters, params string[] membersToExpand) =>
+            Mapper.ProjectTo<TDestination>(source, parameters, membersToExpand);
     }
 
     public abstract class SpecBaseBase


### PR DESCRIPTION
Fixes #2857. I omitted the overloads with two parameters. I think we can live without them. People can easily add them, but I guess we could have them built in as extension methods.