### PR TITLE
Added methods BeforeMap and AfterMap for IMappingExpression with ResolutionContext

### DIFF
--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -55,10 +55,16 @@ namespace AutoMapper.Configuration
         public new IMappingExpression BeforeMap(Action<object, object> beforeFunction) 
             => (IMappingExpression)base.BeforeMap(beforeFunction);
 
+        public new IMappingExpression BeforeMap(Action<object, object, ResolutionContext> beforeFunction)
+            => (IMappingExpression)base.BeforeMap(beforeFunction);
+
         public new IMappingExpression BeforeMap<TMappingAction>() where TMappingAction : IMappingAction<object, object> 
             => (IMappingExpression)base.BeforeMap<TMappingAction>();
 
         public new IMappingExpression AfterMap(Action<object, object> afterFunction) 
+            => (IMappingExpression)base.AfterMap(afterFunction);
+
+        public new IMappingExpression AfterMap(Action<object, object, ResolutionContext> afterFunction)
             => (IMappingExpression)base.AfterMap(afterFunction);
 
         public new IMappingExpression AfterMap<TMappingAction>() where TMappingAction : IMappingAction<object, object> 

--- a/src/AutoMapper/IMappingExpression.cs
+++ b/src/AutoMapper/IMappingExpression.cs
@@ -147,6 +147,13 @@ namespace AutoMapper
         IMappingExpression BeforeMap(Action<object, object> beforeFunction);
 
         /// <summary>
+        /// Execute a custom function to the source and/or destination types before member mapping
+        /// </summary>
+        /// <param name="beforeFunction">Callback for the source/destination types</param>
+        /// <returns>Itself</returns>
+        IMappingExpression BeforeMap(Action<object, object, ResolutionContext> beforeFunction);
+
+        /// <summary>
         /// Execute a custom mapping action before member mapping
         /// </summary>
         /// <typeparam name="TMappingAction">Mapping action type instantiated during mapping</typeparam>
@@ -160,6 +167,13 @@ namespace AutoMapper
         /// <param name="afterFunction">Callback for the source/destination types</param>
         /// <returns>Itself</returns>
         IMappingExpression AfterMap(Action<object, object> afterFunction);
+
+        /// <summary>
+        /// Execute a custom function to the source and/or destination types after member mapping
+        /// </summary>
+        /// <param name="afterFunction">Callback for the source/destination types</param>
+        /// <returns>Itself</returns>
+        IMappingExpression AfterMap(Action<object, object, ResolutionContext> afterFunction);
 
         /// <summary>
         /// Execute a custom mapping action after member mapping

--- a/src/UnitTests/BeforeAfterMapping.cs
+++ b/src/UnitTests/BeforeAfterMapping.cs
@@ -33,6 +33,30 @@ namespace AutoMapper.UnitTests.BeforeAfterMapping
             afterMapCalled.ShouldBeTrue();
         }
 
+        [Fact]
+        public void Before_and_After_overrides_should_be_called()
+        {
+            var beforeMapCalled = false;
+            var afterMapCalled = false;
+
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Source, Destination>();
+                cfg.ForAllMaps((map, expression) =>
+                {
+                    expression.BeforeMap((src, dest, context) => beforeMapCalled = true);
+                    expression.AfterMap((src, dest, context) => afterMapCalled = true);
+                });
+            });
+
+            var mapper = config.CreateMapper();
+
+            mapper.Map<Source, Destination>(new Source());
+
+            beforeMapCalled.ShouldBeTrue();
+            afterMapCalled.ShouldBeTrue();
+        }
+
     }
 
     public class When_configuring_before_and_after_methods_multiple_times
@@ -57,6 +81,32 @@ namespace AutoMapper.UnitTests.BeforeAfterMapping
                     .BeforeMap((src, dest) => beforeMapCount++)
                     .AfterMap((src, dest) => afterMapCount++)
                     .AfterMap((src, dest) => afterMapCount++);
+            });
+
+            var mapper = config.CreateMapper();
+
+            mapper.Map<Source, Destination>(new Source());
+
+            beforeMapCount.ShouldBe(2);
+            afterMapCount.ShouldBe(2);
+        }
+
+        [Fact]
+        public void Before_and_After_overrides_should_be_called()
+        {
+            var beforeMapCount = 0;
+            var afterMapCount = 0;
+
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.CreateMap<Source, Destination>();
+                cfg.ForAllMaps((map, expression) =>
+                {
+                    expression.BeforeMap((src, dest, context) => beforeMapCount++)
+                        .BeforeMap((src, dest, context) => beforeMapCount++);
+                    expression.AfterMap((src, dest, context) => afterMapCount++)
+                        .AfterMap((src, dest, context) => afterMapCount++);
+                });
             });
 
             var mapper = config.CreateMapper();


### PR DESCRIPTION
This allows to use `ResolutionContext` when callbacks are added in `MapperConfigurationExpression.ForAllMaps()`, when only the non-templated `IMappingExpression` is available.

I guess the line encoding is buggy, so that's why the change is so big for `MappingExpression.cs`, but only lines 58-60 and 67-69 were added.