### PR TITLE
A value converter/resolver always returns a value of the destination …

### DIFF
--- a/src/AutoMapper/ConfigurationValidator.cs
+++ b/src/AutoMapper/ConfigurationValidator.cs
@@ -110,7 +110,10 @@ namespace AutoMapper
         {
             foreach (var propertyMap in typeMap.PropertyMaps)
             {
-                if (propertyMap.Ignored) continue;
+                if(propertyMap.Ignored || propertyMap.ValueConverterConfig != null || propertyMap.ValueResolverConfig != null)
+                {
+                    continue;
+                }
 
                 var sourceType = propertyMap.SourceType;
 

--- a/src/UnitTests/ConfigurationValidation.cs
+++ b/src/UnitTests/ConfigurationValidation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using AutoMapper.Mappers;
 using Shouldly;
 using Xunit;
@@ -715,6 +716,33 @@ namespace AutoMapper.UnitTests.ConfigurationValidation
         interface IAbstractDest
         {
             string DifferentName { get; set; }
+        }
+    }
+
+    public class When_configuring_a_resolver : AutoMapperSpecBase
+    {
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMissingTypeMaps = false;
+            cfg.CreateMap<Query, Command>().ForMember(d => d.Details, o => o.MapFrom<DetailsValueResolver>());
+        });
+        public class DetailsValueResolver : IValueResolver<Query, Command, List<KeyValuePair<string, string>>>
+        {
+            public List<KeyValuePair<string, string>> Resolve(Query source, Command destination, List<KeyValuePair<string, string>> destMember, ResolutionContext context)
+            {
+                return source.Details
+                    .Select(d => new KeyValuePair<string, string>(d.ToString(), d.ToString()))
+                    .ToList();
+            }
+        }
+        public class Query
+        {
+            public List<int> Details { get; set; }
+        }
+
+        public class Command
+        {
+            public List<KeyValuePair<string, string>> Details { get; private set; }
         }
     }
 }


### PR DESCRIPTION
…property type, so it can be mapped. Fixes #2902.
For historical reasons, typeof(object) was used as a marker type to skip validation for members with class based resolvers. Now that the source type is the real one, that no longer works. But it seems to me that class based resolvers always return the destination property type, TMember in IMemberConfigurationExpression. So if it has a class based resolver, it can be mapped. I guess we'll see :)