### PR TITLE
Add support to specify ShouldMapMethod 

### DIFF
--- a/src/AutoMapper/Configuration/IProfileConfiguration.cs
+++ b/src/AutoMapper/Configuration/IProfileConfiguration.cs
@@ -40,6 +40,13 @@ namespace AutoMapper.Configuration
         Func<FieldInfo, bool> ShouldMapField { get; }
 
         /// <summary>
+        /// Specify which methods, of those that are eligible (public, parameterless, and non-static or extension methods), should be mapped.
+        /// By default all eligible methods are mapped.
+        /// </summary>
+        Func<MethodInfo, bool> ShouldMapMethod { get; }
+
+
+        /// <summary>
         /// Specify which constructors should be considered for the destination objects.
         /// By default all constructors are considered.
         /// </summary>

--- a/src/AutoMapper/IProfileExpression.cs
+++ b/src/AutoMapper/IProfileExpression.cs
@@ -145,6 +145,7 @@ namespace AutoMapper
 
         Func<PropertyInfo, bool> ShouldMapProperty { get; set; }
         Func<FieldInfo, bool> ShouldMapField { get; set; }
+        Func<MethodInfo, bool> ShouldMapMethod { get; set; }
         Func<ConstructorInfo, bool> ShouldUseConstructor { get; set; }
         
         string ProfileName { get; }

--- a/src/AutoMapper/Profile.cs
+++ b/src/AutoMapper/Profile.cs
@@ -74,6 +74,7 @@ namespace AutoMapper
         public bool? EnableNullPropagationForQueryMapping { get; set; }
         public Func<PropertyInfo, bool> ShouldMapProperty { get; set; }
         public Func<FieldInfo, bool> ShouldMapField { get; set; }
+        public Func<MethodInfo, bool> ShouldMapMethod { get; set; }
         public Func<ConstructorInfo, bool> ShouldUseConstructor { get; set; }
 
         public INamingConvention SourceMemberNamingConvention { get; set; }

--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -34,6 +34,7 @@ namespace AutoMapper
             ConstructorMappingEnabled = profile.ConstructorMappingEnabled ?? configuration?.ConstructorMappingEnabled ?? true;
             ShouldMapField = profile.ShouldMapField ?? configuration?.ShouldMapField ?? (p => p.IsPublic());
             ShouldMapProperty = profile.ShouldMapProperty ?? configuration?.ShouldMapProperty ?? (p => p.IsPublic());
+            ShouldMapMethod = profile.ShouldMapMethod ?? configuration?.ShouldMapMethod ?? (p => true);
             ShouldUseConstructor = profile.ShouldUseConstructor ?? configuration?.ShouldUseConstructor ?? (c => true);
             CreateMissingTypeMaps = profile.CreateMissingTypeMaps ?? configuration?.CreateMissingTypeMaps ?? true;
             ValidateInlineMaps = profile.ValidateInlineMaps ?? configuration?.ValidateInlineMaps ?? true;
@@ -84,6 +85,7 @@ namespace AutoMapper
         public string Name { get; }
         public Func<FieldInfo, bool> ShouldMapField { get; }
         public Func<PropertyInfo, bool> ShouldMapProperty { get; }
+        public Func<MethodInfo, bool> ShouldMapMethod { get; }
         public Func<ConstructorInfo, bool> ShouldUseConstructor { get; }
 
         public IEnumerable<Action<PropertyMap, IMemberConfigurationExpression>> AllPropertyMapActions { get; }

--- a/src/UnitTests/ShouldMapMethod.cs
+++ b/src/UnitTests/ShouldMapMethod.cs
@@ -1,0 +1,73 @@
+﻿using Xunit;
+using Shouldly;
+using System;
+
+namespace AutoMapper.UnitTests
+{
+    public class ShouldMapMethod : NonValidatingSpecBase
+    {
+        public int SomeValue = 2354;
+        public int AnotherValue = 6798;
+
+        private Destination _destination;
+
+        class Source
+        {
+            private int _someValue;
+            private int _anotherValue;
+
+            public Source(int someValue, int anotherValue) 
+            {
+                _someValue = someValue;
+                anotherValue = _anotherValue;
+            }
+
+            public int SomeNumber() 
+            {
+                return _someValue;
+            }
+
+            public int AnotherNumber() {
+                return _anotherValue;
+            }
+        }
+
+        class Destination
+        {
+            public int SomeNumber { get; set; }
+            public int AnotherNumber { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.ShouldMapMethod = (m => m.Name != nameof(Source.AnotherNumber));
+            cfg.CreateMap<Source, Destination>();
+        });
+
+        protected override void Because_of()
+        {
+            _destination = Mapper.Map<Source, Destination>(new Source(SomeValue, AnotherValue));
+        }
+
+        [Fact]
+        public void Should_report_unmapped_property()
+        {
+            new Action(() => Configuration.AssertConfigurationIsValid())
+                .ShouldThrowException<AutoMapperConfigurationException>(ex => 
+                {
+                    ex.Errors.ShouldNotBeNull();
+                    ex.Errors.ShouldNotBeEmpty();
+                    ex.Errors[0].UnmappedPropertyNames.ShouldNotBeNull();
+                    ex.Errors[0].UnmappedPropertyNames.ShouldNotBeNull();
+                    ex.Errors[0].UnmappedPropertyNames[0].ShouldBe(nameof(Destination.AnotherNumber));
+                });
+        }
+
+        [Fact]
+        public void Should_not_map_another_number_method() 
+        {
+            _destination.SomeNumber.ShouldBe(SomeValue);
+            _destination.AnotherNumber.ShouldNotBe(AnotherValue);
+        }
+    }
+}

--- a/src/UnitTests/ShouldMapMethod.cs
+++ b/src/UnitTests/ShouldMapMethod.cs
@@ -58,7 +58,7 @@ namespace AutoMapper.UnitTests
                     ex.Errors.ShouldNotBeNull();
                     ex.Errors.ShouldNotBeEmpty();
                     ex.Errors[0].UnmappedPropertyNames.ShouldNotBeNull();
-                    ex.Errors[0].UnmappedPropertyNames.ShouldNotBeNull();
+                    ex.Errors[0].UnmappedPropertyNames.ShouldNotBeEmpty();
                     ex.Errors[0].UnmappedPropertyNames[0].ShouldBe(nameof(Destination.AnotherNumber));
                 });
         }


### PR DESCRIPTION
Add support to specify ShouldMapMethod to determine which methods, of those that are eligible to be mapped (parameterless, public, and non-static or extension methods) should be mapped.

Fixed #2959 