### PR TITLE
Fix for #2961

### DIFF
--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -361,6 +361,12 @@ namespace AutoMapper.QueryableExtensions
                 }
                 var parameterName = node.Member.Name;
 
+                const string vbPrefix = "$VB$Local_";
+                if (parameterName.StartsWith(vbPrefix, StringComparison.Ordinal))
+                {
+                    parameterName = parameterName.Substring(vbPrefix.Length);
+                }
+
                 var matchingMember = _parameters.GetType().GetDeclaredProperty(parameterName);
 
                 return matchingMember != null 


### PR DESCRIPTION
Seems that for VB.Net dictionary mapping of parameters works but wasn't working for parameterized queries, this fixes the problem.

Fixes #2961 