### PR TITLE
Skip generic mappings when precompiling

### DIFF
--- a/src/AutoMapper/MapperConfiguration.cs
+++ b/src/AutoMapper/MapperConfiguration.cs
@@ -98,7 +98,7 @@ namespace AutoMapper
 
         public void CompileMappings()
         {
-            foreach (var request in _typeMapPlanCache.Keys.Select(types => new MapRequest(types, types)).ToArray())
+            foreach (var request in _typeMapPlanCache.Keys.Where(t=>t.GetOpenGenericTypePair() == null).Select(types => new MapRequest(types, types)).ToArray())
             {
                 GetMapperFunc(request);
             }

--- a/src/UnitTests/ConfigCompilation.cs
+++ b/src/UnitTests/ConfigCompilation.cs
@@ -1,5 +1,6 @@
 ﻿namespace AutoMapper.UnitTests
 {
+    using System.Collections.Generic;
     using Shouldly;
     using Xunit;
 
@@ -14,6 +15,7 @@
         {
             cfg.CreateMap<Source, Dest>();
             cfg.CreateMap<Source2, Dest2>();
+            cfg.CreateMap(typeof(IEnumerable<>), typeof(IEnumerable<>)).ConvertUsing(s => s);
         });
 
         [Fact]


### PR DESCRIPTION
Fixes #2976.