### PR TITLE
Respect PathMappings in unmapped property names list

### DIFF
--- a/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
@@ -80,7 +80,7 @@ namespace AutoMapper.Configuration
             => AddMapsCore(assembliesToScan);
 
         public void AddMaps(IEnumerable<string> assemblyNamesToScan)
-            => AddMapsCore(assemblyNamesToScan.Select(name => Assembly.Load(name)));
+            => AddMapsCore(assemblyNamesToScan.Select(Assembly.Load));
 
         public void AddMaps(params string[] assemblyNamesToScan)
             => AddMaps((IEnumerable<string>)assemblyNamesToScan);

--- a/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
@@ -54,16 +54,16 @@ namespace AutoMapper.Configuration
             => AddMaps(assembliesToScan);
 
         public void AddProfiles(IEnumerable<string> assemblyNamesToScan)
-            => AddMaps(assemblyNamesToScan.Select(name => Assembly.Load(new AssemblyName(name))));
+            => AddMaps(assemblyNamesToScan);
 
         public void AddProfiles(params string[] assemblyNamesToScan)
-            => AddMaps(assemblyNamesToScan.Select(name => Assembly.Load(new AssemblyName(name))));
+            => AddMaps(assemblyNamesToScan);
 
         public void AddProfiles(IEnumerable<Type> typesFromAssembliesContainingProfiles)
-            => AddMaps(typesFromAssembliesContainingProfiles.Select(t => t.GetTypeInfo().Assembly));
+            => AddMaps(typesFromAssembliesContainingProfiles);
 
         public void AddProfiles(params Type[] typesFromAssembliesContainingProfiles)
-            => AddMaps(typesFromAssembliesContainingProfiles.Select(t => t.GetTypeInfo().Assembly));
+            => AddMaps(typesFromAssembliesContainingProfiles);
 
         public void AddProfiles(IEnumerable<Profile> enumerableOfProfiles)
         {
@@ -80,16 +80,16 @@ namespace AutoMapper.Configuration
             => AddMapsCore(assembliesToScan);
 
         public void AddMaps(IEnumerable<string> assemblyNamesToScan)
-            => AddMapsCore(assemblyNamesToScan.Select(name => Assembly.Load(new AssemblyName(name))));
+            => AddMapsCore(assemblyNamesToScan.Select(name => Assembly.Load(name)));
 
         public void AddMaps(params string[] assemblyNamesToScan)
-            => AddMapsCore(assemblyNamesToScan.Select(name => Assembly.Load(new AssemblyName(name))));
+            => AddMaps((IEnumerable<string>)assemblyNamesToScan);
 
         public void AddMaps(IEnumerable<Type> typesFromAssembliesContainingMappingDefinitions)
             => AddMapsCore(typesFromAssembliesContainingMappingDefinitions.Select(t => t.GetTypeInfo().Assembly));
 
         public void AddMaps(params Type[] typesFromAssembliesContainingMappingDefinitions)
-            => AddMapsCore(typesFromAssembliesContainingMappingDefinitions.Select(t => t.GetTypeInfo().Assembly));
+            => AddMaps((IEnumerable<Type>)typesFromAssembliesContainingMappingDefinitions);
 
         private void AddMapsCore(IEnumerable<Assembly> assembliesToScan)
         {

--- a/src/AutoMapper/ConstructorParameterMap.cs
+++ b/src/AutoMapper/ConstructorParameterMap.cs
@@ -30,7 +30,7 @@ namespace AutoMapper
 
         public override Type DestinationType => Parameter.ParameterType;
 
-        public override IEnumerable<MemberInfo> SourceMembers { get; set; }
+        public override IEnumerable<MemberInfo> SourceMembers { get; }
         public override string DestinationName => Parameter.Member.DeclaringType + "." + Parameter.Member + ".parameter " + Parameter.Name;
 
         public bool HasDefaultValue => Parameter.IsOptional;

--- a/src/AutoMapper/ConstructorParameterMap.cs
+++ b/src/AutoMapper/ConstructorParameterMap.cs
@@ -30,7 +30,7 @@ namespace AutoMapper
 
         public override Type DestinationType => Parameter.ParameterType;
 
-        public override IEnumerable<MemberInfo> SourceMembers { get; }
+        public override IEnumerable<MemberInfo> SourceMembers { get; set; }
         public override string DestinationName => Parameter.Member.DeclaringType + "." + Parameter.Member + ".parameter " + Parameter.Name;
 
         public bool HasDefaultValue => Parameter.IsOptional;

--- a/src/AutoMapper/DefaultMemberMap.cs
+++ b/src/AutoMapper/DefaultMemberMap.cs
@@ -17,7 +17,7 @@ namespace AutoMapper
 
         public virtual TypeMap TypeMap => default;
         public virtual Type SourceType => default;
-        public virtual IEnumerable<MemberInfo> SourceMembers { get; set; }
+        public virtual IEnumerable<MemberInfo> SourceMembers { get; }
             = Enumerable.Empty<MemberInfo>();
         public virtual LambdaExpression CustomSource => null;
         public virtual string DestinationName => default;

--- a/src/AutoMapper/DefaultMemberMap.cs
+++ b/src/AutoMapper/DefaultMemberMap.cs
@@ -38,5 +38,25 @@ namespace AutoMapper
 
         public virtual IEnumerable<ValueTransformerConfiguration> ValueTransformers { get; } 
             = Enumerable.Empty<ValueTransformerConfiguration>();
+
+        public MemberInfo SourceMember
+        {
+            get
+            {
+                if (CustomMapExpression != null)
+                {
+                    var finder = new MemberFinderVisitor();
+                    finder.Visit(CustomMapExpression);
+
+                    if (finder.Member != null)
+                    {
+                        return finder.Member.Member;
+                    }
+                }
+
+                return SourceMembers.LastOrDefault();
+            }
+        }
+
     }
 }

--- a/src/AutoMapper/DefaultMemberMap.cs
+++ b/src/AutoMapper/DefaultMemberMap.cs
@@ -17,7 +17,7 @@ namespace AutoMapper
 
         public virtual TypeMap TypeMap => default;
         public virtual Type SourceType => default;
-        public virtual IEnumerable<MemberInfo> SourceMembers { get; } 
+        public virtual IEnumerable<MemberInfo> SourceMembers { get; set; }
             = Enumerable.Empty<MemberInfo>();
         public virtual LambdaExpression CustomSource => null;
         public virtual string DestinationName => default;

--- a/src/AutoMapper/DefaultMemberMap.cs
+++ b/src/AutoMapper/DefaultMemberMap.cs
@@ -18,22 +18,22 @@ namespace AutoMapper
         public virtual TypeMap TypeMap => default;
         public virtual Type SourceType => default;
         public virtual IEnumerable<MemberInfo> SourceMembers => Enumerable.Empty<MemberInfo>();
-        public virtual LambdaExpression CustomSource => null;
+        public virtual LambdaExpression CustomSource { get => default; set { } }
         public virtual string DestinationName => default;
         public virtual Type DestinationType => default;
         public virtual TypePair Types => new TypePair(SourceType, DestinationType);
         public virtual bool CanResolveValue { get => default; set { } }
-
+        public virtual bool IsMapped => Ignored || CanResolveValue;
         public virtual bool Ignored { get => default; set { } }
         public virtual bool Inline { get => true; set { } }
-        public virtual bool UseDestinationValue => default;
-        public virtual object NullSubstitute => default;
-        public virtual LambdaExpression PreCondition => default;
+        public virtual bool UseDestinationValue { get => default; set { } }
+        public virtual object NullSubstitute { get => default; set { } }
+        public virtual LambdaExpression PreCondition { get => default; set { } }
         public virtual LambdaExpression Condition { get => default; set { } }
         public virtual LambdaExpression CustomMapExpression { get => default; set { } }
         public virtual LambdaExpression CustomMapFunction { get => default; set { } }
-        public virtual ValueResolverConfiguration ValueResolverConfig => default;
-        public virtual ValueConverterConfiguration ValueConverterConfig => default;
+        public virtual ValueResolverConfiguration ValueResolverConfig { get => default; set { } }
+        public virtual ValueConverterConfiguration ValueConverterConfig { get => default; set { } }
 
         public virtual IEnumerable<ValueTransformerConfiguration> ValueTransformers => Enumerable.Empty<ValueTransformerConfiguration>();
 

--- a/src/AutoMapper/DefaultMemberMap.cs
+++ b/src/AutoMapper/DefaultMemberMap.cs
@@ -17,8 +17,7 @@ namespace AutoMapper
 
         public virtual TypeMap TypeMap => default;
         public virtual Type SourceType => default;
-        public virtual IEnumerable<MemberInfo> SourceMembers { get; }
-            = Enumerable.Empty<MemberInfo>();
+        public virtual IEnumerable<MemberInfo> SourceMembers => Enumerable.Empty<MemberInfo>();
         public virtual LambdaExpression CustomSource => null;
         public virtual string DestinationName => default;
         public virtual Type DestinationType => default;
@@ -26,7 +25,7 @@ namespace AutoMapper
         public virtual bool CanResolveValue { get => default; set { } }
 
         public virtual bool Ignored { get => default; set { } }
-        public virtual bool Inline { get; set; } = true;
+        public virtual bool Inline { get => true; set { } }
         public virtual bool UseDestinationValue => default;
         public virtual object NullSubstitute => default;
         public virtual LambdaExpression PreCondition => default;
@@ -36,8 +35,7 @@ namespace AutoMapper
         public virtual ValueResolverConfiguration ValueResolverConfig => default;
         public virtual ValueConverterConfiguration ValueConverterConfig => default;
 
-        public virtual IEnumerable<ValueTransformerConfiguration> ValueTransformers { get; } 
-            = Enumerable.Empty<ValueTransformerConfiguration>();
+        public virtual IEnumerable<ValueTransformerConfiguration> ValueTransformers => Enumerable.Empty<ValueTransformerConfiguration>();
 
         public MemberInfo SourceMember
         {
@@ -53,10 +51,8 @@ namespace AutoMapper
                         return finder.Member.Member;
                     }
                 }
-
                 return SourceMembers.LastOrDefault();
             }
         }
-
     }
 }

--- a/src/AutoMapper/IMemberMap.cs
+++ b/src/AutoMapper/IMemberMap.cs
@@ -26,5 +26,6 @@ namespace AutoMapper
         ValueResolverConfiguration ValueResolverConfig { get; }
         ValueConverterConfiguration ValueConverterConfig { get; }
         IEnumerable<ValueTransformerConfiguration> ValueTransformers { get; }
+        MemberInfo SourceMember { get; }
     }
 }

--- a/src/AutoMapper/IMemberMap.cs
+++ b/src/AutoMapper/IMemberMap.cs
@@ -27,5 +27,6 @@ namespace AutoMapper
         ValueConverterConfiguration ValueConverterConfig { get; }
         IEnumerable<ValueTransformerConfiguration> ValueTransformers { get; }
         MemberInfo SourceMember { get; }
+        bool IsMapped { get; }
     }
 }

--- a/src/AutoMapper/MemberFinderVisitor.cs
+++ b/src/AutoMapper/MemberFinderVisitor.cs
@@ -1,0 +1,15 @@
+using System.Linq.Expressions;
+
+namespace AutoMapper
+{
+    public class MemberFinderVisitor : ExpressionVisitor
+    {
+        public MemberExpression Member { get; private set; }
+
+        protected override Expression VisitMember(MemberExpression node)
+        {
+            Member = node;
+            return base.VisitMember(node);
+        }
+    }
+}

--- a/src/AutoMapper/PathMap.cs
+++ b/src/AutoMapper/PathMap.cs
@@ -18,7 +18,6 @@ namespace AutoMapper
             CustomMapExpression = pathMap.CustomMapExpression;
             Condition = pathMap.Condition;
             Ignored = pathMap.Ignored;
-            SourceMembers = CustomMapExpression.Body.GetMembers().Select(x => x.Member);
         }
 
         public PathMap(LambdaExpression destinationExpression, MemberPath memberPath, TypeMap typeMap)

--- a/src/AutoMapper/PathMap.cs
+++ b/src/AutoMapper/PathMap.cs
@@ -18,6 +18,7 @@ namespace AutoMapper
             CustomMapExpression = pathMap.CustomMapExpression;
             Condition = pathMap.Condition;
             Ignored = pathMap.Ignored;
+            SourceMembers = CustomMapExpression.Body.GetMembers().Select(x => x.Member);
         }
 
         public PathMap(LambdaExpression destinationExpression, MemberPath memberPath, TypeMap typeMap)

--- a/src/AutoMapper/PathMap.cs
+++ b/src/AutoMapper/PathMap.cs
@@ -30,7 +30,7 @@ namespace AutoMapper
         public override TypeMap TypeMap { get; }
 
         public override Type SourceType => CustomMapExpression.ReturnType;
-        public override LambdaExpression CustomSource { get; }
+        public override LambdaExpression CustomSource { get; set; }
         public LambdaExpression DestinationExpression { get; }
         public override LambdaExpression CustomMapExpression { get; set; }
         public MemberPath MemberPath { get; }

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -143,17 +143,6 @@ namespace AutoMapper
         public void AddValueTransformation(ValueTransformerConfiguration valueTransformerConfiguration) =>
             _valueTransformerConfigs.Add(valueTransformerConfiguration);
 
-        private class MemberFinderVisitor : ExpressionVisitor
-        {
-            public MemberExpression Member { get; private set; }
-
-            protected override Expression VisitMember(MemberExpression node)
-            {
-                Member = node;
-                return base.VisitMember(node);
-            }
-        }
-
         internal void CheckMappedReadonly()
         {
             if(IsResolveConfigured && !ReflectionHelper.CanBeSet(DestinationMember))

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -75,8 +75,6 @@ namespace AutoMapper
                                   ?? CustomMapExpression?.ReturnType
                                   ?? SourceMember?.GetMemberType();
 
-        public override TypePair Types => IsMapped ? new TypePair(SourceType, DestinationType) : default;
-
         public void ChainMembers(IEnumerable<MemberInfo> members) =>
             _memberChain.AddRange(members as IList<MemberInfo> ?? members.ToList());
 

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -12,7 +12,7 @@ namespace AutoMapper
     using static Expression;
 
     [DebuggerDisplay("{DestinationMember.Name}")]
-    public class PropertyMap : IMemberMap
+    public class PropertyMap : DefaultMemberMap
     {
         private readonly List<MemberInfo> _memberChain = new List<MemberInfo>();
         private readonly List<ValueTransformerConfiguration> _valueTransformerConfigs = new List<ValueTransformerConfiguration>();
@@ -46,55 +46,36 @@ namespace AutoMapper
                 lambda :
                 Lambda(lambda.ReplaceParameters(customSource.Body), customSource.Parameters.Concat(lambda.Parameters.Skip(1)));
 
-        public TypeMap TypeMap { get; }
+        public override TypeMap TypeMap { get; }
         public MemberInfo DestinationMember { get; }
-        public string DestinationName => DestinationMember.Name;
+        public override string DestinationName => DestinationMember.Name;
 
-        public Type DestinationType => DestinationMember.GetMemberType();
+        public override Type DestinationType => DestinationMember.GetMemberType();
 
-        public IEnumerable<MemberInfo> SourceMembers => _memberChain;
-        public LambdaExpression CustomSource { get; set; }
-        public bool Inline { get; set; } = true;
-        public bool Ignored { get; set; }
+        public override IEnumerable<MemberInfo> SourceMembers => _memberChain;
+        public override LambdaExpression CustomSource { get; set; }
+        public override bool Inline { get; set; } = true;
+        public override bool Ignored { get; set; }
         public bool AllowNull { get; set; }
         public int? MappingOrder { get; set; }
-        public LambdaExpression CustomMapFunction { get; set; }
-        public LambdaExpression Condition { get; set; }
-        public LambdaExpression PreCondition { get; set; }
-        public LambdaExpression CustomMapExpression { get; set; }
-        public bool UseDestinationValue { get; set; }
+        public override LambdaExpression CustomMapFunction { get; set; }
+        public override LambdaExpression Condition { get; set; }
+        public override LambdaExpression PreCondition { get; set; }
+        public override LambdaExpression CustomMapExpression { get; set; }
+        public override bool UseDestinationValue { get; set; }
         public bool ExplicitExpansion { get; set; }
-        public object NullSubstitute { get; set; }
-        public ValueResolverConfiguration ValueResolverConfig { get; set; }
-        public ValueConverterConfiguration ValueConverterConfig { get; set; }
-        public IEnumerable<ValueTransformerConfiguration> ValueTransformers => _valueTransformerConfigs;
+        public override object NullSubstitute { get; set; }
+        public override ValueResolverConfiguration ValueResolverConfig { get; set; }
+        public override ValueConverterConfiguration ValueConverterConfig { get; set; }
+        public override IEnumerable<ValueTransformerConfiguration> ValueTransformers => _valueTransformerConfigs;
 
-        public MemberInfo SourceMember
-        {
-            get
-            {
-                if (CustomMapExpression != null)
-                {
-                    var finder = new MemberFinderVisitor();
-                    finder.Visit(CustomMapExpression);
-
-                    if (finder.Member != null)
-                    {
-                        return finder.Member.Member;
-                    }
-                }
-
-                return _memberChain.LastOrDefault();
-            }
-        }
-
-        public Type SourceType => ValueConverterConfig?.SourceMember?.ReturnType
+        public override Type SourceType => ValueConverterConfig?.SourceMember?.ReturnType
                                   ?? ValueResolverConfig?.SourceMember?.ReturnType
                                   ?? CustomMapFunction?.ReturnType
                                   ?? CustomMapExpression?.ReturnType
                                   ?? SourceMember?.GetMemberType();
 
-        public TypePair Types => IsMapped ? new TypePair(SourceType, DestinationType) : default;
+        public override TypePair Types => IsMapped ? new TypePair(SourceType, DestinationType) : default;
 
         public void ChainMembers(IEnumerable<MemberInfo> members) =>
             _memberChain.AddRange(members as IList<MemberInfo> ?? members.ToList());
@@ -116,9 +97,7 @@ namespace AutoMapper
             _valueTransformerConfigs.InsertRange(0, inheritedMappedProperty._valueTransformerConfigs);
         }
 
-        public bool IsMapped => HasSource || Ignored;
-
-        public bool CanResolveValue => HasSource && !Ignored;
+        public override bool CanResolveValue => HasSource && !Ignored;
 
         public bool HasSource => _memberChain.Count > 0 || IsResolveConfigured;
 

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -173,7 +173,7 @@ namespace AutoMapper
             else
             {
                var redirectedSourceMembers = MemberMaps
-                    .Where(pm => !pm.Ignored && pm.SourceMember != null && pm.SourceMember.Name != pm.DestinationName)
+                    .Where(pm => pm.IsMapped && pm.SourceMember != null && pm.SourceMember.Name != pm.DestinationName)
                     .Select(pm => pm.SourceMember.Name);
 
                var ignoredSourceMembers = SourceMemberConfigs

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -180,11 +180,18 @@ namespace AutoMapper
                     .Where(smc => smc.IsIgnored())
                     .Select(pm => pm.SourceMember.Name).ToList();
 
+                var redirectedPathMembers = PathMaps
+                    .Select(pm => pm.CustomMapExpression)
+                    .Select(me => me.Body)
+                    .SelectMany(body => body.GetMembers())
+                    .Select(m => m.Member.Name);
+
                 properties = SourceTypeDetails.PublicReadAccessors
                     .Select(p => p.Name)
                     .Except(autoMappedProperties)
                     .Except(redirectedSourceMembers)
-                    .Except(ignoredSourceMembers);
+                    .Except(ignoredSourceMembers)
+                    .Except(redirectedPathMembers);
             }
 
             return properties.Where(memberName => !Profile.GlobalIgnores.Any(memberName.StartsWith)).ToArray();

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -172,26 +172,19 @@ namespace AutoMapper
             }
             else
             {
-                var redirectedSourceMembers = PropertyMaps
-                    .Where(pm => pm.IsMapped && pm.SourceMember != null && pm.SourceMember.Name != pm.DestinationName)
+               var redirectedSourceMembers = MemberMaps
+                    .Where(pm => !pm.Ignored && pm.SourceMember != null && pm.SourceMember.Name != pm.DestinationName)
                     .Select(pm => pm.SourceMember.Name);
 
-                var ignoredSourceMembers = SourceMemberConfigs
-                    .Where(smc => smc.IsIgnored())
-                    .Select(pm => pm.SourceMember.Name).ToList();
-
-                var redirectedPathMembers = PathMaps
-                    .Select(pm => pm.CustomMapExpression)
-                    .Select(me => me.Body)
-                    .SelectMany(body => body.GetMembers())
-                    .Select(m => m.Member.Name);
+               var ignoredSourceMembers = SourceMemberConfigs
+                   .Where(smc => smc.IsIgnored())
+                   .Select(pm => pm.SourceMember.Name);
 
                 properties = SourceTypeDetails.PublicReadAccessors
                     .Select(p => p.Name)
                     .Except(autoMappedProperties)
                     .Except(redirectedSourceMembers)
-                    .Except(ignoredSourceMembers)
-                    .Except(redirectedPathMembers);
+                    .Except(ignoredSourceMembers);
             }
 
             return properties.Where(memberName => !Profile.GlobalIgnores.Any(memberName.StartsWith)).ToArray();
@@ -340,7 +333,7 @@ namespace AutoMapper
             notOverridenPathMaps.ForEach(p=>AddPathMap(new PathMap(p, this, expression) { CustomMapExpression = CheckCustomSource(p.CustomMapExpression) }));
             return;
             LambdaExpression CheckCustomSource(LambdaExpression lambda) => PropertyMap.CheckCustomSource(lambda, expression);
-        }       
+        }
 
         private void ApplyInheritedTypeMap(TypeMap inheritedTypeMap)
         {

--- a/src/UnitTests/Bug/MemberListSourceAndForPath.cs
+++ b/src/UnitTests/Bug/MemberListSourceAndForPath.cs
@@ -1,0 +1,49 @@
+﻿using Shouldly;
+using Xunit;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public class MemberListSourceAndForPath : AutoMapperSpecBase
+    {
+        bool _equal;
+
+        public class TargetOuter
+        {
+            public TargetInner Inner { get; set; }
+
+            // The properties below should be ignored, they are not relevant
+            public int Unrelated { get; set; }
+            public string AlsoUnrelated { get; set; }
+        }
+
+        public class TargetInner
+        {
+            public string MyProp { get; set; }
+        }
+
+        public class Input
+        {
+            public string Source { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Input, TargetOuter>(MemberList.Source)
+                .ForPath(x => x.Inner.MyProp, opt => opt.MapFrom(x => x.Source));
+        });
+
+        protected override void Because_of()
+        {
+            var input = new Input() {Source = "Hello World!"};
+            var output = Mapper.Map<TargetOuter>(input);
+
+            _equal = output.Inner.MyProp == input.Source;
+        }
+
+        [Fact]
+        public void Should_ignore_destination_members()
+        {
+            _equal.ShouldBeTrue();
+        }
+    }
+}


### PR DESCRIPTION
Instead of only checking expression that have been created using `ForMember`, this also respects the `ForPath` configuration as well
Fixes #3000.