### PR TITLE
fixed enum values caseinsensitivity bug

### DIFF
--- a/src/AutoMapper/Mappers/EnumToEnumMapper.cs
+++ b/src/AutoMapper/Mappers/EnumToEnumMapper.cs
@@ -19,7 +19,7 @@ namespace AutoMapper.Mappers
                 return (TDestination)Enum.ToObject(destEnumType, source);
             }
 
-            if (!Enum.GetNames(destEnumType).Contains(source.ToString()))
+            if (!Enum.GetNames(destEnumType).Contains(source.ToString(), StringComparer.OrdinalIgnoreCase))
             {
                 var underlyingSourceType = Enum.GetUnderlyingType(sourceEnumType);
                 var underlyingSourceValue = System.Convert.ChangeType(source, underlyingSourceType);

--- a/src/UnitTests/Bug/EnumCaseSensitivityBug.cs
+++ b/src/UnitTests/Bug/EnumCaseSensitivityBug.cs
@@ -1,0 +1,42 @@
+﻿using Shouldly;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    using Xunit;
+
+    public class EnumCaseSensitivityBug : AutoMapperSpecBase
+    {
+        private SecondEnum _resultSecondEnum;
+        private FirstEnum _resultFirstEnum;
+
+        public enum FirstEnum
+        {
+            Dog,
+            Cat
+        }
+
+        public enum SecondEnum
+        {
+            cat,
+            dog
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            // not creating a map on purpose to trigger use of EnumToEnumMapper
+        });
+
+        protected override void Because_of()
+        {
+            _resultSecondEnum = Mapper.Map<SecondEnum>(FirstEnum.Cat);
+            _resultFirstEnum = Mapper.Map<FirstEnum>(SecondEnum.dog);
+        }
+
+        [Fact]
+        public void Should_match_on_the_name_even_if_values_match()
+        {
+            _resultSecondEnum.ShouldBe(SecondEnum.cat);
+            _resultFirstEnum.ShouldBe(FirstEnum.Dog);
+        }
+    }
+}


### PR DESCRIPTION
Fixed enum value case insensitivity bug

Enum.GetName(sourceEnumType, source), true) the true here means parse case insensitive but the condition above was not case insensitive.