### PR TITLE
Potential fix for Custom Readonly Generic Typed Collections

### DIFF
--- a/src/AutoMapper/Configuration/Internal/PrimitiveHelper.cs
+++ b/src/AutoMapper/Configuration/Internal/PrimitiveHelper.cs
@@ -41,7 +41,7 @@ namespace AutoMapper.Configuration.Internal
             => typeof(IQueryable).IsAssignableFrom(type);
 
         public static bool IsListType(Type type)
-            => typeof(IList).IsAssignableFrom(type);
+            => typeof(IList).IsAssignableFrom(type) || type.ImplementsGenericInterface(typeof(IList<>));
 
         public static bool IsListOrDictionaryType(Type type)
             => type.IsListType() || type.IsDictionaryType();

--- a/src/UnitTests/CollectionMapping.cs
+++ b/src/UnitTests/CollectionMapping.cs
@@ -293,6 +293,94 @@ namespace AutoMapper.UnitTests
         } 
     }
 
+    public class When_mapping_to_custom_readonly_typed_generic_list_type : AutoMapperSpecBase
+    {
+        public class MyCustomTypeCollection<T> : IList<T>
+        {
+            private List<T> _collection = new List<T>();
+
+            public T this[int index] { get => ((IList<T>)_collection)[index]; set => ((IList<T>)_collection)[index] = value; }
+
+            public int Count => ((IList<T>)_collection).Count;
+
+            public bool IsReadOnly => ((IList<T>)_collection).IsReadOnly;
+
+            public void Add(T item)
+            {
+                ((IList<T>)_collection).Add(item);
+            }
+
+            public void Clear()
+            {
+                ((IList<T>)_collection).Clear();
+            }
+
+            public bool Contains(T item)
+            {
+                return ((IList<T>)_collection).Contains(item);
+            }
+
+            public void CopyTo(T[] array, int arrayIndex)
+            {
+                ((IList<T>)_collection).CopyTo(array, arrayIndex);
+            }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                return ((IList<T>)_collection).GetEnumerator();
+            }
+
+            public int IndexOf(T item)
+            {
+                return ((IList<T>)_collection).IndexOf(item);
+            }
+
+            public void Insert(int index, T item)
+            {
+                ((IList<T>)_collection).Insert(index, item);
+            }
+
+            public bool Remove(T item)
+            {
+                return ((IList<T>)_collection).Remove(item);
+            }
+
+            public void RemoveAt(int index)
+            {
+                ((IList<T>)_collection).RemoveAt(index);
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return ((IList<T>)_collection).GetEnumerator();
+            }
+        }
+
+        public class SourceItem
+        {
+            public string Name { get; set; }
+            public List<string> ShipsTo { get; set; }
+        }
+
+        public class DestItem
+        {
+            public string Name { get; set; }
+            public MyCustomTypeCollection<string> ShipsTo { get; } = new MyCustomTypeCollection<string>();
+        }
+
+        protected override MapperConfiguration Configuration =>
+            new MapperConfiguration(cfg => cfg.CreateMap<SourceItem, DestItem>()
+            .ForMember(d => d.ShipsTo, m => m.UseDestinationValue()));
+
+        [Fact]
+        public void Should_map_ok()
+        {
+            var items = Enumerable.Range(1, 5).Select(i => i.ToString()).ToArray();
+            Mapper.Map<DestItem>(new SourceItem { ShipsTo = new List<string>(items) })
+                .ShipsTo.Cast<string>().SequenceEqual(items).ShouldBeTrue();
+        }
+    }
+
     public class When_mapping_collections_with_inheritance : AutoMapperSpecBase
     {
         public class Source

--- a/src/UnitTests/Internal/PrimitiveExtensionsTester.cs
+++ b/src/UnitTests/Internal/PrimitiveExtensionsTester.cs
@@ -24,6 +24,67 @@ namespace AutoMapper.UnitTests
             public int PublicProperty { get; set; }
         }
 
+        class CustomCollection<T> : IList<T>
+        {
+            private List<T> _collection = new List<T>();
+
+            public T this[int index] { get => ((IList<T>)_collection)[index]; set => ((IList<T>)_collection)[index] = value; }
+
+            public int Count => ((IList<T>)_collection).Count;
+
+            public bool IsReadOnly => ((IList<T>)_collection).IsReadOnly;
+
+            public void Add(T item)
+            {
+                ((IList<T>)_collection).Add(item);
+            }
+
+            public void Clear()
+            {
+                ((IList<T>)_collection).Clear();
+            }
+
+            public bool Contains(T item)
+            {
+                return ((IList<T>)_collection).Contains(item);
+            }
+
+            public void CopyTo(T[] array, int arrayIndex)
+            {
+                ((IList<T>)_collection).CopyTo(array, arrayIndex);
+            }
+
+            public IEnumerator<T> GetEnumerator()
+            {
+                return ((IList<T>)_collection).GetEnumerator();
+            }
+
+            public int IndexOf(T item)
+            {
+                return ((IList<T>)_collection).IndexOf(item);
+            }
+
+            public void Insert(int index, T item)
+            {
+                ((IList<T>)_collection).Insert(index, item);
+            }
+
+            public bool Remove(T item)
+            {
+                return ((IList<T>)_collection).Remove(item);
+            }
+
+            public void RemoveAt(int index)
+            {
+                ((IList<T>)_collection).RemoveAt(index);
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return ((IList<T>)_collection).GetEnumerator();
+            }
+        }
+
         [Fact]
         public void Should_find_explicitly_implemented_member()
         {
@@ -52,6 +113,12 @@ namespace AutoMapper.UnitTests
         public void Should_flag_dictionary_as_writeable_collection()
         {
             PrimitiveHelper.IsListOrDictionaryType(typeof(Dictionary<string, int>)).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Should_flag_custom_generic_list_type_as_writeable_collection()
+        {
+            PrimitiveHelper.IsListOrDictionaryType(typeof(CustomCollection<int>)).ShouldBeTrue();
         }
     }
 }


### PR DESCRIPTION
Summary of the changes:
- Expanded PrimitiveHelper.IsListType to include the generic list interface
- Added extra unit test to check IsListType on a custom collection type that just implements `IList<T>`(but not `IList`)
- Added unit test to confirm fix for #3036

#3036