### PR TITLE
Fix small bug in constructor

### DIFF
--- a/src/UnitTests/ConfigurationValidation.cs
+++ b/src/UnitTests/ConfigurationValidation.cs
@@ -162,7 +162,7 @@ namespace AutoMapper.UnitTests.ConfigurationValidation
         {
             public Dest(int value, int blarg)
             {
-                Value = blarg;
+                Value = value;
             }
 
             public int Value { get; }


### PR DESCRIPTION
In the constructor of the class confused variables.
In the version with an error, the `When_scanning_by_name` class `Should_load_profiles` test fails.