### PR TITLE
Type.EmptyTypes instead of new Type[0]

### DIFF
--- a/src/AutoMapper/Execution/PropertyEmitter.cs
+++ b/src/AutoMapper/Execution/PropertyEmitter.cs
@@ -23,7 +23,7 @@ namespace AutoMapper.Execution
             _propertyBuilder = owner.DefineProperty(name, PropertyAttributes.None, propertyType, null);
             _getterBuilder = owner.DefineMethod($"get_{name}",
                 MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig |
-                MethodAttributes.SpecialName, propertyType, new Type[0]);
+                MethodAttributes.SpecialName, propertyType, Type.EmptyTypes);
             ILGenerator getterIl = _getterBuilder.GetILGenerator();
             getterIl.Emit(OpCodes.Ldarg_0);
             getterIl.Emit(OpCodes.Ldfld, _fieldBuilder);

--- a/src/AutoMapper/Execution/ProxyGenerator.cs
+++ b/src/AutoMapper/Execution/ProxyGenerator.cs
@@ -25,7 +25,7 @@ namespace AutoMapper.Execution
             typeof(INotifyPropertyChanged).GetRuntimeEvent("PropertyChanged");
 
         private static readonly ConstructorInfo proxyBase_ctor =
-            typeof(ProxyBase).GetDeclaredConstructor(new Type[0]);
+            typeof(ProxyBase).GetDeclaredConstructor(Type.EmptyTypes);
 
         private static readonly ModuleBuilder proxyModule = CreateProxyModule();
 
@@ -55,9 +55,9 @@ namespace AutoMapper.Execution
             Debug.WriteLine(typeName, "Emitting proxy type");
             TypeBuilder typeBuilder = proxyModule.DefineType(typeName,
                 TypeAttributes.Class | TypeAttributes.Sealed | TypeAttributes.Public, typeof(ProxyBase),
-                interfaceType.IsInterface() ? new[] { interfaceType } : new Type[0]);
+                interfaceType.IsInterface() ? new[] { interfaceType } : Type.EmptyTypes);
             ConstructorBuilder constructorBuilder = typeBuilder.DefineConstructor(MethodAttributes.Public,
-                CallingConventions.Standard, new Type[0]);
+                CallingConventions.Standard, Type.EmptyTypes);
             ILGenerator ctorIl = constructorBuilder.GetILGenerator();
             ctorIl.Emit(OpCodes.Ldarg_0);
             ctorIl.Emit(OpCodes.Call, proxyBase_ctor);

--- a/src/AutoMapper/Mappers/FlagsEnumMapper.cs
+++ b/src/AutoMapper/Mappers/FlagsEnumMapper.cs
@@ -31,7 +31,7 @@ namespace AutoMapper.Mappers
                 ToType(
                     Call(EnumParseMethod,
                         Constant(destExpression.Type),
-                        Call(sourceExpression, sourceExpression.Type.GetDeclaredMethod("ToString", new Type[0])),
+                        Call(sourceExpression, sourceExpression.Type.GetDeclaredMethod("ToString", Type.EmptyTypes)),
                         Constant(true)
                     ),
                     destExpression.Type

--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -210,9 +210,9 @@ namespace AutoMapper
             if(closedMap.TypeConverterType != null)
             {
                 var typeParams =
-                    (openMapConfig.SourceType.IsGenericTypeDefinition() ? closedTypes.SourceType.GetGenericArguments() : new Type[0])
+                    (openMapConfig.SourceType.IsGenericTypeDefinition() ? closedTypes.SourceType.GetGenericArguments() : Type.EmptyTypes)
                         .Concat
-                    (openMapConfig.DestinationType.IsGenericTypeDefinition() ? closedTypes.DestinationType.GetGenericArguments() : new Type[0]);
+                    (openMapConfig.DestinationType.IsGenericTypeDefinition() ? closedTypes.DestinationType.GetGenericArguments() : Type.EmptyTypes);
 
                 var neededParameters = closedMap.TypeConverterType.GetGenericParameters().Length;
                 closedMap.TypeConverterType = closedMap.TypeConverterType.MakeGenericType(typeParams.Take(neededParameters).ToArray());


### PR DESCRIPTION
To avoid unnecessary allocations.