### PR TITLE
Update Queryable-Extensions.md for latest version

### DIFF
--- a/docs/Queryable-Extensions.md
+++ b/docs/Queryable-Extensions.md
@@ -50,7 +50,7 @@ public List<OrderLineDTO> GetLinesForOrder(int orderId)
   using (var context = new orderEntities())
   {
     return context.OrderLines.Where(ol => ol.OrderId == orderId)
-             .ProjectTo<OrderLineDTO>().ToList();
+             .ProjectTo<OrderLineDTO>(configuration).ToList();
   }
 }
 ```


### PR DESCRIPTION
I just got this issue in my code following this doc.

**No overload for method 'ProjectTo' takes 0 arguments.**

Reading the 9.0 upgrade guide it looks like you now have to put the configuration in 'ProjectTo'.
Bonus question, am I right to assume that inside a CQRS handler in ASP.NET, I can just call the current mapper configuration provider just like this?

```csharp
_context.OrderLines.ProjectTo<OrderLineDTO>(_mapper.ConfigurationProvider).ToListAsync(cancellationToken);
```

Thank you!