### PR TITLE
Fix inheritance of ReplaceMemberName global configuration in Profiles

### DIFF
--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -37,7 +37,7 @@ namespace AutoMapper
 
             ValueTransformers = profile.ValueTransformers.Concat(configuration?.ValueTransformers ?? Enumerable.Empty<ValueTransformerConfiguration>()).ToArray();
 
-            MemberConfigurations = profile.MemberConfigurations.ToArray();
+            MemberConfigurations = profile.MemberConfigurations.Concat(configuration?.MemberConfigurations ?? Enumerable.Empty<IMemberConfiguration>()).ToArray();
 
             MemberConfigurations.FirstOrDefault()?.AddMember<NameSplitMember>(_ => _.SourceMemberNamingConvention = profile.SourceMemberNamingConvention);
             MemberConfigurations.FirstOrDefault()?.AddMember<NameSplitMember>(_ => _.DestinationMemberNamingConvention = profile.DestinationMemberNamingConvention);

--- a/src/UnitTests/Tests/TypeMapFactorySpecs.cs
+++ b/src/UnitTests/Tests/TypeMapFactorySpecs.cs
@@ -199,4 +199,47 @@ namespace AutoMapper.UnitTests.Tests
             dest.Value.ShouldBe(5);
         }
     }
+
+    public class When_using_a_source_member_name_replacer_with_profile : SpecBase
+    {
+        public class Source
+        {
+            public int Value { get; set; }
+            public int Ävíator { get; set; }
+            public int SubAirlinaFlight { get; set; }
+        }
+
+        public class Destination
+        {
+            public int Value { get; set; }
+            public int Aviator { get; set; }
+            public int SubAirlineFlight { get; set; }
+        }
+
+        public class TestProfile : Profile
+        {
+            public TestProfile()
+            {
+                CreateMap<Source, Destination>();
+            }
+        }
+
+        [Fact]
+        public void Should_map_properties_with_different_names()
+        {
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.ReplaceMemberName("A", "Ä");
+                cfg.ReplaceMemberName("i", "í");
+                cfg.ReplaceMemberName("Airline", "Airlina");
+                cfg.AddProfile<TestProfile>();
+            });
+
+            var mapper = config.CreateMapper();
+            var dest = mapper.Map<Destination>(new Source { Ävíator = 3, SubAirlinaFlight = 4, Value = 5 });
+            dest.Aviator.ShouldBe(3);
+            dest.SubAirlineFlight.ShouldBe(4);
+            dest.Value.ShouldBe(5);
+        }
+    }
 }


### PR DESCRIPTION
Updated the ProfileMap.cs to add the MemberConfigurations from the global configuration to the profiles specified MemberConfigurations.
Fixes #3227.