### PR TITLE
Fix outdated API/documentation (fixes #3260)

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -66,7 +66,7 @@ or by automatically scanning for profiles:
 var config = new MapperConfiguration(cfg => {
     cfg.AddMaps(myAssembly);
 });
-var configuration = new MapperConfiguration(cfg => cfg.AddProfiles(myAssembly));
+var configuration = new MapperConfiguration(cfg => cfg.AddMaps(myAssembly));
 
 // Can also use assembly names:
 var configuration = new MapperConfiguration(cfg =>

--- a/docs/Dependency-injection.md
+++ b/docs/Dependency-injection.md
@@ -126,7 +126,7 @@ public class AutoMapperModule : NinjectModule
         var config = new MapperConfiguration(cfg =>
         {
             // Add all profiles in current assembly
-            cfg.AddProfiles(GetType().Assembly);
+            cfg.AddMaps(GetType().Assembly);
         });
 
         return config;
@@ -178,7 +178,7 @@ public class MapperProvider
         var mce = new MapperConfigurationExpression();
         mce.ConstructServicesUsing(_container.GetInstance);
 
-        mce.AddProfiles(typeof(SomeProfile).Assembly);
+        mce.AddMaps(typeof(SomeProfile).Assembly);
 
         var mc = new MapperConfiguration(mce);
         mc.AssertConfigurationIsValid();


### PR DESCRIPTION
This small commit fixes the outdated API/documentation referencing AddProfiles(Assembly myAssembly) that doesn't exist.