### PR TITLE
Add automatic mapping of writable collection members that have no write accessor

### DIFF
--- a/src/AutoMapper/Configuration/IProfileConfiguration.cs
+++ b/src/AutoMapper/Configuration/IProfileConfiguration.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using AutoMapper.Configuration.Conventions;
-using AutoMapper.Mappers;
 
 namespace AutoMapper.Configuration
 {
@@ -16,6 +15,7 @@ namespace AutoMapper.Configuration
         bool? AllowNullDestinationValues { get; }
         bool? AllowNullCollections { get; }
         bool? EnableNullPropagationForQueryMapping { get; }
+        bool? EnableMappingOfCollectionMembersWithoutWriteAccessor { get; }
         IEnumerable<Action<TypeMap, IMappingExpression>> AllTypeMapActions { get; }
         IEnumerable<Action<PropertyMap, IMemberConfigurationExpression>> AllPropertyMapActions { get; }
 

--- a/src/AutoMapper/Configuration/Internal/PrimitiveHelper.cs
+++ b/src/AutoMapper/Configuration/Internal/PrimitiveHelper.cs
@@ -31,8 +31,11 @@ namespace AutoMapper.Configuration.Internal
         public static Type GetTypeOfNullable(Type type) 
             => type.GetTypeInfo().GenericTypeArguments[0];
 
-        public static bool IsCollectionType(Type type) 
+        public static bool IsGenericCollectionType(Type type) 
             => type.ImplementsGenericInterface(typeof(ICollection<>));
+
+        public static bool IsCollectionType(Type type)
+            => typeof(ICollection).IsAssignableFrom(type) || IsGenericCollectionType(type);
 
         public static bool IsEnumerableType(Type type) 
             => typeof(IEnumerable).IsAssignableFrom(type);

--- a/src/AutoMapper/Configuration/PrimitiveExtensions.cs
+++ b/src/AutoMapper/Configuration/PrimitiveExtensions.cs
@@ -33,6 +33,9 @@ namespace AutoMapper.Configuration
         public static Type GetTypeOfNullable(this Type type)
             => PrimitiveHelper.GetTypeOfNullable(type);
 
+        public static bool IsGenericCollectionType(this Type type)
+            => PrimitiveHelper.IsGenericCollectionType(type);
+
         public static bool IsCollectionType(this Type type)
             => PrimitiveHelper.IsCollectionType(type);
 

--- a/src/AutoMapper/Execution/ExpressionBuilder.cs
+++ b/src/AutoMapper/Execution/ExpressionBuilder.cs
@@ -60,7 +60,7 @@ namespace AutoMapper.Execution
             var destination = memberMap == null
                 ? destinationParameter.IfNullElse(defaultDestination, destinationParameter)
                 : memberMap.UseDestinationValue.GetValueOrDefault() ? destinationParameter : defaultDestination;
-            var ifSourceNull = destinationParameter.Type.IsCollectionType() ? ClearDestinationCollection() : destination;
+            var ifSourceNull = destinationParameter.Type.IsGenericCollectionType() ? ClearDestinationCollection() : destination;
             return sourceParameter.IfNullElse(ifSourceNull, objectMapperExpression);
             Expression ClearDestinationCollection()
             {

--- a/src/AutoMapper/IMapperConfigurationExpression.cs
+++ b/src/AutoMapper/IMapperConfigurationExpression.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
-using AutoMapper.Configuration;
 using AutoMapper.Features;
 
 namespace AutoMapper

--- a/src/AutoMapper/IProfileExpression.cs
+++ b/src/AutoMapper/IProfileExpression.cs
@@ -119,6 +119,11 @@ namespace AutoMapper
         bool? EnableNullPropagationForQueryMapping { get; set; }
 
         /// <summary>
+        /// Enable mapping of collection members that have no write accessor (i.e no setter for properties).
+        /// </summary>
+        bool? EnableMappingOfCollectionMembersWithoutWriteAccessor { get; set; }
+
+        /// <summary>
         /// Naming convention for source members
         /// </summary>
         INamingConvention SourceMemberNamingConvention { get; set; }
@@ -145,7 +150,7 @@ namespace AutoMapper
         Func<FieldInfo, bool> ShouldMapField { get; set; }
         Func<MethodInfo, bool> ShouldMapMethod { get; set; }
         Func<ConstructorInfo, bool> ShouldUseConstructor { get; set; }
-        
+
         string ProfileName { get; }
         IMemberConfiguration AddMemberConfiguration();
 

--- a/src/AutoMapper/Mappers/CollectionMapper.cs
+++ b/src/AutoMapper/Mappers/CollectionMapper.cs
@@ -9,7 +9,7 @@ namespace AutoMapper.Mappers
 
     public class CollectionMapper : EnumerableMapperBase
     {
-        public override bool IsMatch(TypePair context) => context.SourceType.IsEnumerableType() && context.DestinationType.IsCollectionType();
+        public override bool IsMatch(TypePair context) => context.SourceType.IsEnumerableType() && context.DestinationType.IsGenericCollectionType();
 
         public override Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap,
             IMemberMap memberMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)

--- a/src/AutoMapper/Profile.cs
+++ b/src/AutoMapper/Profile.cs
@@ -66,6 +66,7 @@ namespace AutoMapper
         public bool? AllowNullDestinationValues { get; set; }
         public bool? AllowNullCollections { get; set; }
         public bool? EnableNullPropagationForQueryMapping { get; set; }
+        public bool? EnableMappingOfCollectionMembersWithoutWriteAccessor { get; set; }
         public Func<PropertyInfo, bool> ShouldMapProperty { get; set; }
         public Func<FieldInfo, bool> ShouldMapField { get; set; }
         public Func<MethodInfo, bool> ShouldMapMethod { get; set; }
@@ -95,13 +96,13 @@ namespace AutoMapper
             });
         }
 
-        public IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>() => 
+        public IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>() =>
             CreateMap<TSource, TDestination>(MemberList.Destination);
 
-        public IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>(MemberList memberList) => 
+        public IMappingExpression<TSource, TDestination> CreateMap<TSource, TDestination>(MemberList memberList) =>
             CreateMappingExpression<TSource, TDestination>(memberList);
 
-        public IMappingExpression CreateMap(Type sourceType, Type destinationType) => 
+        public IMappingExpression CreateMap(Type sourceType, Type destinationType) =>
             CreateMap(sourceType, destinationType, MemberList.Destination);
 
         public IMappingExpression CreateMap(Type sourceType, Type destinationType, MemberList memberList)

--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -29,6 +29,7 @@ namespace AutoMapper
             AllowNullCollections = profile.AllowNullCollections ?? configuration?.AllowNullCollections ?? false;
             AllowNullDestinationValues = profile.AllowNullDestinationValues ?? configuration?.AllowNullDestinationValues ?? true;
             EnableNullPropagationForQueryMapping = profile.EnableNullPropagationForQueryMapping ?? configuration?.EnableNullPropagationForQueryMapping ?? false;
+            EnableMappingOfCollectionMembersWithoutWriteAccessor = profile.EnableMappingOfCollectionMembersWithoutWriteAccessor ?? configuration?.EnableMappingOfCollectionMembersWithoutWriteAccessor ?? false;
             ConstructorMappingEnabled = profile.ConstructorMappingEnabled ?? configuration?.ConstructorMappingEnabled ?? true;
             ShouldMapField = profile.ShouldMapField ?? configuration?.ShouldMapField ?? (p => p.IsPublic());
             ShouldMapProperty = profile.ShouldMapProperty ?? configuration?.ShouldMapProperty ?? (p => p.IsPublic());
@@ -72,6 +73,7 @@ namespace AutoMapper
         public bool AllowNullDestinationValues { get; }
         public bool ConstructorMappingEnabled { get; }
         public bool EnableNullPropagationForQueryMapping { get; }
+        public bool EnableMappingOfCollectionMembersWithoutWriteAccessor { get; }
         public string Name { get; }
         public Func<FieldInfo, bool> ShouldMapField { get; }
         public Func<PropertyInfo, bool> ShouldMapProperty { get; }

--- a/src/AutoMapper/QueryableExtensions/Impl/MappedTypeExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/MappedTypeExpressionBinder.cs
@@ -1,6 +1,6 @@
-using AutoMapper.Configuration;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using AutoMapper.Configuration;
 
 namespace AutoMapper.QueryableExtensions.Impl
 {
@@ -23,7 +23,7 @@ namespace AutoMapper.QueryableExtensions.Impl
             }
             // Handles null source property so it will not create an object with possible non-nullable properties 
             // which would result in an exception.
-            if (propertyMap.TypeMap.Profile.AllowNullDestinationValues && !propertyMap.AllowNull && !(result.ResolutionExpression is ParameterExpression) && !result.ResolutionExpression.Type.IsCollectionType())
+            if (propertyMap.TypeMap.Profile.AllowNullDestinationValues && !propertyMap.AllowNull && !(result.ResolutionExpression is ParameterExpression) && !result.ResolutionExpression.Type.IsGenericCollectionType())
             {
                 transformedExpression = result.ResolutionExpression.IfNullElse(Constant(null, transformedExpression.Type), transformedExpression);
             }

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -11,7 +11,6 @@ namespace AutoMapper
 {
     using AutoMapper.Features;
     using Internal;
-    using static Expression;
 
     /// <summary>
     /// Main configuration object holding all mapping configuration for a source and destination type
@@ -153,6 +152,15 @@ namespace AutoMapper
             var propertyMap = new PropertyMap(destProperty, this);
 
             propertyMap.ChainMembers(resolvers);
+
+            if (propertyMap.CanResolveValue
+                && Profile.EnableMappingOfCollectionMembersWithoutWriteAccessor
+                && destProperty is PropertyInfo propertyInfo
+                && propertyInfo.PropertyType.IsGenericCollectionType()
+                && !ReflectionHelper.CanBeSet(propertyMap.DestinationMember))
+            {
+                propertyMap.UseDestinationValue = true;
+            }
 
             AddPropertyMap(propertyMap);
         }

--- a/src/UnitTests/Mappers/ReadOnlyCollectionMapperTests.cs
+++ b/src/UnitTests/Mappers/ReadOnlyCollectionMapperTests.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
 using Shouldly;
 using Xunit;
 
@@ -98,6 +96,81 @@ namespace AutoMapper.UnitTests.Mappers
 
             protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(config =>
             {
+                config.CreateMap<Source, Destination>();
+            });
+
+            [Fact]
+            public void Should_map_readonly_values()
+            {
+                var source = new Source
+                {
+                    Values = new List<int>
+                    {
+                        1,
+                        2,
+                        3,
+                        4,
+                    }
+                };
+
+                var dest = Mapper.Map<Destination>(source);
+
+                dest.Values.Count.ShouldBe(4);
+            }
+        }
+
+        public class When_mapping_to_collection_property_without_setter_and_feature_not_enabled : AutoMapperSpecBase
+        {
+            public class Source
+            {
+                public IReadOnlyCollection<int> Values { get; set; }
+            }
+
+            public class Destination
+            {
+                public IList<int> Values { get; } = new List<int>();
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(config =>
+            {
+                config.CreateMap<Source, Destination>();
+            });
+
+            [Fact]
+            public void Should_map_readonly_values()
+            {
+                var source = new Source
+                {
+                    Values = new List<int>
+                    {
+                        1,
+                        2,
+                        3,
+                        4,
+                    }
+                };
+
+                var dest = Mapper.Map<Destination>(source);
+
+                dest.Values.Count.ShouldBe(0);
+            }
+        }
+
+        public class When_mapping_to_collection_property_without_setter_and_feature_enabled : AutoMapperSpecBase
+        {
+            public class Source
+            {
+                public IReadOnlyCollection<int> Values { get; set; }
+            }
+
+            public class Destination
+            {
+                public IList<int> Values { get; } = new List<int>();
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(config =>
+            {
+                config.EnableMappingOfCollectionMembersWithoutWriteAccessor = true;
                 config.CreateMap<Source, Destination>();
             });
 


### PR DESCRIPTION
This is a follow-up to issue #2782 that I had raised more than a year ago.
It also addresses the parts of #3036 which weren't covered by PR #2928.
See https://github.com/AutoMapper/AutoMapper/pull/3037#issuecomment-485367650

I created a feature flag on the mapping configuration to toggle this behavior.
By default, the feature is off and the behavior of AutoMapper remains the same.
This should allow releasing it without breaking existing code that is using the library (so, it should be fit for a 9.1).

When it is switched on, such properties will be auto-mapped:
```csharp
IList<int> Values { get; } = new List<int>();
```
Notice that `IList<>` is now supported, not just `List<>`.

I've also taken the liberty to simplify some logic in the `TypeDetails` class.

Take the following Where clause in its `BuildPublicAccessors` method:
```csharp
.Where(pi => pi.CanWrite || pi.PropertyType.IsListOrDictionaryType())
```

It seems to be redundant if its logic is put in the `PropertyWritable` method. I could not find a reason why the latter was filtering on `IEnumerable`, going so far as specifically excluding `string`, only to then filter further in `BuildPublicAccessors` on more specialized list and dictionary types.

When the feature is turned on, instead of only list and dictionary types, it takes all types implementing `ICollection<>` and `ICollection`, which covers the non-generic `IList` as well as writable dictionary types.

All unit tests pass, and I added 2 more to cover when the feature is on or off.

Feel free to suggest or make modifications to better suit the quality expectations of the project.