### PR TITLE
Add support for passing value-typed members to IncludeMembers

### DIFF
--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -211,7 +211,7 @@ namespace AutoMapper.Configuration
 
         public IMappingExpression<TSource, TDestination> IncludeMembers(params Expression<Func<TSource, object>>[] memberExpressions)
         {
-            IncludeMembersCore(memberExpressions);
+            IncludeMembersCore(memberExpressions.WithoutCastToObject());
             return this;
         }
 

--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -211,7 +211,15 @@ namespace AutoMapper.Configuration
 
         public IMappingExpression<TSource, TDestination> IncludeMembers(params Expression<Func<TSource, object>>[] memberExpressions)
         {
-            IncludeMembersCore(memberExpressions.WithoutCastToObject());
+            var memberExpressionsWithoutCastToObject = Array.ConvertAll(
+                memberExpressions,
+                e =>
+                {
+                    var bodyIsCastToObject = e.Body.NodeType == ExpressionType.Convert && e.Body.Type == typeof(object);
+                    return bodyIsCastToObject ? Expression.Lambda(((UnaryExpression)e.Body).Operand, e.Parameters) : e;
+                });
+
+            IncludeMembersCore(memberExpressionsWithoutCastToObject);
             return this;
         }
 

--- a/src/AutoMapper/ExpressionExtensions.cs
+++ b/src/AutoMapper/ExpressionExtensions.cs
@@ -69,14 +69,5 @@ namespace AutoMapper
 
         public static Expression IfNullElse(this Expression expression, Expression then, Expression @else = null)
             => ExpressionFactory.IfNullElse(expression, then, @else);
-
-        public static LambdaExpression[] WithoutCastToObject<T>(this Expression<Func<T, object>>[] expressions)
-            => Array.ConvertAll(
-                expressions,
-                e =>
-                {
-                    var bodyIsCastToObject = (e.Body.NodeType == ExpressionType.Convert || e.Body.NodeType == ExpressionType.ConvertChecked) && e.Body.Type == typeof(object);
-                    return bodyIsCastToObject ? Lambda(((UnaryExpression)e.Body).Operand, e.Parameters) : e;
-                });
     }
 }

--- a/src/AutoMapper/ExpressionExtensions.cs
+++ b/src/AutoMapper/ExpressionExtensions.cs
@@ -69,5 +69,14 @@ namespace AutoMapper
 
         public static Expression IfNullElse(this Expression expression, Expression then, Expression @else = null)
             => ExpressionFactory.IfNullElse(expression, then, @else);
+
+        public static LambdaExpression[] WithoutCastToObject<T>(this Expression<Func<T, object>>[] expressions)
+            => Array.ConvertAll(
+                expressions,
+                e =>
+                {
+                    var bodyIsCastToObject = (e.Body.NodeType == ExpressionType.Convert || e.Body.NodeType == ExpressionType.ConvertChecked) && e.Body.Type == typeof(object);
+                    return bodyIsCastToObject ? Lambda(((UnaryExpression)e.Body).Operand, e.Parameters) : e;
+                });
     }
 }

--- a/src/UnitTests/IMappingExpression/IncludeMembers.cs
+++ b/src/UnitTests/IMappingExpression/IncludeMembers.cs
@@ -1420,26 +1420,4 @@ namespace AutoMapper.UnitTests.IMappingExpression
             cfg.CreateMap<InnerSource, Destination>(MemberList.None);
         });
     }
-    public class IncludeMembersFromUnconstrainedGenericValidation : AutoMapperSpecBase
-    {
-        class Source<T>
-        {
-            public T InnerSource { get; set; }
-        }
-        class InnerSource
-        {
-            public string Name { get; set; }
-        }
-        class Destination
-        {
-            public string Name { get; set; }
-        }
-        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
-        {
-            var map = cfg.CreateMap<Source<InnerSource>, Destination>();
-            IncludeMembersFromUnconstrainedGeneric(map);
-            cfg.CreateMap<InnerSource, Destination>(MemberList.None);
-        });
-        private static void IncludeMembersFromUnconstrainedGeneric<T>(IMappingExpression<Source<T>, Destination> map) => map.IncludeMembers(src => src.InnerSource);
-    }
 }

--- a/src/UnitTests/IMappingExpression/IncludeMembers.cs
+++ b/src/UnitTests/IMappingExpression/IncludeMembers.cs
@@ -1400,4 +1400,46 @@ namespace AutoMapper.UnitTests.IMappingExpression
         [Fact]
         public void Should_override_IncludeMembers() => Mapper.Map<CreateCustomerDto>(new NewCustomer { Postcode = "Postcode", Address = new Address() }).Postcode.ShouldBe("Postcode");
     }
+    public class IncludeMembersWithValueTypeValidation : AutoMapperSpecBase
+    {
+        class Source
+        {
+            public InnerSource InnerSource { get; set; }
+        }
+        struct InnerSource
+        {
+            public string Name { get; set; }
+        }
+        class Destination
+        {
+            public string Name { get; set; }
+        }
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>().IncludeMembers(s => s.InnerSource);
+            cfg.CreateMap<InnerSource, Destination>(MemberList.None);
+        });
+    }
+    public class IncludeMembersFromUnconstrainedGenericValidation : AutoMapperSpecBase
+    {
+        class Source<T>
+        {
+            public T InnerSource { get; set; }
+        }
+        class InnerSource
+        {
+            public string Name { get; set; }
+        }
+        class Destination
+        {
+            public string Name { get; set; }
+        }
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            var map = cfg.CreateMap<Source<InnerSource>, Destination>();
+            IncludeMembersFromUnconstrainedGeneric(map);
+            cfg.CreateMap<InnerSource, Destination>(MemberList.None);
+        });
+        private static void IncludeMembersFromUnconstrainedGeneric<T>(IMappingExpression<Source<T>, Destination> map) => map.IncludeMembers(src => src.InnerSource);
+    }
 }


### PR DESCRIPTION
Fixes #3276 

I decided to go with replacing the expressions if they have a body that casts to object.
It's the strategy that has the smallest footprint on the source code.