### PR TITLE
WIP: EnumerableToReadOnlyDictionaryMapper

### DIFF
--- a/src/AutoMapper/Mappers/EnumerableToReadOnlyDictionaryMapper.cs
+++ b/src/AutoMapper/Mappers/EnumerableToReadOnlyDictionaryMapper.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Linq.Expressions;
+using AutoMapper.Configuration;
+using AutoMapper.Internal;
+using AutoMapper.Mappers.Internal;
+
+namespace AutoMapper.Mappers
+{
+    using static Expression;
+    using static ExpressionFactory;
+    using static CollectionMapperExpressionFactory;
+
+    public class EnumerableToReadOnlyDictionaryMapper : IObjectMapper
+    {
+        public bool IsMatch(TypePair context) => context.DestinationType.IsReadOnlyDictionaryType()
+                                                 && context.SourceType.IsEnumerableType()
+                                                 && !context.SourceType.IsReadOnlyDictionaryType();
+
+        public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap,
+            IMemberMap memberMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
+        {
+            var dictionaryTypes = ElementTypeHelper.GetElementTypes(destExpression.Type, ElementTypeFlags.BreakKeyValuePair);
+            var dictType = typeof(Dictionary<,>).MakeGenericType(dictionaryTypes);
+            var dict = MapCollectionExpression(configurationProvider, profileMap, memberMap, sourceExpression, Default(dictType), contextExpression, typeof(Dictionary<,>), MapItemExpr);
+            var dest = Variable(dictType, "dest");
+
+            var readOnlyDictType = destExpression.Type.IsInterface
+                ? typeof(ReadOnlyDictionary<,>).MakeGenericType(dictionaryTypes)
+                : destExpression.Type;
+
+            var ctor = readOnlyDictType.GetDeclaredConstructors()
+                .First(ci => ci.GetParameters().Length == 1 && ci.GetParameters()[0].ParameterType.IsAssignableFrom(dest.Type));
+
+            return Block(new[] { dest },
+                Assign(dest, dict),
+                Condition(NotEqual(dest, Default(dictType)),
+                    ToType(New(ctor, dest), destExpression.Type),
+                    Default(destExpression.Type)));
+
+        }
+    }
+}

--- a/src/AutoMapper/Mappers/MapperRegistry.cs
+++ b/src/AutoMapper/Mappers/MapperRegistry.cs
@@ -20,6 +20,7 @@ namespace AutoMapper.Mappers
             new MultidimensionalArrayMapper(),
             new ArrayCopyMapper(),
             new ArrayMapper(),
+            new EnumerableToReadOnlyDictionaryMapper(),
             new EnumerableToDictionaryMapper(),
             new NameValueCollectionMapper(),
             new ReadOnlyDictionaryMapper(),

--- a/src/UnitTests/Bug/MappingFromListToIReadOnlyDictionary.cs
+++ b/src/UnitTests/Bug/MappingFromListToIReadOnlyDictionary.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace AutoMapper.UnitTests.Bug
+{
+    public class MappingFromListToIReadOnlyDictionary : AutoMapperSpecBase
+    {
+        private class Source
+        {
+            public List<int> Field { get; set; }
+        }
+
+        private class Destination
+        {
+            public IReadOnlyDictionary<int,int> Field { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>();
+        });
+    }
+}


### PR DESCRIPTION
…tion from List to IReadOnlyDictionary. (fixes #3300)

This will now behave like a map configuration from List to Dictionary. The configuration will not throw an IndexOutOfRange, but the mapping operation will throw a mapping exception unless a custom mapper is defined.