### PR TITLE
Fix for issue 3300: System.IndexOutOfRangeException is thrown 

### DIFF
--- a/src/AutoMapper/Mappers/Internal/CollectionMapperExpressionFactory.cs
+++ b/src/AutoMapper/Mappers/Internal/CollectionMapperExpressionFactory.cs
@@ -105,12 +105,12 @@ namespace AutoMapper.Mappers.Internal
             var sourceElementTypes = GetElementTypes(sourceType, ElementTypeFlags.BreakKeyValuePair);
             var destElementTypes = GetElementTypes(destType, ElementTypeFlags.BreakKeyValuePair);
 
-            var typePairKey = new TypePair(sourceElementTypes[0], destElementTypes[0]);
-            var typePairValue = new TypePair(sourceElementTypes[1], destElementTypes[1]);
-
             var sourceElementType = typeof(KeyValuePair<,>).MakeGenericType(sourceElementTypes);
             itemParam = Parameter(sourceElementType, "item");
             var destElementType = typeof(KeyValuePair<,>).MakeGenericType(destElementTypes);
+
+            var typePairKey = new TypePair(sourceElementTypes[0], destElementTypes[0]);
+            var typePairValue = new TypePair(sourceElementTypes[1], destElementTypes[1]);
 
             var keyExpr = MapExpression(configurationProvider, profileMap, typePairKey,
                 Property(itemParam, "Key"), contextParam);


### PR DESCRIPTION
https://github.com/AutoMapper/AutoMapper/issues/3300

Moving MakeGenericType before the new TypePair because MakeGenericType throws the proper exception