### PR TITLE
disregard Convert node in ForPath

### DIFF
--- a/src/AutoMapper/ExpressionExtensions.cs
+++ b/src/AutoMapper/ExpressionExtensions.cs
@@ -22,7 +22,7 @@ namespace AutoMapper
         public static IEnumerable<MemberExpression> GetMembers(this Expression expression)
         {
             var memberExpression = expression as MemberExpression;
-            if(memberExpression == null)
+            if (memberExpression == null)
             {
                 return new MemberExpression[0];
             }
@@ -44,13 +44,22 @@ namespace AutoMapper
 
         public static void EnsureMemberPath(this LambdaExpression exp, string name)
         {
-            if(!exp.IsMemberPath())
+            if (!exp.IsMemberPath())
             {
-                throw new ArgumentOutOfRangeException(name, "Only member accesses are allowed. "+exp);
+                throw new ArgumentOutOfRangeException(name, "Only member accesses are allowed. " + exp);
             }
         }
 
-        public static bool IsMemberPath(this LambdaExpression exp) => exp.Body.GetMembers().FirstOrDefault()?.Expression == exp.Parameters.First();
+        public static LambdaExpression CleanExpression(this LambdaExpression exp)
+        {
+            Expression expression = exp.Body;
+            while (expression.NodeType == ExpressionType.Convert && expression.Type == typeof(object))
+                expression = ((UnaryExpression)exp.Body).Operand;
+            return Lambda(expression, exp.Parameters);
+        }
+
+        public static bool IsMemberPath(this LambdaExpression exp) =>
+            exp.CleanExpression().Body.GetMembers().FirstOrDefault()?.Expression == exp.Parameters.First();
 
         public static Expression ReplaceParameters(this LambdaExpression exp, params Expression[] replace)
             => ExpressionFactory.ReplaceParameters(exp, replace);

--- a/src/AutoMapper/Internal/ExpressionFactory.cs
+++ b/src/AutoMapper/Internal/ExpressionFactory.cs
@@ -112,7 +112,7 @@ namespace AutoMapper.Internal
 
         public static Expression ConvertReplaceParameters(LambdaExpression exp, params Expression[] replace)
         {
-            var replaceExp = exp.Body;
+            var replaceExp = exp.CleanExpression().Body;
             for (var i = 0; i < Math.Min(replace.Length, exp.Parameters.Count); i++)
                 replaceExp = new ConvertingVisitor(exp.Parameters[i], replace[i]).Visit(replaceExp);
             return replaceExp;

--- a/src/UnitTests/IMappingExpression/GenericConfiguration.cs
+++ b/src/UnitTests/IMappingExpression/GenericConfiguration.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace AutoMapper.UnitTests.IMappingExpression
+{
+    public class GenericConfiguration
+    {
+        class Source
+        {
+            public string Name { get; set; }
+            public int Value { get; set; }
+        }
+        class Destination
+        {
+            public string Name { get; set; }
+            public InnerDestination InnerDestination { get; set; }
+        }
+        class InnerDestination
+        {
+            public int Value { get; set; }
+        }
+
+        [Fact]
+        public void MapperField()
+        {
+            var source = new Source() { Name = "Foo", Value = 100 };
+            var mapping = new GenericTypeMap<Source, Destination>().Map(source);
+
+            Assert.Equal(source.Value, mapping.InnerDestination.Value);
+        }
+    }
+    public class GenericTypeMap<TSource, TDestination>
+    {
+        class FieldMapper
+        {
+            public string Source { get; set; }
+            public string Destination { get; set; }
+        }
+
+        private MapperConfiguration Configuration => new MapperConfiguration(x =>
+        {
+            var map = x.CreateMap<TSource, TDestination>();
+
+            var dbMapperProperties = new List<FieldMapper>
+                {
+                    new FieldMapper{ Source = "Value", Destination = "InnerDestination.Value" },
+                };
+
+            foreach (var propertyMap in dbMapperProperties)
+            {
+                var peSource = Expression.Parameter(typeof(TSource), "src");
+                var sourceExpression = Expression.Property(peSource, propertyMap.Source);
+                var sourceMapFromExpression =
+                     Expression.Lambda<Func<TSource, object>>(
+                         Expression.Convert(sourceExpression, typeof(object)), new ParameterExpression[] { peSource });
+
+                var peDestination = Expression.Parameter(typeof(TDestination), "dest");
+
+                Expression destinationExpression = peDestination;
+                foreach (var navigatinoPropertieDestination in propertyMap.Destination.Split('.'))
+                    destinationExpression = Expression.Property(destinationExpression, navigatinoPropertieDestination);
+
+                Expression<Func<TDestination, object>> destinationMapFromExpression =
+                       Expression.Lambda<Func<TDestination, object>>
+                           (Expression.Convert(destinationExpression, typeof(object)), new ParameterExpression[] { peDestination });
+
+
+                map.ForPath(destinationMapFromExpression, a => a.MapFrom(sourceMapFromExpression));
+            }
+        });
+
+        public TDestination Map(TSource source) =>
+            Configuration.CreateMapper().Map<TDestination>(source);
+    }
+
+}


### PR DESCRIPTION
Hello, I'm opening PR for a small change when creating lambda expressions dynamically, before it was a problem when using Expression.Convert because the verification in the ForPath method returned that it was not a valid path. I currently remove the 'Convert' method at the time of validation and simply read the expression. I will create a test to exemplify, I hope to be helping.