### PR TITLE
Avoid collections with null values when reaching max depth

### DIFF
--- a/src/AutoMapper/Execution/ExpressionBuilder.cs
+++ b/src/AutoMapper/Execution/ExpressionBuilder.cs
@@ -13,6 +13,9 @@ namespace AutoMapper.Execution
 
     public static class ExpressionBuilder
     {
+        private static readonly Expression<Func<ResolutionContext, int>> GetTypeDepthInfo =
+            ctxt => ctxt.GetTypeDepth(default);
+
         private static readonly Expression<Func<IRuntimeMapper, ResolutionContext>> CreateContext =
             mapper => new ResolutionContext(mapper.DefaultContext.Options, mapper);
 
@@ -122,5 +125,12 @@ namespace AutoMapper.Execution
             return null;
         }
 
+        public static BinaryExpression OverMaxDepth(this Expression context, TypeMap typeMap) =>
+            typeMap?.MaxDepth > 0 ?
+                GreaterThan(
+                    Call(context, ((MethodCallExpression)GetTypeDepthInfo.Body).Method, Constant(typeMap.Types)),
+                    Constant(typeMap.MaxDepth)
+                ) :
+                null;
     }
 }

--- a/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
+++ b/src/AutoMapper/Execution/TypeMapPlanBuilder.cs
@@ -23,9 +23,6 @@ namespace AutoMapper.Execution
         private static readonly Expression<Action<ResolutionContext>> DecTypeDepthInfo =
             ctxt => ctxt.DecrementTypeDepth(default);
 
-        private static readonly Expression<Func<ResolutionContext, int>> GetTypeDepthInfo =
-            ctxt => ctxt.GetTypeDepth(default);
-
         private readonly IConfigurationProvider _configurationProvider;
         private readonly ParameterExpression _destination;
         private readonly ParameterExpression _initialDestination;
@@ -262,14 +259,12 @@ namespace AutoMapper.Execution
                     Condition(_typeMap.Condition.Body,
                         mapperFunc, Default(_typeMap.DestinationTypeToUse));
 
-            if(_typeMap.MaxDepth > 0)
+            var overMaxDepth = Context.OverMaxDepth(_typeMap);
+            if (overMaxDepth != null)
                 mapperFunc = Condition(
-                    LessThanOrEqual(
-                        Call(Context, ((MethodCallExpression)GetTypeDepthInfo.Body).Method, Constant(_typeMap.Types)),
-                        Constant(_typeMap.MaxDepth)
-                    ),
-                    mapperFunc,
-                    Default(_typeMap.DestinationTypeToUse));
+                    overMaxDepth,
+                    Default(_typeMap.DestinationTypeToUse),
+                    mapperFunc);
 
             if(_typeMap.Profile.AllowNullDestinationValues)
                 mapperFunc = Source.IfNullElse(Default(_typeMap.DestinationTypeToUse), mapperFunc);

--- a/src/AutoMapper/Mappers/Internal/CollectionMapperExpressionFactory.cs
+++ b/src/AutoMapper/Mappers/Internal/CollectionMapperExpressionFactory.cs
@@ -41,6 +41,11 @@ namespace AutoMapper.Mappers.Internal
             UseDestinationValue();
 
             var addItems = ForEach(sourceExpression, itemParam, Call(destination, addMethod, itemExpr));
+            var overMaxDepth = contextExpression.OverMaxDepth(memberMap?.TypeMap);
+            if (overMaxDepth != null)
+            {
+                addItems = Condition(overMaxDepth, Empty(), addItems);
+            }
             var mapExpr = Block(addItems, destination);
 
             var clearMethod = destinationCollectionType.GetDeclaredMethod("Clear");

--- a/src/UnitTests/MaxDepthTests.cs
+++ b/src/UnitTests/MaxDepthTests.cs
@@ -57,14 +57,11 @@ namespace AutoMapper.UnitTests
         }
 
         [Fact]
-        public void Second_level_children_are_null_with_max_depth_1()
+        public void Second_level_children_is_empty_with_max_depth_1()
         {
             var config = new MapperConfiguration(cfg => cfg.CreateMap<Source, Destination>().MaxDepth(1));
             var destination = config.CreateMapper().Map<Source, Destination>(_source);
-            foreach (var child in destination.Children)
-            {
-                child.ShouldBeNull();
-            }
+            destination.Children.ShouldBeEmpty();
         }
 
         [Fact]
@@ -81,17 +78,13 @@ namespace AutoMapper.UnitTests
         }
 
         [Fact]
-        public void Third_level_children_are_null_with_max_depth_2()
+        public void Third_level_children_is_empty_with_max_depth_2()
         {
             var config = new MapperConfiguration(cfg => cfg.CreateMap<Source, Destination>().MaxDepth(2));
             var destination = config.CreateMapper().Map<Source, Destination>(_source);
             foreach (var child in destination.Children)
             {
-                child.Children.ShouldNotBeNull();
-                foreach (var subChild in child.Children)
-                {
-                    subChild.ShouldBeNull();
-                }
+                child.Children.ShouldBeEmpty();
             }
         }
 


### PR DESCRIPTION
Breaking change. From #3391 and #2511. Another `if`, another dollar :) We can always keep the current behaviour.