### PR TITLE
Allow any expression with IncludeMembers

### DIFF
--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -201,7 +201,7 @@ namespace AutoMapper.Configuration
 
         private void IncludeMembersCore(LambdaExpression[] memberExpressions)
         {
-            foreach(var member in memberExpressions.Select(member => member.GetMember()).Where(member => member != null))
+            foreach(var member in memberExpressions.Select(memberExpression => memberExpression.GetMember()).Where(member => member != null))
             {
                 ForSourceMemberCore(member, o => o.DoNotValidate());
             }

--- a/src/AutoMapper/Configuration/MappingExpression.cs
+++ b/src/AutoMapper/Configuration/MappingExpression.cs
@@ -201,10 +201,9 @@ namespace AutoMapper.Configuration
 
         private void IncludeMembersCore(LambdaExpression[] memberExpressions)
         {
-            foreach(var member in memberExpressions)
+            foreach(var member in memberExpressions.Select(member => member.GetMember()).Where(member => member != null))
             {
-                member.EnsureMemberPath(nameof(memberExpressions));
-                ForSourceMemberCore(new MemberPath(member).First, o => o.DoNotValidate());
+                ForSourceMemberCore(member, o => o.DoNotValidate());
             }
             TypeMapActions.Add(tm => tm.IncludedMembers = memberExpressions);
         }

--- a/src/AutoMapper/Configuration/MappingExpressionBase.cs
+++ b/src/AutoMapper/Configuration/MappingExpressionBase.cs
@@ -148,7 +148,7 @@ namespace AutoMapper.Configuration
 
         private void ReverseIncludedMembers(TypeMap typeMap)
         {
-            foreach(var includedMember in typeMap.IncludedMembers)
+            foreach(var includedMember in typeMap.IncludedMembers.Where(i=>i.IsMemberPath()))
             {
                 var memberPath = new MemberPath(includedMember);
                 var newSource = Parameter(typeMap.DestinationType, "source");

--- a/src/AutoMapper/ConfigurationValidator.cs
+++ b/src/AutoMapper/ConfigurationValidator.cs
@@ -79,7 +79,7 @@ namespace AutoMapper
                 var context = new ValidationContext(types, memberMap, typeMap);
                 _config.Validate(context);
 
-                if(typeMap.CustomMapExpression != null || typeMap.CustomMapFunction != null || typeMap.TypeConverterType != null)
+                if(!typeMap.ShouldCheckForValid)
                 {
                     return;
                 }

--- a/src/AutoMapper/DefaultMemberMap.cs
+++ b/src/AutoMapper/DefaultMemberMap.cs
@@ -23,7 +23,8 @@ namespace AutoMapper
         public virtual TypeMap TypeMap => default;
         public virtual Type SourceType => default;
         public virtual IReadOnlyCollection<MemberInfo> SourceMembers => Array.Empty<MemberInfo>();
-        public virtual LambdaExpression CustomSource { get => default; set { } }
+        public LambdaExpression CustomSource => IncludedMember.MemberExpression;
+        public virtual IncludedMember IncludedMember { get => default; set { } }
         public virtual string DestinationName => default;
         public virtual Type DestinationType => default;
         public virtual TypePair Types => new TypePair(SourceType, DestinationType);
@@ -43,17 +44,7 @@ namespace AutoMapper
 
         public virtual IEnumerable<ValueTransformerConfiguration> ValueTransformers => Enumerable.Empty<ValueTransformerConfiguration>();
 
-        public MemberInfo SourceMember
-        {
-            get
-            {
-                if (CustomMapExpression?.Body is MemberExpression memberExpression && memberExpression.Expression == CustomMapExpression.Parameters[0])
-                {
-                    return memberExpression.Member;
-                }
-                return SourceMembers.LastOrDefault();
-            }
-        }
+        public MemberInfo SourceMember => CustomMapExpression.GetMember() ?? SourceMembers.LastOrDefault();
   
         public void MapFrom(LambdaExpression sourceMember)
         {

--- a/src/AutoMapper/ExpressionExtensions.cs
+++ b/src/AutoMapper/ExpressionExtensions.cs
@@ -5,12 +5,20 @@ using System.Linq.Expressions;
 using System.Reflection;
 using AutoMapper.Internal;
 
-namespace AutoMapper
+namespace AutoMapper.Internal
 {
     using static Expression;
 
-    internal static class ExpressionExtensions
+    public static class ExpressionExtensions
     {
+        public static Expression Chain(this IEnumerable<Expression> expressions, Expression parameter) => expressions.Aggregate(parameter,
+            (left, right) => right is LambdaExpression lambda ? lambda.ReplaceParameters(left) : right.GetMembersChain().MemberAccesses(left));
+        public static LambdaExpression Lambda(this IEnumerable<MemberInfo> members)
+        {
+            var source = Parameter(members.First().DeclaringType, "source");
+            return Expression.Lambda(members.MemberAccesses(source), source);
+        }
+        
         public static Expression MemberAccesses(this IEnumerable<MemberInfo> members, Expression obj) =>
             members
                 .Aggregate(
@@ -19,29 +27,57 @@ namespace AutoMapper
                             (getter.IsStatic() ? Call(null, method, inner) : (Expression)Call(inner, method)) :
                             MakeMemberAccess(getter.IsStatic() ? null : inner, getter));
 
-        public static IEnumerable<MemberExpression> GetMembers(this Expression expression)
-        {
-            var memberExpression = expression as MemberExpression;
-            if(memberExpression == null)
-            {
-                return new MemberExpression[0];
-            }
-            return memberExpression.GetMembers();
-        }
+        public static IEnumerable<MemberInfo> GetMembersChain(this LambdaExpression lambda) => lambda.Body.GetMembersChain();
 
-        public static IEnumerable<MemberExpression> GetMembers(this MemberExpression expression)
+        public static MemberInfo GetMember(this LambdaExpression lambda) => 
+            (lambda?.Body is MemberExpression memberExpression && memberExpression.Expression == lambda.Parameters[0]) ? memberExpression.Member : null;
+
+        public static IEnumerable<MemberInfo> GetMembersChain(this Expression expression) => expression.GetChain().Select(m=>m.MemberInfo);
+
+        public static IEnumerable<Member> GetChain(this Expression expression)
         {
             return GetMembersCore().Reverse();
-            IEnumerable<MemberExpression> GetMembersCore()
+            IEnumerable<Member> GetMembersCore()
             {
                 while (expression != null)
                 {
-                    yield return expression;
-                    expression = expression.Expression as MemberExpression;
+                    if (expression is MemberExpression member)
+                    {
+                        yield return new Member(expression, member.Member);
+                        expression = member.Expression;
+                    }
+                    else if (expression is MethodCallExpression method)
+                    {
+                        yield return new Member(expression, method.Method);
+                        expression = method.Object ?? method.Arguments[0];
+                    }
+                    else
+                    {
+                        break;
+                    }
                 }
             }
         }
+        public readonly struct Member
+        {
+            public Member(Expression expression, MemberInfo memberInfo)
+            {
+                Expression = expression;
+                MemberInfo = memberInfo;
+            }
 
+            public Expression Expression { get; }
+            public MemberInfo MemberInfo { get; }
+        }
+        public static IEnumerable<MemberExpression> GetMemberExpressions(this Expression expression)
+        {
+            var memberExpression = expression as MemberExpression;
+            if (memberExpression == null)
+            {
+                return Array.Empty<MemberExpression>();
+            }
+            return expression.GetChain().Select(m => m.Expression as MemberExpression).TakeWhile(m => m != null);
+        }
         public static void EnsureMemberPath(this LambdaExpression exp, string name)
         {
             if(!exp.IsMemberPath())
@@ -50,7 +86,7 @@ namespace AutoMapper
             }
         }
 
-        public static bool IsMemberPath(this LambdaExpression exp) => exp.Body.GetMembers().FirstOrDefault()?.Expression == exp.Parameters.First();
+        public static bool IsMemberPath(this LambdaExpression exp) => exp.Body.GetMemberExpressions().FirstOrDefault()?.Expression == exp.Parameters.First();
 
         public static Expression ReplaceParameters(this LambdaExpression exp, params Expression[] replace)
             => ExpressionFactory.ReplaceParameters(exp, replace);
@@ -64,7 +100,7 @@ namespace AutoMapper
         public static LambdaExpression Concat(this LambdaExpression expr, LambdaExpression concat)
             => ExpressionFactory.Concat(expr, concat);
 
-        public static Expression NullCheck(this Expression expression, Type destinationType)
+        public static Expression NullCheck(this Expression expression, Type destinationType = null)
             => ExpressionFactory.NullCheck(expression, destinationType);
 
         public static Expression IfNullElse(this Expression expression, Expression then, Expression @else = null)

--- a/src/AutoMapper/IMappingExpression.cs
+++ b/src/AutoMapper/IMappingExpression.cs
@@ -17,7 +17,8 @@ namespace AutoMapper
         IMappingExpression IncludeMembers(params string[] memberNames);
 
         /// <summary>
-        /// Create a type mapping from the destination to the source type, using the destination members as validation.
+        /// Create a type mapping from the destination to the source type, with validation disabled.
+        /// This allows for two-way mapping.
         /// </summary>
         /// <returns>Itself</returns>
         IMappingExpression ReverseMap();
@@ -139,7 +140,8 @@ namespace AutoMapper
         IMappingExpression<TSource, TDestination> AddTransform<TValue>(Expression<Func<TValue, TValue>> transformer);
 
         /// <summary>
-        /// Create a type mapping from the destination to the source type, using the <typeparamref name="TDestination"/> members as validation
+        /// Create a type mapping from the destination to the source type, with validation disabled.
+        /// This allows for two-way mapping.
         /// </summary>
         /// <returns>Itself</returns>
         IMappingExpression<TDestination, TSource> ReverseMap();

--- a/src/AutoMapper/IMemberMap.cs
+++ b/src/AutoMapper/IMemberMap.cs
@@ -13,6 +13,7 @@ namespace AutoMapper
         Type SourceType { get; }
         IReadOnlyCollection<MemberInfo> SourceMembers { get; }
         LambdaExpression CustomSource { get; }
+        IncludedMember IncludedMember { get; }
         Type DestinationType { get; }
         string DestinationName { get; }
         TypePair Types { get; }

--- a/src/AutoMapper/Internal/ExpressionFactory.cs
+++ b/src/AutoMapper/Internal/ExpressionFactory.cs
@@ -122,8 +122,9 @@ namespace AutoMapper.Internal
 
         public static LambdaExpression Concat(LambdaExpression expr, LambdaExpression concat) => (LambdaExpression)new ExpressionConcatVisitor(expr).Visit(concat);
 
-        public static Expression NullCheck(Expression expression, Type destinationType)
+        public static Expression NullCheck(Expression expression, Type destinationType = null)
         {
+            destinationType = destinationType ?? expression.Type;
             var target = expression;
             Expression nullConditions = Constant(false);
             do

--- a/src/AutoMapper/Internal/MemberVisitor.cs
+++ b/src/AutoMapper/Internal/MemberVisitor.cs
@@ -16,7 +16,7 @@ namespace AutoMapper.Internal
 
         protected override Expression VisitMember(MemberExpression node)
         {
-            _members.AddRange(node.GetMembers().Select(e => e.Member));
+            _members.AddRange(node.GetMemberExpressions().Select(e => e.Member));
             return node;
         }
 

--- a/src/AutoMapper/PathMap.cs
+++ b/src/AutoMapper/PathMap.cs
@@ -1,20 +1,19 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 
 namespace AutoMapper
 {
     using Internal;
+    using System.ComponentModel;
 
     [DebuggerDisplay("{DestinationExpression}")]
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public class PathMap : DefaultMemberMap
     {
-        public PathMap(PathMap pathMap, TypeMap typeMap, LambdaExpression customSource) : this(pathMap.DestinationExpression, pathMap.MemberPath, typeMap)
+        public PathMap(PathMap pathMap, TypeMap typeMap, IncludedMember includedMember) : this(pathMap.DestinationExpression, pathMap.MemberPath, typeMap)
         {
-            CustomSource = customSource;
+            IncludedMember = includedMember;
             CustomMapExpression = pathMap.CustomMapExpression;
             Condition = pathMap.Condition;
             Ignored = pathMap.Ignored;
@@ -30,7 +29,7 @@ namespace AutoMapper
         public override TypeMap TypeMap { get; }
 
         public override Type SourceType => CustomMapExpression.ReturnType;
-        public override LambdaExpression CustomSource { get; set; }
+        public override IncludedMember IncludedMember { get; set; }
         public LambdaExpression DestinationExpression { get; }
         public override LambdaExpression CustomMapExpression { get; set; }
         public MemberPath MemberPath { get; }

--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -7,6 +7,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using AutoMapper.Configuration;
 using AutoMapper.Configuration.Conventions;
+using AutoMapper.Internal;
 
 namespace AutoMapper
 {
@@ -249,8 +250,10 @@ namespace AutoMapper
         {
             TypeMap = typeMap;
             MemberExpression = memberExpression;
+            Variable = Expression.Variable(memberExpression.Body.Type, string.Join("", memberExpression.GetMembersChain().Select(m => m.Name)));
         }
         public TypeMap TypeMap { get; }
         public LambdaExpression MemberExpression { get; }
+        public ParameterExpression Variable { get; }
     }
 }

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -28,20 +28,8 @@ namespace AutoMapper
         public PropertyMap(PropertyMap inheritedMappedProperty, TypeMap typeMap)
             : this(inheritedMappedProperty.DestinationMember, typeMap) => ApplyInheritedPropertyMap(inheritedMappedProperty);
 
-        public PropertyMap(PropertyMap includedMemberMap, TypeMap typeMap, LambdaExpression expression) 
-            : this(includedMemberMap, typeMap) => ApplyIncludedMemberMap(includedMemberMap, expression);
-
-        private void ApplyIncludedMemberMap(PropertyMap includedMemberMap, LambdaExpression expression)
-        {
-            CustomSource = expression;
-            if(includedMemberMap._memberChain.Count > 0)
-            {
-                _memberChain = expression.Body.GetMembers().Select(e => e.Member).Concat(includedMemberMap._memberChain).ToList();
-            }
-            CustomMapExpression = CheckCustomSource(CustomMapExpression);
-        }
-
-        private LambdaExpression CheckCustomSource(LambdaExpression lambda) => CheckCustomSource(lambda, CustomSource);
+        public PropertyMap(PropertyMap includedMemberMap, TypeMap typeMap, IncludedMember includedMember) 
+            : this(includedMemberMap, typeMap) => IncludedMember = includedMember;
 
         public static LambdaExpression CheckCustomSource(LambdaExpression lambda, LambdaExpression customSource) =>
             (lambda == null || customSource == null) ?
@@ -55,7 +43,7 @@ namespace AutoMapper
         public override Type DestinationType => DestinationMember.GetMemberType();
 
         public override IReadOnlyCollection<MemberInfo> SourceMembers => _memberChain;
-        public override LambdaExpression CustomSource { get; set; }
+        public override IncludedMember IncludedMember { get; set; }
         public override bool Inline { get; set; } = true;
         public override bool CanBeSet => ReflectionHelper.CanBeSet(DestinationMember);
         public override bool Ignored { get; set; }

--- a/src/AutoMapper/QueryableExtensions/ExpressionResolutionResult.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionResolutionResult.cs
@@ -5,13 +5,16 @@ namespace AutoMapper.QueryableExtensions
 {
     public class ExpressionResolutionResult
     {
+        private readonly Expression _nonMarkerExpression;
         public Expression ResolutionExpression { get; }
+        public Expression NonMarkerExpression => _nonMarkerExpression ?? ResolutionExpression;
         public Type Type { get; }
-
-        public ExpressionResolutionResult(Expression resolutionExpression, Type type)
+        public ExpressionResolutionResult(Expression resolutionExpression, Type type = null)
         {
             ResolutionExpression = resolutionExpression;
-            Type = type;
+            Type = type ?? resolutionExpression.Type;
         }
+        public ExpressionResolutionResult(Expression resolutionExpression, LambdaExpression nonMarkerExpression) : this(resolutionExpression) =>
+            _nonMarkerExpression = nonMarkerExpression;
     }
 }

--- a/src/AutoMapper/QueryableExtensions/Impl/CustomProjectionExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/CustomProjectionExpressionBinder.cs
@@ -1,3 +1,4 @@
+using AutoMapper.Internal;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 

--- a/src/AutoMapper/QueryableExtensions/Impl/MappedTypeExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/MappedTypeExpressionBinder.cs
@@ -1,4 +1,5 @@
 using AutoMapper.Configuration;
+using AutoMapper.Internal;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 

--- a/src/AutoMapper/QueryableExtensions/Impl/MemberGetterExpressionResultConverter.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/MemberGetterExpressionResultConverter.cs
@@ -1,8 +1,6 @@
-using System.Collections.Generic;
+using AutoMapper.Internal;
 using System.ComponentModel;
-using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 
 namespace AutoMapper.QueryableExtensions.Impl
 {
@@ -10,17 +8,8 @@ namespace AutoMapper.QueryableExtensions.Impl
     public class MemberGetterExpressionResultConverter : IExpressionResultConverter
     {
         public ExpressionResolutionResult GetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult, IMemberMap propertyMap, LetPropertyMaps letPropertyMaps)
-            => propertyMap.SourceMembers.Aggregate(expressionResolutionResult, ExpressionResolutionResult);
-
-        private static ExpressionResolutionResult ExpressionResolutionResult(
-            ExpressionResolutionResult expressionResolutionResult, MemberInfo getter)
-        {
-            var member = (getter is MethodInfo method)
-                ? (Expression)Expression.Call(method, expressionResolutionResult.ResolutionExpression)
-                : Expression.MakeMemberAccess(expressionResolutionResult.ResolutionExpression, getter);
-            return new ExpressionResolutionResult(member, member.Type);
-        }
-
-        public bool CanGetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult, IMemberMap propertyMap) => propertyMap.SourceMembers.Count > 0;
+            => new ExpressionResolutionResult(propertyMap.SourceMembers.MemberAccesses(propertyMap.CheckCustomSource(expressionResolutionResult, letPropertyMaps)));
+        public bool CanGetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult, IMemberMap propertyMap) => 
+            propertyMap.SourceMembers.Count > 0;
     }
 }

--- a/src/AutoMapper/QueryableExtensions/Impl/MemberResolverExpressionResultConverter.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/MemberResolverExpressionResultConverter.cs
@@ -1,25 +1,39 @@
+using System.Linq;
 using System.ComponentModel;
 using System.Linq.Expressions;
+using AutoMapper.Internal;
 
 namespace AutoMapper.QueryableExtensions.Impl
 {
+    using static Expression;
+
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class MemberResolverExpressionResultConverter : IExpressionResultConverter
     {
         public ExpressionResolutionResult GetExpressionResolutionResult(
             ExpressionResolutionResult expressionResolutionResult, IMemberMap propertyMap, LetPropertyMaps letPropertyMaps)
         {
-            Expression subQueryMarker;
-            if((subQueryMarker = letPropertyMaps.GetSubQueryMarker()) != null)
+            var mapFrom = propertyMap.CustomMapExpression;
+            if (!IsSubQuery() || letPropertyMaps.ConfigurationProvider.ResolveTypeMap(propertyMap.SourceType, propertyMap.DestinationType) == null)
             {
-                return new ExpressionResolutionResult(subQueryMarker, subQueryMarker.Type);
+                return new ExpressionResolutionResult(mapFrom.ReplaceParameters(propertyMap.CheckCustomSource(expressionResolutionResult, letPropertyMaps)));
             }
-            var currentChild = propertyMap.CustomMapExpression.ReplaceParameters(expressionResolutionResult.ResolutionExpression);
-            var currentChildType = currentChild.Type;
-
-            return new ExpressionResolutionResult(currentChild, currentChildType);
+            if (propertyMap.CustomSource == null)
+            {
+                return new ExpressionResolutionResult(letPropertyMaps.GetSubQueryMarker(mapFrom), mapFrom);
+            }
+            var newMapFrom = Lambda(mapFrom.ReplaceParameters(propertyMap.CustomSource.Body), propertyMap.CustomSource.Parameters);
+            return new ExpressionResolutionResult(letPropertyMaps.GetSubQueryMarker(newMapFrom), newMapFrom);
+            bool IsSubQuery()
+            {
+                if (!(mapFrom.Body is MethodCallExpression methodCall))
+                {
+                    return false;
+                }
+                var method = methodCall.Method;
+                return method.IsStatic && method.DeclaringType == typeof(Enumerable);
+            }
         }
-
         public bool CanGetExpressionResolutionResult(ExpressionResolutionResult expressionResolutionResult, IMemberMap propertyMap) => propertyMap.CustomMapExpression != null;
     }
 }

--- a/src/AutoMapper/QueryableExtensions/Impl/NullableDestinationExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/NullableDestinationExpressionBinder.cs
@@ -20,7 +20,7 @@ namespace AutoMapper.QueryableExtensions.Impl
         {
             var destinationType = propertyMap.DestinationType;
             var expressionToBind =
-                result.ResolutionExpression.GetMembers().Reverse().Aggregate(
+                result.ResolutionExpression.GetMemberExpressions().Reverse().Aggregate(
                     ExpressionFactory.ToType(result.ResolutionExpression, destinationType),
                     (accumulator, current) => current.IfNullElse(Constant(null, destinationType), accumulator));
             return Bind(propertyMap.DestinationMember, expressionToBind);

--- a/src/AutoMapper/QueryableExtensions/Impl/QueryMapperHelper.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/QueryMapperHelper.cs
@@ -1,11 +1,24 @@
+using AutoMapper.Internal;
 using System;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace AutoMapper.QueryableExtensions.Impl
 {
     public static class QueryMapperHelper
     {
+        public static Expression CheckCustomSource(this IMemberMap memberMap, ExpressionResolutionResult expressionResolutionResult, LetPropertyMaps letPropertyMaps)
+        {
+            if (memberMap.CustomSource == null)
+            {
+                return expressionResolutionResult.ResolutionExpression;
+            }
+            return memberMap.CustomSource.IsMemberPath() ?
+                memberMap.CustomSource.ReplaceParameters(expressionResolutionResult.ResolutionExpression) :
+                letPropertyMaps.GetSubQueryMarker(memberMap.CustomSource);
+        }
+
         public static PropertyMap GetPropertyMap(this IConfigurationProvider config, MemberInfo sourceMemberInfo, Type destinationMemberType)
         {
             var typeMap = config.CheckIfMapExists(sourceMemberInfo.DeclaringType, destinationMemberType);

--- a/src/IntegrationTests/CustomMapFrom/MapObjectPropertyFromSubQuery.cs
+++ b/src/IntegrationTests/CustomMapFrom/MapObjectPropertyFromSubQuery.cs
@@ -351,20 +351,6 @@ namespace AutoMapper.IntegrationTests
             }
         }
 
-        class FirstOrDefaultCounter : ExpressionVisitor
-        {
-            public int Count;
-
-            protected override Expression VisitMethodCall(MethodCallExpression node)
-            {
-                if(node.Method.Name == "FirstOrDefault")
-                {
-                    Count++;
-                }
-                return base.VisitMethodCall(node);
-            }
-        }
-
         public class ProductArticle
         {
             public int Id { get; set; }

--- a/src/IntegrationTests/IncludeMembers.cs
+++ b/src/IntegrationTests/IncludeMembers.cs
@@ -70,7 +70,8 @@ namespace AutoMapper.IntegrationTests
         {
             using(var context = new Context())
             {
-                var result = ProjectTo<Destination>(context.Sources).Single();
+                var projectTo = ProjectTo<Destination>(context.Sources);
+                var result = projectTo.Single();
                 result.Name.ShouldBe("name");
                 result.Description.ShouldBe("description");
                 result.Title.ShouldBe("title");
@@ -78,6 +79,681 @@ namespace AutoMapper.IntegrationTests
         }
     }
 
+    public class IncludeMembersFirstOrDefault : AutoMapperSpecBase
+    {
+        class Source
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public List<InnerSource> InnerSources { get; set; } = new List<InnerSource>();
+            public List<OtherInnerSource> OtherInnerSources { get; set; } = new List<OtherInnerSource>();
+        }
+        class InnerSource
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string Description { get; set; }
+            public string Publisher { get; set; }
+        }
+        class OtherInnerSource
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string Description { get; set; }
+            public string Title { get; set; }
+            public string Author { get; set; }
+        }
+        class Destination
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string Description { get; set; }
+            public string Title { get; set; }
+            public string Author { get; set; }
+            public string Publisher { get; set; }
+        }
+        class Context : DbContext
+        {
+            public Context()
+            {
+                Database.SetInitializer(new DatabaseInitializer());
+            }
+
+            public DbSet<Source> Sources { get; set; }
+        }
+        class DatabaseInitializer : DropCreateDatabaseAlways<Context>
+        {
+            protected override void Seed(Context context)
+            {
+                var source = new Source
+                {
+                    Name = "name",
+                    InnerSources = { new InnerSource { Description = "description", Publisher = "publisher" } },
+                    OtherInnerSources = { new OtherInnerSource { Title = "title", Author = "author" } }
+                };
+                context.Sources.Add(source);
+                base.Seed(context);
+            }
+        }
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>().IncludeMembers(s => s.InnerSources.FirstOrDefault(), s => s.OtherInnerSources.FirstOrDefault());
+            cfg.CreateMap<InnerSource, Destination>(MemberList.None);
+            cfg.CreateMap<OtherInnerSource, Destination>(MemberList.None);
+        });
+        [Fact]
+        public void Should_flatten()
+        {
+            using (var context = new Context())
+            {
+                var projectTo = ProjectTo<Destination>(context.Sources);
+                FirstOrDefaultCounter.Assert(projectTo, 2);
+                var result = projectTo.Single();
+                result.Name.ShouldBe("name");
+                result.Description.ShouldBe("description");
+                result.Title.ShouldBe("title");
+                result.Author.ShouldBe("author");
+                result.Publisher.ShouldBe("publisher");
+            }
+        }
+    }
+
+    public class IncludeMembersFirstOrDefaultWithMapFromExpression : AutoMapperSpecBase
+    {
+        class Source
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public List<InnerSource> InnerSources { get; set; } = new List<InnerSource>();
+            public List<OtherInnerSource> OtherInnerSources { get; set; } = new List<OtherInnerSource>();
+        }
+        class InnerSource
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string Description1 { get; set; }
+            public string Publisher { get; set; }
+        }
+        class OtherInnerSource
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string Description { get; set; }
+            public string Title1 { get; set; }
+            public string Author { get; set; }
+        }
+        class Destination
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string Description { get; set; }
+            public string Title { get; set; }
+            public string Author { get; set; }
+            public string Publisher { get; set; }
+        }
+        class Context : DbContext
+        {
+            public Context()
+            {
+                Database.SetInitializer(new DatabaseInitializer());
+            }
+
+            public DbSet<Source> Sources { get; set; }
+        }
+        class DatabaseInitializer : DropCreateDatabaseAlways<Context>
+        {
+            protected override void Seed(Context context)
+            {
+                var source = new Source
+                {
+                    Name = "name",
+                    InnerSources = { new InnerSource { Description1 = "description", Publisher = "publisher" } },
+                    OtherInnerSources = { new OtherInnerSource { Title1 = "title", Author = "author" } }
+                };
+                context.Sources.Add(source);
+                base.Seed(context);
+            }
+        }
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>().IncludeMembers(s => s.InnerSources.FirstOrDefault(), s => s.OtherInnerSources.FirstOrDefault());
+            cfg.CreateMap<InnerSource, Destination>(MemberList.None).ForMember(d => d.Description, o => o.MapFrom(s => s.Description1));
+            cfg.CreateMap<OtherInnerSource, Destination>(MemberList.None).ForMember(d => d.Title, o => o.MapFrom(s => s.Title1));
+        });
+        [Fact]
+        public void Should_flatten()
+        {
+            using (var context = new Context())
+            {
+                var projectTo = ProjectTo<Destination>(context.Sources);
+                FirstOrDefaultCounter.Assert(projectTo, 2);
+                var result = projectTo.Single();
+                result.Name.ShouldBe("name");
+                result.Description.ShouldBe("description");
+                result.Title.ShouldBe("title");
+                result.Author.ShouldBe("author");
+                result.Publisher.ShouldBe("publisher");
+            }
+        }
+    }
+    public class IncludeMembersFirstOrDefaultWithSubqueryMapFrom : AutoMapperSpecBase
+    {
+        class Source
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public List<InnerSource> InnerSources { get; set; } = new List<InnerSource>();
+            public List<OtherInnerSource> OtherInnerSources { get; set; } = new List<OtherInnerSource>();
+        }
+        class InnerSource
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public List<InnerSourceDetails> InnerSourceDetails { get; } = new List<InnerSourceDetails>();
+        }
+        class InnerSourceDetails
+        {
+            public int Id { get; set; }
+            public string Description { get; set; }
+            public string Publisher { get; set; }
+        }
+        class OtherInnerSource
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string Description { get; set; }
+            public List<OtherInnerSourceDetails> OtherInnerSourceDetails { get; } = new List<OtherInnerSourceDetails>();
+        }
+        class OtherInnerSourceDetails
+        {
+            public int Id { get; set; }
+            public string Title { get; set; }
+            public string Author { get; set; }
+        }
+        class Destination
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public DestinationDetails Details { get; set; }
+            public OtherDestinationDetails OtherDetails { get; set; }
+        }
+        class DestinationDetails
+        {
+            public string Description { get; set; }
+            public string Publisher { get; set; }
+        }
+        class OtherDestinationDetails
+        {
+            public string Title { get; set; }
+            public string Author { get; set; }
+        }
+        class Context : DbContext
+        {
+            public Context()
+            {
+                Database.SetInitializer(new DatabaseInitializer());
+            }
+
+            public DbSet<Source> Sources { get; set; }
+        }
+        class DatabaseInitializer : DropCreateDatabaseAlways<Context>
+        {
+            protected override void Seed(Context context)
+            {
+                var source = new Source
+                {
+                    Name = "name",
+                    InnerSources = { new InnerSource { InnerSourceDetails = { new InnerSourceDetails { Description = "description", Publisher = "publisher" } } } },
+                    OtherInnerSources = { new OtherInnerSource { OtherInnerSourceDetails = { new OtherInnerSourceDetails { Title = "title", Author = "author" } } } }
+                };
+                context.Sources.Add(source);
+                base.Seed(context);
+            }
+        }
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>().IncludeMembers(s => s.InnerSources.FirstOrDefault(), s => s.OtherInnerSources.FirstOrDefault());
+            cfg.CreateMap<InnerSource, Destination>(MemberList.None).ForMember(d => d.Details, o => o.MapFrom(s => s.InnerSourceDetails.FirstOrDefault()));
+            cfg.CreateMap<OtherInnerSource, Destination>(MemberList.None).ForMember(d => d.OtherDetails, o => o.MapFrom(s => s.OtherInnerSourceDetails.FirstOrDefault()));
+            cfg.CreateMap<InnerSourceDetails, DestinationDetails>();
+            cfg.CreateMap<OtherInnerSourceDetails, OtherDestinationDetails>();
+        });
+        [Fact]
+        public void Should_flatten()
+        {
+            using (var context = new Context())
+            {
+                var projectTo = ProjectTo<Destination>(context.Sources);
+                FirstOrDefaultCounter.Assert(projectTo, 4);
+                var result = projectTo.Single();
+                result.Name.ShouldBe("name");
+                result.Details.Description.ShouldBe("description");
+                result.Details.Publisher.ShouldBe("publisher");
+                result.OtherDetails.Title.ShouldBe("title");
+                result.OtherDetails.Author.ShouldBe("author");
+            }
+        }
+    }
+    public class IncludeMembersSelectFirstOrDefaultWithSubqueryMapFrom : AutoMapperSpecBase
+    {
+        class Source
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public List<InnerSourceWrapper> InnerSourceWrappers { get; set; } = new List<InnerSourceWrapper>();
+            public List<OtherInnerSource> OtherInnerSources { get; set; } = new List<OtherInnerSource>();
+        }
+        class InnerSourceWrapper
+        {
+            public int Id { get; set; }
+            public InnerSource InnerSource { get; set; }
+        }
+        class InnerSource
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public List<InnerSourceDetailsWrapper> InnerSourceDetailsWrapper { get; } = new List<InnerSourceDetailsWrapper>();
+        }
+        class InnerSourceDetailsWrapper
+        {
+            public int Id { get; set; }
+            public InnerSourceDetails InnerSourceDetails { get; set; }
+        }
+        class InnerSourceDetails
+        {
+            public int Id { get; set; }
+            public string Description { get; set; }
+            public string Publisher { get; set; }
+        }
+        class OtherInnerSource
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string Description { get; set; }
+            public List<OtherInnerSourceDetails> OtherInnerSourceDetails { get; } = new List<OtherInnerSourceDetails>();
+        }
+        class OtherInnerSourceDetails
+        {
+            public int Id { get; set; }
+            public string Title { get; set; }
+            public string Author { get; set; }
+        }
+        class Destination
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public DestinationDetails Details { get; set; }
+            public OtherDestinationDetails OtherDetails { get; set; }
+        }
+        class DestinationDetails
+        {
+            public string Description { get; set; }
+            public string Publisher { get; set; }
+        }
+        class OtherDestinationDetails
+        {
+            public string Title { get; set; }
+            public string Author { get; set; }
+        }
+        class Context : DbContext
+        {
+            public Context()
+            {
+                Database.SetInitializer(new DatabaseInitializer());
+            }
+
+            public DbSet<Source> Sources { get; set; }
+        }
+        class DatabaseInitializer : DropCreateDatabaseAlways<Context>
+        {
+            protected override void Seed(Context context)
+            {
+                var source = new Source
+                {
+                    Name = "name",
+                    InnerSourceWrappers = { new InnerSourceWrapper { InnerSource = new InnerSource { InnerSourceDetailsWrapper = { new InnerSourceDetailsWrapper { InnerSourceDetails = new InnerSourceDetails { Description = "description", Publisher = "publisher" } } } } }
+                },
+                    OtherInnerSources = { new OtherInnerSource { OtherInnerSourceDetails = { new OtherInnerSourceDetails { Title = "title", Author = "author" } } } }
+                };
+                context.Sources.Add(source);
+                base.Seed(context);
+            }
+        }
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>().IncludeMembers(s => s.InnerSourceWrappers.Select(s => s.InnerSource).FirstOrDefault(), s => s.OtherInnerSources.Select(s=>s).FirstOrDefault());
+            cfg.CreateMap<InnerSource, Destination>(MemberList.None).ForMember(d => d.Details, o => o.MapFrom(s => s.InnerSourceDetailsWrapper.Select(s => s.InnerSourceDetails).FirstOrDefault()));
+            cfg.CreateMap<OtherInnerSource, Destination>(MemberList.None).ForMember(d => d.OtherDetails, o => o.MapFrom(s => s.OtherInnerSourceDetails.Select(s => s).FirstOrDefault()));
+            cfg.CreateMap<InnerSourceDetails, DestinationDetails>();
+            cfg.CreateMap<OtherInnerSourceDetails, OtherDestinationDetails>();
+        });
+        [Fact]
+        public void Should_flatten()
+        {
+            using (var context = new Context())
+            {
+                var projectTo = ProjectTo<Destination>(context.Sources);
+                FirstOrDefaultCounter.Assert(projectTo, 4);
+                var result = projectTo.Single();
+                result.Name.ShouldBe("name");
+                result.Details.Description.ShouldBe("description");
+                result.Details.Publisher.ShouldBe("publisher");
+                result.OtherDetails.Title.ShouldBe("title");
+                result.OtherDetails.Author.ShouldBe("author");
+            }
+        }
+    }
+    public class SubqueryMapFromWithIncludeMembersFirstOrDefault : AutoMapperSpecBase
+    {
+        class Source
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public List<InnerSource> InnerSources { get; set; } = new List<InnerSource>();
+            public List<OtherInnerSource> OtherInnerSources { get; set; } = new List<OtherInnerSource>();
+        }
+        class InnerSource
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public List<InnerSourceDetails> InnerSourceDetails { get; } = new List<InnerSourceDetails>();
+        }
+        class InnerSourceDetails
+        {
+            public int Id { get; set; }
+            public string Description { get; set; }
+            public string Publisher { get; set; }
+        }
+        class OtherInnerSource
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string Description { get; set; }
+            public List<OtherInnerSourceDetails> OtherInnerSourceDetails { get; } = new List<OtherInnerSourceDetails>();
+        }
+        class OtherInnerSourceDetails
+        {
+            public int Id { get; set; }
+            public string Title { get; set; }
+            public string Author { get; set; }
+        }
+        class Destination
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public DestinationDetails Details { get; set; }
+            public OtherDestinationDetails OtherDetails { get; set; }
+        }
+        class DestinationDetails
+        {
+            public string Description { get; set; }
+            public string Publisher { get; set; }
+        }
+        class OtherDestinationDetails
+        {
+            public string Title { get; set; }
+            public string Author { get; set; }
+        }
+        class Context : DbContext
+        {
+            public Context()
+            {
+                Database.SetInitializer(new DatabaseInitializer());
+            }
+
+            public DbSet<Source> Sources { get; set; }
+        }
+        class DatabaseInitializer : DropCreateDatabaseAlways<Context>
+        {
+            protected override void Seed(Context context)
+            {
+                var source = new Source
+                {
+                    Name = "name",
+                    InnerSources = { new InnerSource { InnerSourceDetails = { new InnerSourceDetails { Description = "description", Publisher = "publisher" } } } },
+                    OtherInnerSources = { new OtherInnerSource { OtherInnerSourceDetails = { new OtherInnerSourceDetails { Title = "title", Author = "author" } } } }
+                };
+                context.Sources.Add(source);
+                base.Seed(context);
+            }
+        }
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>()
+                .ForMember(d => d.Details, o => o.MapFrom(s => s.InnerSources.FirstOrDefault()))
+                .ForMember(d => d.OtherDetails, o => o.MapFrom(s => s.OtherInnerSources.FirstOrDefault()));
+            cfg.CreateMap<InnerSource, DestinationDetails>().IncludeMembers(s => s.InnerSourceDetails.FirstOrDefault());
+            cfg.CreateMap<OtherInnerSource, OtherDestinationDetails>().IncludeMembers(s => s.OtherInnerSourceDetails.FirstOrDefault());
+            cfg.CreateMap<InnerSourceDetails, DestinationDetails>();
+            cfg.CreateMap<OtherInnerSourceDetails, OtherDestinationDetails>();
+        });
+        [Fact]
+        public void Should_flatten()
+        {
+            using (var context = new Context())
+            {
+                var projectTo = ProjectTo<Destination>(context.Sources);
+                FirstOrDefaultCounter.Assert(projectTo, 6);
+                var result = projectTo.Single();
+                result.Name.ShouldBe("name");
+                result.Details.Description.ShouldBe("description");
+                result.Details.Publisher.ShouldBe("publisher");
+                result.OtherDetails.Title.ShouldBe("title");
+                result.OtherDetails.Author.ShouldBe("author");
+            }
+        }
+    }
+    public class SubqueryMapFromWithIncludeMembersSelectFirstOrDefault : AutoMapperSpecBase
+    {
+        class Source
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public List<InnerSource> InnerSources { get; set; } = new List<InnerSource>();
+            public List<OtherInnerSource> OtherInnerSources { get; set; } = new List<OtherInnerSource>();
+        }
+        class InnerSource
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public List<InnerSourceDetails> InnerSourceDetails { get; } = new List<InnerSourceDetails>();
+        }
+        class InnerSourceDetails
+        {
+            public int Id { get; set; }
+            public string Description { get; set; }
+            public string Publisher { get; set; }
+        }
+        class OtherInnerSource
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string Description { get; set; }
+            public List<OtherInnerSourceDetails> OtherInnerSourceDetails { get; } = new List<OtherInnerSourceDetails>();
+        }
+        class OtherInnerSourceDetails
+        {
+            public int Id { get; set; }
+            public string Title { get; set; }
+            public string Author { get; set; }
+        }
+        class Destination
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public DestinationDetails Details { get; set; }
+            public OtherDestinationDetails OtherDetails { get; set; }
+        }
+        class DestinationDetails
+        {
+            public string Description { get; set; }
+            public string Publisher { get; set; }
+        }
+        class OtherDestinationDetails
+        {
+            public string Title { get; set; }
+            public string Author { get; set; }
+        }
+        class Context : DbContext
+        {
+            public Context()
+            {
+                Database.SetInitializer(new DatabaseInitializer());
+            }
+
+            public DbSet<Source> Sources { get; set; }
+        }
+        class DatabaseInitializer : DropCreateDatabaseAlways<Context>
+        {
+            protected override void Seed(Context context)
+            {
+                var source = new Source
+                {
+                    Name = "name",
+                    InnerSources = { new InnerSource { InnerSourceDetails = { new InnerSourceDetails { Description = "description", Publisher = "publisher" } } } },
+                    OtherInnerSources = { new OtherInnerSource { OtherInnerSourceDetails = { new OtherInnerSourceDetails { Title = "title", Author = "author" } } } }
+                };
+                context.Sources.Add(source);
+                base.Seed(context);
+            }
+        }
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>()
+                .ForMember(d => d.Details, o => o.MapFrom(s => s.InnerSources.Select(s => s).FirstOrDefault()))
+                .ForMember(d => d.OtherDetails, o => o.MapFrom(s => s.OtherInnerSources.Select(s => s).FirstOrDefault()));
+            cfg.CreateMap<InnerSource, DestinationDetails>().IncludeMembers(s => s.InnerSourceDetails.Select(s => s).FirstOrDefault());
+            cfg.CreateMap<OtherInnerSource, OtherDestinationDetails>().IncludeMembers(s => s.OtherInnerSourceDetails.Select(s => s).FirstOrDefault());
+            cfg.CreateMap<InnerSourceDetails, DestinationDetails>();
+            cfg.CreateMap<OtherInnerSourceDetails, OtherDestinationDetails>();
+        });
+        [Fact]
+        public void Should_flatten()
+        {
+            using (var context = new Context())
+            {
+                var projectTo = ProjectTo<Destination>(context.Sources);
+                FirstOrDefaultCounter.Assert(projectTo, 6);
+                var result = projectTo.Single();
+                result.Name.ShouldBe("name");
+                result.Details.Description.ShouldBe("description");
+                result.Details.Publisher.ShouldBe("publisher");
+                result.OtherDetails.Title.ShouldBe("title");
+                result.OtherDetails.Author.ShouldBe("author");
+            }
+        }
+    }
+    public class SubqueryMapFromWithIncludeMembersSelectMemberFirstOrDefault : AutoMapperSpecBase
+    {
+        class Source
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public List<InnerSourceWrapper> InnerSourceWrappers { get; set; } = new List<InnerSourceWrapper>();
+            public List<OtherInnerSource> OtherInnerSources { get; set; } = new List<OtherInnerSource>();
+        }
+        class InnerSourceWrapper
+        {
+            public int Id { get; set; }
+            public InnerSource InnerSource { get; set; }
+        }
+        class InnerSource
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public List<InnerSourceDetailsWrapper> InnerSourceDetailsWrapper { get; } = new List<InnerSourceDetailsWrapper>();
+        }
+        class InnerSourceDetailsWrapper
+        {
+            public int Id { get; set; }
+            public InnerSourceDetails InnerSourceDetails { get; set; }
+        }
+        class InnerSourceDetails
+        {
+            public int Id { get; set; }
+            public string Description { get; set; }
+            public string Publisher { get; set; }
+        }
+        class OtherInnerSource
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string Description { get; set; }
+            public List<OtherInnerSourceDetails> OtherInnerSourceDetails { get; } = new List<OtherInnerSourceDetails>();
+        }
+        class OtherInnerSourceDetails
+        {
+            public int Id { get; set; }
+            public string Title { get; set; }
+            public string Author { get; set; }
+        }
+        class Destination
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public DestinationDetails Details { get; set; }
+            public OtherDestinationDetails OtherDetails { get; set; }
+        }
+        class DestinationDetails
+        {
+            public string Description { get; set; }
+            public string Publisher { get; set; }
+        }
+        class OtherDestinationDetails
+        {
+            public string Title { get; set; }
+            public string Author { get; set; }
+        }
+        class Context : DbContext
+        {
+            public Context()
+            {
+                Database.SetInitializer(new DatabaseInitializer());
+            }
+
+            public DbSet<Source> Sources { get; set; }
+        }
+        class DatabaseInitializer : DropCreateDatabaseAlways<Context>
+        {
+            protected override void Seed(Context context)
+            {
+                var source = new Source
+                {
+                    Name = "name",
+                    InnerSourceWrappers = { new InnerSourceWrapper { InnerSource = new InnerSource { InnerSourceDetailsWrapper = { new InnerSourceDetailsWrapper { InnerSourceDetails = new InnerSourceDetails { Description = "description", Publisher = "publisher" } } } } }
+                },
+                    OtherInnerSources = { new OtherInnerSource { OtherInnerSourceDetails = { new OtherInnerSourceDetails { Title = "title", Author = "author" } } } }
+                };
+                context.Sources.Add(source);
+                base.Seed(context);
+            }
+        }
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>()
+                .ForMember(d => d.Details, o => o.MapFrom(s => s.InnerSourceWrappers.Select(s => s.InnerSource).FirstOrDefault()))
+                .ForMember(d => d.OtherDetails, o => o.MapFrom(s => s.OtherInnerSources.Select(s => s).FirstOrDefault()));
+            cfg.CreateMap<InnerSource, DestinationDetails>().IncludeMembers(s => s.InnerSourceDetailsWrapper.Select(s => s.InnerSourceDetails).FirstOrDefault());
+            cfg.CreateMap<OtherInnerSource, OtherDestinationDetails>().IncludeMembers(s => s.OtherInnerSourceDetails.Select(s => s).FirstOrDefault());
+            cfg.CreateMap<InnerSourceDetails, DestinationDetails>();
+            cfg.CreateMap<OtherInnerSourceDetails, OtherDestinationDetails>();
+        });
+        [Fact]
+        public void Should_flatten()
+        {
+            using (var context = new Context())
+            {
+                var projectTo = ProjectTo<Destination>(context.Sources);
+                FirstOrDefaultCounter.Assert(projectTo, 6);
+                var result = projectTo.Single();
+                result.Name.ShouldBe("name");
+                result.Details.Description.ShouldBe("description");
+                result.Details.Publisher.ShouldBe("publisher");
+                result.OtherDetails.Title.ShouldBe("title");
+                result.OtherDetails.Author.ShouldBe("author");
+            }
+        }
+    }
     public class IncludeMembersWithMapFromExpression : AutoMapperSpecBase
     {
         class Source
@@ -206,6 +882,73 @@ namespace AutoMapper.IntegrationTests
             using(var context = new Context())
             {
                 var result = ProjectTo<Destination>(context.Sources).Single();
+                result.Name.ShouldBe("name");
+                result.Code.ShouldBe(5);
+                result.OtherCode.ShouldBe(7);
+            }
+        }
+    }
+    public class IncludeMembersMembersFirstOrDefaultWithNullSubstitute : AutoMapperSpecBase
+    {
+        class Source
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public List<InnerSource> InnerSources { get; set; } = new List<InnerSource>();
+            public List<OtherInnerSource> OtherInnerSources { get; set; } = new List<OtherInnerSource>();
+        }
+        class InnerSource
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public int? Code { get; set; }
+        }
+        class OtherInnerSource
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public int? Code { get; set; }
+            public int? OtherCode { get; set; }
+        }
+        class Destination
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public int Code { get; set; }
+            public int OtherCode { get; set; }
+        }
+        class Context : DbContext
+        {
+            public Context()
+            {
+                Database.SetInitializer(new DatabaseInitializer());
+            }
+
+            public DbSet<Source> Sources { get; set; }
+        }
+        class DatabaseInitializer : DropCreateDatabaseAlways<Context>
+        {
+            protected override void Seed(Context context)
+            {
+                var source = new Source { Name = "name" };
+                context.Sources.Add(source);
+                base.Seed(context);
+            }
+        }
+        protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
+        {
+            cfg.CreateMap<Source, Destination>().IncludeMembers(s => s.InnerSources.FirstOrDefault(), s => s.OtherInnerSources.FirstOrDefault());
+            cfg.CreateMap<InnerSource, Destination>(MemberList.None).ForMember(d => d.Code, o => o.NullSubstitute(5));
+            cfg.CreateMap<OtherInnerSource, Destination>(MemberList.None).ForMember(d => d.OtherCode, o => o.NullSubstitute(7));
+        });
+        [Fact]
+        public void Should_flatten()
+        {
+            using (var context = new Context())
+            {
+                var projectTo = ProjectTo<Destination>(context.Sources);
+                FirstOrDefaultCounter.Assert(projectTo, 2);
+                var result = projectTo.Single();
                 result.Name.ShouldBe("name");
                 result.Code.ShouldBe(5);
                 result.OtherCode.ShouldBe(7);

--- a/src/UnitTests/AutoMapperSpecBase.cs
+++ b/src/UnitTests/AutoMapperSpecBase.cs
@@ -4,6 +4,7 @@ using Xunit;
 namespace AutoMapper.UnitTests
 {
     using QueryableExtensions;
+    using Shouldly;
     using System.Collections.Generic;
     using System.Linq;
     using System.Linq.Expressions;
@@ -74,6 +75,23 @@ namespace AutoMapper.UnitTests
             Cleanup();
         }
     }
-
+    class FirstOrDefaultCounter : ExpressionVisitor
+    {
+        public int Count;
+        protected override Expression VisitMethodCall(MethodCallExpression node)
+        {
+            if (node.Method.Name == "FirstOrDefault")
+            {
+                Count++;
+            }
+            return base.VisitMethodCall(node);
+        }
+        public static void Assert(IQueryable queryable, int count) => Assert(queryable.Expression, count);
+        public static void Assert(Expression expression, int count)
+        {
+            var firstOrDefault = new FirstOrDefaultCounter();
+            firstOrDefault.Visit(expression);
+            firstOrDefault.Count.ShouldBe(count);
+        }
+    }
 }
-

--- a/src/UnitTests/BasicFlattening.cs
+++ b/src/UnitTests/BasicFlattening.cs
@@ -126,11 +126,11 @@ namespace AutoMapper.UnitTests
         }
         public class Data
         {
-            public int? Value { get; set; }
+            public int? Integer { get; set; }
         }
         public class Destination
         {
-            public int? ParentDataValue { get; set; }
+            public int? ParentDataInteger { get; set; }
         }
 
         protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>
@@ -146,7 +146,7 @@ namespace AutoMapper.UnitTests
         [Fact]
         public void Should_handle_inner_nulls()
         {
-            _destination.ParentDataValue.ShouldBeNull();
+            _destination.ParentDataInteger.ShouldBeNull();
         }
     }
 

--- a/src/UnitTests/ForAllMembers.cs
+++ b/src/UnitTests/ForAllMembers.cs
@@ -1,54 +1,85 @@
-﻿namespace AutoMapper.UnitTests
+﻿using System;
+using Shouldly;
+using Xunit;
+
+namespace AutoMapper.UnitTests.ForAllMembers
 {
-    namespace ForAllMembers
+    public class When_conditionally_applying_a_resolver_globally : AutoMapperSpecBase
     {
-        using System;
-        using Shouldly;
-        using Xunit;
-
-        public class When_conditionally_applying_a_resolver_globally : AutoMapperSpecBase
+        public class Source
         {
-            public class Source
+            public DateTime SomeDate { get; set; }
+            public DateTime OtherDate { get; set; }
+        }
+
+        public class Dest
+        {
+            public DateTime SomeDate { get; set; }
+            public DateTime OtherDate { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+        {
+            cfg.ForAllPropertyMaps(pm => pm.DestinationName.StartsWith("Other"),
+                (pm, opt) => opt.MapFrom(typeof(ConditionalValueResolver), pm.SourceMember.Name));
+
+            cfg.CreateMap<Source, Dest>();
+        });
+
+        public class ConditionalValueResolver : IMemberValueResolver<object, object, DateTime, DateTime>
+        {
+            public DateTime Resolve(object s, object d, DateTime source, DateTime destination, ResolutionContext context)
             {
-                public DateTime SomeDate { get; set; }
-                public DateTime OtherDate { get; set; }
+                return source.AddDays(1);
             }
+        }
 
-            public class Dest
+        [Fact]
+        public void Should_use_resolver()
+        {
+            var source = new Source
             {
-                public DateTime SomeDate { get; set; }
-                public DateTime OtherDate { get; set; }
+                SomeDate = new DateTime(2000, 1, 1),
+                OtherDate = new DateTime(2000, 1, 1),
+            };
+            var dest = Mapper.Map<Source, Dest>(source);
+
+            dest.SomeDate.ShouldBe(source.SomeDate);
+            dest.OtherDate.ShouldBe(source.OtherDate.AddDays(1));
+        }
+    }
+    public class When_conditionally_applying_a_resolver_per_profile : AutoMapperSpecBase
+    {
+        public class Source
+        {
+            public DateTime SomeDate { get; set; }
+            public DateTime OtherDate { get; set; }
+        }
+        public class Dest
+        {
+            public DateTime SomeDate { get; set; }
+            public DateTime OtherDate { get; set; }
+        }
+        class MyProfile : Profile
+        {
+            public MyProfile()
+            {
+                CreateMap<Source, Dest>();
+                ForAllPropertyMaps(pm => pm.DestinationName.StartsWith("Other"), (pm, opt) => opt.MapFrom(typeof(ConditionalValueResolver), pm.SourceMember.Name));
             }
-
-            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
-            {
-                cfg.ForAllPropertyMaps(pm => pm.DestinationName.StartsWith("Other"), 
-                    (pm, opt) => opt.MapFrom(typeof(ConditionalValueResolver), pm.SourceMember.Name));
-
-                cfg.CreateMap<Source, Dest>();
-            });
-
-            public class ConditionalValueResolver : IMemberValueResolver<object, object, DateTime, DateTime>
-            {
-                public DateTime Resolve(object s, object d, DateTime source, DateTime destination, ResolutionContext context)
-                {
-                    return source.AddDays(1);
-                }
-            }
-
-            [Fact]
-            public void Should_use_resolver()
-            {
-                var source = new Source
-                {
-                    SomeDate = new DateTime(2000, 1, 1),
-                    OtherDate = new DateTime(2000, 1, 1),
-                };
-                var dest = Mapper.Map<Source, Dest>(source);
-
-                dest.SomeDate.ShouldBe(source.SomeDate);
-                dest.OtherDate.ShouldBe(source.OtherDate.AddDays(1));
-            }
+        }
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => cfg.AddProfile<MyProfile>());
+        public class ConditionalValueResolver : IMemberValueResolver<object, object, DateTime, DateTime>
+        {
+            public DateTime Resolve(object s, object d, DateTime source, DateTime destination, ResolutionContext context) => source.AddDays(1);
+        }
+        [Fact]
+        public void Should_use_resolver()
+        {
+            var source = new Source { SomeDate = new DateTime(2000, 1, 1), OtherDate = new DateTime(2000, 1, 1) };
+            var dest = Mapper.Map<Source, Dest>(source);
+            dest.SomeDate.ShouldBe(source.SomeDate);
+            dest.OtherDate.ShouldBe(source.OtherDate.AddDays(1));
         }
     }
 }

--- a/src/UnitTests/Internal/PrimitiveExtensionsTester.cs
+++ b/src/UnitTests/Internal/PrimitiveExtensionsTester.cs
@@ -6,7 +6,11 @@ using Shouldly;
 
 namespace AutoMapper.UnitTests
 {
+    using AutoMapper.Internal;
     using Configuration;
+    using System;
+    using System.Linq;
+    using System.Linq.Expressions;
 
     public class PrimitiveExtensionsTester
     {
@@ -28,6 +32,14 @@ namespace AutoMapper.UnitTests
         public void Should_find_explicitly_implemented_member()
         {
             PrimitiveHelper.GetFieldOrProperty(typeof(DestinationClass), "Value").ShouldNotBeNull();
+        }
+
+        [Fact]
+        public void GetMembersChain()
+        {
+            Expression<Func<DateTime, DayOfWeek>> e = x => x.Date.AddDays(1).Date.AddHours(2).AddMinutes(2).Date.DayOfWeek;
+            var chain = e.GetMembersChain().Select(m => m.Name).ToArray();
+            chain.ShouldBe(new[] { "Date", "AddDays", "Date", "AddHours", "AddMinutes", "Date", "DayOfWeek" });
         }
     }
 }


### PR DESCRIPTION
The idea is to cache the included members. In a variable for `Map` and in a let clause for `ProjectTo`. I guess _any_ expression doesn't necessarily sound like a good idea. We'll see :)