### PR TITLE
Trim keys when mapping from dictionaries

### DIFF
--- a/src/AutoMapper/Mappers/FromStringDictionaryMapper.cs
+++ b/src/AutoMapper/Mappers/FromStringDictionaryMapper.cs
@@ -45,7 +45,7 @@ namespace AutoMapper.Mappers
             {
                 if (match.sourceNames.Count() > 1)
                 {
-                    throw new InvalidOperationException($"Multiple matching keys were found in the source dictionary for {match.member.Name}.");
+                    throw new AutoMapperMappingException($"Multiple matching keys were found in the source dictionary for destination member {match.member}.", null, new TypePair(typeof(StringDictionary), typeof(TDestination)));
                 }
 
                 var value = context.MapMember(match.member, source[match.sourceNames.First()], boxedDestination);

--- a/src/UnitTests/Mappers/StringDictionaryMapperTests.cs
+++ b/src/UnitTests/Mappers/StringDictionaryMapperTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Shouldly;
 using Xunit;
 using StringDictionary = System.Collections.Generic.Dictionary<string, object>;
@@ -158,7 +159,7 @@ namespace AutoMapper.UnitTests.Mappers
             Should.Throw<AutoMapperMappingException>(() =>
             {
                 Mapper.Map<Destination>(_source);
-            });
+            }).InnerException.ShouldBeOfType<AutoMapperMappingException>().Types.ShouldBe(new TypePair(typeof(IDictionary<string, object>), typeof(Destination)));
         }
     }
 

--- a/src/UnitTests/Mappers/StringDictionaryMapperTests.cs
+++ b/src/UnitTests/Mappers/StringDictionaryMapperTests.cs
@@ -120,7 +120,49 @@ namespace AutoMapper.UnitTests.Mappers
         }
     }
 
-    public class When_mapping_from_StringDictionary_to_StringDictionary: NonValidatingSpecBase
+    public class When_mapping_from_StringDictionary_with_whitespace : NonValidatingSpecBase
+    {
+        Destination _destination;
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => { });
+
+        protected override void Because_of()
+        {
+            var source = new StringDictionary() { { " Foo", "Foo" }, { " Bar", "Bar" }, { " Baz ", 2 } };
+            _destination = Mapper.Map<Destination>(source);
+        }
+
+        [Fact]
+        public void Should_map()
+        {
+            _destination.Foo.ShouldBe("Foo");
+            _destination.Bar.ShouldBe("Bar");
+            _destination.Baz.ShouldBe(2);
+        }
+    }
+
+    public class When_mapping_from_StringDictionary_prefer_shortest : NonValidatingSpecBase
+    {
+        Destination _destination;
+
+        protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => { });
+
+        protected override void Because_of()
+        {
+            var source = new StringDictionary() { { "Foo", "Foo0" }, { " Foo", "Foo1" }, { "  Foo", "Foo2" }, { "Bar", "Bar" }, { "Baz", 2 } };
+            _destination = Mapper.Map<Destination>(source);
+        }
+
+        [Fact]
+        public void Should_map_with_closest_match()
+        {
+            _destination.Foo.ShouldBe("Foo0");
+            _destination.Bar.ShouldBe("Bar");
+            _destination.Baz.ShouldBe(2);
+        }
+    }
+
+    public class When_mapping_from_StringDictionary_to_StringDictionary : NonValidatingSpecBase
     {
         StringDictionary _destination;
 
@@ -128,7 +170,7 @@ namespace AutoMapper.UnitTests.Mappers
 
         protected override void Because_of()
         {
-            var source = new StringDictionary() { { "Foo", "Foo" }, { "Bar", "Bar" } };
+            var source = new StringDictionary() { { "Foo", "Foo" }, { "Bar", "Bar" }, { "Bar ", "Bar_" } };
             _destination = Mapper.Map<StringDictionary>(source);
         }
 
@@ -137,6 +179,7 @@ namespace AutoMapper.UnitTests.Mappers
         {
             _destination["Foo"].ShouldBe("Foo");
             _destination["Bar"].ShouldBe("Bar");
+            _destination["Bar "].ShouldBe("Bar_");
         }
     }
 
@@ -248,10 +291,9 @@ namespace AutoMapper.UnitTests.Mappers
         [Fact]
         public void Should_throw()
         {
-            new Action(()=>Mapper.Map<SomeBase>(new StringDictionary()))
-                .ShouldThrowException<AutoMapperMappingException>(ex=>
+            new Action(() => Mapper.Map<SomeBase>(new StringDictionary()))
+                .ShouldThrowException<AutoMapperMappingException>(ex =>
                     ex.InnerException.Message.ShouldStartWith($"Cannot create an instance of abstract type {typeof(SomeBase)}."));
-
         }
     }
 }

--- a/src/UnitTests/Mappers/StringDictionaryMapperTests.cs
+++ b/src/UnitTests/Mappers/StringDictionaryMapperTests.cs
@@ -141,24 +141,24 @@ namespace AutoMapper.UnitTests.Mappers
         }
     }
 
-    public class When_mapping_from_StringDictionary_prefer_shortest : NonValidatingSpecBase
+    public class When_mapping_from_StringDictionary_multiple_matching_keys : NonValidatingSpecBase
     {
-        Destination _destination;
+        StringDictionary _source;
 
         protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg => { });
 
         protected override void Because_of()
         {
-            var source = new StringDictionary() { { "Foo", "Foo0" }, { " Foo", "Foo1" }, { "  Foo", "Foo2" }, { "Bar", "Bar" }, { "Baz", 2 } };
-            _destination = Mapper.Map<Destination>(source);
+            _source = new StringDictionary() { { "Foo", "Foo0" }, { " Foo", "Foo1" }, { "  Foo", "Foo2" }, { "Bar", "Bar" }, { "Baz", 2 } };
         }
 
         [Fact]
-        public void Should_map_with_closest_match()
+        public void Should_throw_when_mapping()
         {
-            _destination.Foo.ShouldBe("Foo0");
-            _destination.Bar.ShouldBe("Bar");
-            _destination.Baz.ShouldBe(2);
+            Should.Throw<AutoMapperMappingException>(() =>
+            {
+                Mapper.Map<Destination>(_source);
+            });
         }
     }
 


### PR DESCRIPTION
- Now when mapping from string dictionaries keys surrounded with white-spaces are considered
  - Preferring the one with the least amount of white-spaces, when multiple entries are present
- Added matching tests

Fixes #3483 