### PR TITLE
Ignore static constructors

### DIFF
--- a/src/AutoMapper/Internal/TypeExtensions.cs
+++ b/src/AutoMapper/Internal/TypeExtensions.cs
@@ -55,7 +55,7 @@ namespace AutoMapper.Internal
 
         public static Type GetTypeDefinitionIfGeneric(this Type type) => type.IsGenericType ? type.GetGenericTypeDefinition() : type;
 
-        public static IEnumerable<ConstructorInfo> GetDeclaredConstructors(this Type type) => type.GetTypeInfo().DeclaredConstructors;
+        public static IEnumerable<ConstructorInfo> GetDeclaredConstructors(this Type type) => type.GetTypeInfo().DeclaredConstructors.Where(c=>!c.IsStatic);
 
         public static Type[] GetGenericParameters(this Type type) => type.GetGenericTypeDefinition().GetTypeInfo().GenericTypeParameters;
 

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -122,7 +122,7 @@ namespace AutoMapper
             || DestinationTypeToUse.IsAbstract
             || DestinationTypeToUse.IsGenericTypeDefinition
             || DestinationTypeToUse.IsValueType
-            || DestinationTypeDetails.Constructors.FirstOrDefault(c => !c.IsStatic && c.GetParameters().All(p => p.IsOptional)) != null;
+            || DestinationTypeDetails.Constructors.FirstOrDefault(c => c.GetParameters().All(p => p.IsOptional)) != null;
 
         public bool IsConstructorMapping =>
             CustomCtorExpression == null

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -122,7 +122,7 @@ namespace AutoMapper
             || DestinationTypeToUse.IsAbstract
             || DestinationTypeToUse.IsGenericTypeDefinition
             || DestinationTypeToUse.IsValueType
-            || DestinationTypeDetails.Constructors.FirstOrDefault(c => c.GetParameters().All(p => p.IsOptional)) != null;
+            || DestinationTypeDetails.Constructors.FirstOrDefault(c => !c.IsStatic && c.GetParameters().All(p => p.IsOptional)) != null;
 
         public bool IsConstructorMapping =>
             CustomCtorExpression == null

--- a/src/UnitTests/ShouldUseConstructor.cs
+++ b/src/UnitTests/ShouldUseConstructor.cs
@@ -163,10 +163,8 @@ namespace AutoMapper.UnitTests
         {
             public string B { get; }
 
-
             static Destination()
             {
-
             }
 
             public Destination(string b)

--- a/src/UnitTests/ShouldUseConstructor.cs
+++ b/src/UnitTests/ShouldUseConstructor.cs
@@ -157,7 +157,7 @@ namespace AutoMapper.UnitTests
             new MapperConfiguration(cfg => { cfg.CreateMap<Source, Destination>(); });
     }
 
-    public class ShouldIgnorePresenceOfStaticConstructor : NonValidatingSpecBase
+    public class ShouldIgnoreExplicitStaticConstructor : NonValidatingSpecBase
     {
         class Destination
         {

--- a/src/UnitTests/ShouldUseConstructor.cs
+++ b/src/UnitTests/ShouldUseConstructor.cs
@@ -131,7 +131,6 @@ namespace AutoMapper.UnitTests
         }
     }
 
-
     public class ShouldUseConstructorDefault : AutoMapperSpecBase
     {
         class Destination
@@ -156,5 +155,68 @@ namespace AutoMapper.UnitTests
 
         protected override MapperConfiguration Configuration { get; } =
             new MapperConfiguration(cfg => { cfg.CreateMap<Source, Destination>(); });
+    }
+
+    public class ShouldIgnorePresenceOfStaticConstructor : NonValidatingSpecBase
+    {
+        class Destination
+        {
+            public string B { get; }
+
+
+            static Destination()
+            {
+
+            }
+
+            public Destination(string b)
+            {
+                B = b;
+            }
+        }
+
+        class Source
+        {
+            public string A { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } = 
+            new MapperConfiguration(cfg => { cfg.CreateMap<Source, Destination>(); });
+
+        [Fact]
+        public void Should_ignore_static_constructor()
+        {
+            Should.Throw<AutoMapperConfigurationException>(() =>
+                Configuration.AssertConfigurationIsValid());
+        }
+    }
+
+    public class ShouldIgnoreImplicitStaticConstructor : NonValidatingSpecBase
+    {
+        class Destination
+        {
+            public static string C { get; } = "C";
+            public string B { get; }
+
+            public Destination(string b)
+            {
+                B = b;
+            }
+        }
+
+        class Source
+        {
+            public string A { get; set; }
+        }
+
+        protected override MapperConfiguration Configuration { get; } =
+            new MapperConfiguration(cfg => { cfg.CreateMap<Source, Destination>(); });
+
+        [Fact]
+        public void Should_ignore_implicit_static_constructor()
+        {
+            Should.Throw<AutoMapperConfigurationException>(() =>
+                Configuration.AssertConfigurationIsValid());
+        }
     }
 }


### PR DESCRIPTION
This should fix calls to AssertConfigurationIsValid when using constructor mapping for classes with static constructors

Fixes #3476.
