### PR TITLE
Global pre and postfixes

### DIFF
--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -56,31 +56,17 @@ namespace AutoMapper
             AllPropertyMapActions = profile.AllPropertyMapActions.Concat(configuration?.AllPropertyMapActions ?? Enumerable.Empty<Action<PropertyMap, IMemberConfigurationExpression>>()).ToArray();
             AllTypeMapActions = profile.AllTypeMapActions.Concat(configuration?.AllTypeMapActions ?? Enumerable.Empty<Action<TypeMap, IMappingExpression>>()).ToArray();
 
-            Prefixes =
-                profile.MemberConfigurations
-                    .Concat(configuration?.MemberConfigurations ?? Enumerable.Empty<IMemberConfiguration>())
-                    .Select(m => m.NameMapper)
-                    .SelectMany(m => m.NamedMappers)
-                    .OfType<PrePostfixName>()
-                    .SelectMany(m => m.Prefixes)
-                    .Distinct()
-                    .ToList();
-
-            Postfixes =
-                profile.MemberConfigurations
-                    .Concat(configuration?.MemberConfigurations ?? Enumerable.Empty<IMemberConfiguration>())
-                    .Select(m => m.NameMapper)
-                    .SelectMany(m => m.NamedMappers)
-                    .OfType<PrePostfixName>()
-                    .SelectMany(m => m.Postfixes)
-                    .Distinct()
-                    .ToList();
+            var prePostFixes = profile.MemberConfigurations.Concat(configuration?.MemberConfigurations ?? Enumerable.Empty<IMemberConfiguration>())
+                                        .Select(m => m.NameMapper)
+                                        .SelectMany(m => m.NamedMappers)
+                                        .OfType<PrePostfixName>()
+                                        .ToArray();
+            Prefixes = prePostFixes.SelectMany(m => m.Prefixes).Distinct().ToList();
+            Postfixes = prePostFixes.SelectMany(m => m.Postfixes).Distinct().ToList();
 
             _typeMapConfigs = profile.TypeMapConfigs.ToArray();
             _openTypeMapConfigs = profile.OpenTypeMapConfigs.ToArray();
         }
-
-
         public bool AllowNullCollections { get; }
         public bool AllowNullDestinationValues { get; }
         public bool ConstructorMappingEnabled { get; }

--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -58,18 +58,22 @@ namespace AutoMapper
 
             Prefixes =
                 profile.MemberConfigurations
+                    .Concat(configuration?.MemberConfigurations ?? Enumerable.Empty<IMemberConfiguration>())
                     .Select(m => m.NameMapper)
                     .SelectMany(m => m.NamedMappers)
                     .OfType<PrePostfixName>()
                     .SelectMany(m => m.Prefixes)
+                    .Distinct()
                     .ToList();
 
             Postfixes =
                 profile.MemberConfigurations
+                    .Concat(configuration?.MemberConfigurations ?? Enumerable.Empty<IMemberConfiguration>())
                     .Select(m => m.NameMapper)
                     .SelectMany(m => m.NamedMappers)
                     .OfType<PrePostfixName>()
                     .SelectMany(m => m.Postfixes)
+                    .Distinct()
                     .ToList();
 
             _typeMapConfigs = profile.TypeMapConfigs.ToArray();

--- a/src/UnitTests/MemberResolution.cs
+++ b/src/UnitTests/MemberResolution.cs
@@ -1228,6 +1228,57 @@ namespace AutoMapper.UnitTests
             }
         }
 
+        public class When_source_members_configured_in_a_root_profile_contain_prefixes : AutoMapperSpecBase
+        {
+            private Destination _destination;
+
+            public class Source
+            {
+                public int FooValue { get; set; }
+                public int GetOtherValue()
+                {
+                    return 10;
+                }
+            }
+
+            public class Destination
+            {
+                public int Value { get; set; }
+                public int OtherValue { get; set; }
+            }
+
+            public class ChildProfile : Profile
+            {
+                public ChildProfile()
+                {
+                    CreateMap<Source, Destination>();
+                }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.RecognizePrefixes("Foo");
+                cfg.AddProfile<ChildProfile>();                
+            });
+
+            protected override void Because_of()
+            {
+                _destination = Mapper.Map<Source, Destination>(new Source { FooValue = 5 });
+            }
+
+            [Fact]
+            public void Registered_prefixes_ignored()
+            {
+                _destination.Value.ShouldBe(5);
+            }
+
+            [Fact]
+            public void Default_prefix_included()
+            {
+                _destination.OtherValue.ShouldBe(10);
+            }
+        }
+
         public class When_source_members_contain_prefixes : AutoMapperSpecBase
         {
             private Destination _destination;
@@ -1357,6 +1408,59 @@ namespace AutoMapper.UnitTests
                 _destination.OtherValue.ShouldBe(10);
             }
         }
+
+        public class When_source_members_configured_in_a_root_profile_contain_postfixes_and_prefixes : AutoMapperSpecBase
+        {
+            private Destination _destination;
+
+            public class Source
+            {
+                public int FooValueBar { get; set; }
+                public int GetOtherValue()
+                {
+                    return 10;
+                }
+            }
+
+            public class Destination
+            {
+                public int Value { get; set; }
+                public int OtherValue { get; set; }
+            }
+
+            public class ChildProfile : Profile
+            {
+                public ChildProfile()
+                {
+                    CreateMap<Source, Destination>();
+                }
+            }
+
+            protected override MapperConfiguration Configuration { get; } = new MapperConfiguration(cfg =>
+            {
+                cfg.RecognizePrefixes("Foo");
+                cfg.RecognizePostfixes("Bar");
+                cfg.AddProfile<ChildProfile>();
+            });
+
+            protected override void Because_of()
+            {
+                _destination = Mapper.Map<Source, Destination>(new Source { FooValueBar = 5 });
+            }
+
+            [Fact]
+            public void Registered_prefixes_ignored()
+            {
+                _destination.Value.ShouldBe(5);
+            }
+
+            [Fact]
+            public void Default_prefix_included()
+            {
+                _destination.OtherValue.ShouldBe(10);
+            }
+        }
+
 
         public class When_source_members_contain_postfixes_and_prefixes : AutoMapperSpecBase
         {


### PR DESCRIPTION
According to [these lines](https://github.com/AutoMapper/AutoMapper/blob/6551613bcae9f391c50d392d94b5e5aad800a27f/src/AutoMapper/ProfileMap.cs#L54), `GlobalIgnores`, `SourceExtensionMethods`, `AllPropertyMapActions` and 
`AllTypeMapActions` of a profile are all concatenated with the global configuration.

`Prefixes` and `Postfixes` are not however, preventing the use of a global pre/postfixes definition.

```csharp
var configuration = new MapperConfiguration(config => {
    // Only effective for maps created directly from config
    config.RecognizePostfixes("Id");
    config.AddProfile<SomeProfile>();
});

class SomeProfile : Profile
{
    public SomeProfile ()
    {
        // One would have to uncomment this line for "Id" postfixes
        // to be recognized while mapping from Source to Destination
        //config.RecognizePostfixes("Id");
        CreateMap<Source, Destination>();
    }

}
```

This PR changes `ProfileMap` to allow such use cases. All tests are passing, but I'm not quite sure of implications regarding `AddMemberConfiguration` calls in `Profile`.