### PR TITLE
NonNullableToNullable

### DIFF
--- a/src/AutoMapper/QueryableExtensions/Impl/AssignableExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/AssignableExpressionBinder.cs
@@ -1,3 +1,4 @@
+using AutoMapper.Internal;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
@@ -12,6 +13,6 @@ namespace AutoMapper.QueryableExtensions.Impl
             => BindAssignableExpression(propertyMap, result);
 
         private static MemberAssignment BindAssignableExpression(PropertyMap propertyMap, ExpressionResolutionResult result) 
-            => Expression.Bind(propertyMap.DestinationMember, result.ResolutionExpression);
+            => Expression.Bind(propertyMap.DestinationMember, ExpressionFactory.ToType(result.ResolutionExpression, propertyMap.DestinationType));
     }
 }

--- a/src/UnitTests/Projection/ProjectionTests.cs
+++ b/src/UnitTests/Projection/ProjectionTests.cs
@@ -7,6 +7,20 @@ using System.Collections.Generic;
 
 namespace AutoMapper.UnitTests.Projection
 {
+    public class NonNullableToNullable : AutoMapperSpecBase
+    {
+        class Source
+        {
+            public int Id { get; set; }
+        }
+        class Destination
+        {
+            public int? Id { get; set; }
+        }
+        protected override MapperConfiguration Configuration => new MapperConfiguration(c=>c.CreateMap<Source, Destination>());
+        [Fact]
+        public void Should_project() => ProjectTo<Destination>(new[] { new Source() }.AsQueryable()).First().Id.ShouldBe(0);
+    }
     public class InMemoryMapObjectPropertyFromSubQuery : AutoMapperSpecBase
     {
         protected override MapperConfiguration Configuration => new MapperConfiguration(cfg =>


### PR DESCRIPTION
Hopefully we don't need to bring back the whole `NullableDestinationExpressionBinder`.
@jbogard If you're not releasing 10.1.1, I should probably move this to my branch.