### PR TITLE
Updated example to work with Simple Injector v5

### DIFF
--- a/docs/Dependency-injection.md
+++ b/docs/Dependency-injection.md
@@ -81,36 +81,23 @@ public class MyRegistrar
         container.RegisterSingleton<IService, SomeService>();
 
         // Automapper
-        container.RegisterSingleton(() => GetMapper(container));
-    }
-
-    private AutoMapper.IMapper GetMapper(Container container)
-    {
-        var mp = container.GetInstance<MapperProvider>();
-        return mp.GetMapper();
+        container.RegisterSingleton(() => MapperProvider.GetMapper(container));
     }
 }
 
-public class MapperProvider
+public static class MapperProvider
 {
-    private readonly Container _container;
-
-    public MapperProvider(Container container)
-    {
-        _container = container;
-    }
-
-    public IMapper GetMapper()
+    public static IMapper GetMapper(Container container)
     {
         var mce = new MapperConfigurationExpression();
-        mce.ConstructServicesUsing(_container.GetInstance);
+        mce.ConstructServicesUsing(container.GetInstance);
 
         mce.AddMaps(typeof(SomeProfile).Assembly);
 
         var mc = new MapperConfiguration(mce);
         mc.AssertConfigurationIsValid();
 
-        IMapper m = new Mapper(mc, t => _container.GetInstance(t));
+        IMapper m = new Mapper(mc, t => container.GetInstance(t));
 
         return m;
     }


### PR DESCRIPTION
The original example doesn't work with the OOTB configuration of Simple Injector v5, because v5 requires all components to be registered, while MapperProvider isn't. This removes the need to resolve MapperProvider and simplifies the code by making MapperProvider static.