### PR TITLE
Downloadable mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,31 @@
-<img src="https://s3.amazonaws.com/automapper/logo.png" alt="AutoMapper">
+A bit of example, howto
 
-[![CI](https://github.com/automapper/automapper/workflows/CI/badge.svg)](https://github.com/automapper/automapper/workflows/CI)
-[![NuGet](http://img.shields.io/nuget/v/AutoMapper.svg)](https://www.nuget.org/packages/AutoMapper/)
-[![MyGet (dev)](https://img.shields.io/myget/automapperdev/v/AutoMapper.svg)](http://myget.org/gallery/automapperdev)
+```c#
+var assemblyName = new AssemblyName { Name = "AssemblyName" };
+var assembly = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave);
 
-### What is AutoMapper?
+var module = assembly.DefineDynamicModule("Module", assemblyFile, true);
+var mappingsType = module.DefineType("MainMappingsType", TypeAttributes.Public | TypeAttributes.Abstract | TypeAttributes.Sealed);
 
-AutoMapper is a simple little library built to solve a deceptively complex problem - getting rid of code that mapped one object to another. This type of code is rather dreary and boring to write, so why not invent a tool to do it for us?
-
-This is the main repository for AutoMapper, but there's more:
-
-* [EF6 Extensions](https://github.com/AutoMapper/AutoMapper.EF6)
-* [IDataReader/Record Extensions](https://github.com/AutoMapper/AutoMapper.Data)
-* [Collection Extensions](https://github.com/AutoMapper/AutoMapper.Collection)
-* [Microsoft DI Extensions](https://github.com/AutoMapper/AutoMapper.Extensions.Microsoft.DependencyInjection)
-* [Expression Mapping](https://github.com/AutoMapper/AutoMapper.Extensions.ExpressionMapping)
-* [Enum Extensions](https://github.com/AutoMapper/AutoMapper.Extensions.EnumMapping)
-
-### How do I get started?
-
-First, configure AutoMapper to know what types you want to map, in the startup of your application:
-
-```csharp
-var configuration = new MapperConfiguration(cfg => 
+MapperConfigurationExpression config = // init;
+config.MustBeGeneratedCompatible = true;
+Pro.MethodBuilderFactory = r =>
 {
-    cfg.CreateMap<Foo, FooDto>();
-    cfg.CreateMap<Bar, BarDto>();
-});
-// only during development, validate your mappings; remove it before release
-configuration.AssertConfigurationIsValid();
-// use DI (http://docs.automapper.org/en/latest/Dependency-injection.html) or create the mapper yourself
-var mapper = configuration.CreateMapper();
-```
-Then in your application code, execute the mappings:
+    // Anything can be there. You can concat two FullName's
+    // if you want to reflect get it, or create a special
+    // method that finds a mapper for given <T1, T2>
+    string name = ConvertMethodToName(r.RequestedTypes);
+    var method = mappingType.DefineMethod(name, MethodAttributes.Public | MethodAttributes.Static);
+    return method;
+};
 
-```csharp
-var fooDto = mapper.Map<FooDto>(foo);
-var barDto = mapper.Map<BarDto>(bar);
-```
+var mapperConfiguration = new MapperConfiguration(config);
+mapperConfiguration.AssertConfigurationIsValid();
+var mapper = mapperConfiguration.CreateMapper();
+mapper.CompileMappings();
 
-Check out the [getting started guide](https://automapper.readthedocs.io/en/latest/Getting-started.html). When you're done there, the [wiki](https://automapper.readthedocs.io/en/latest/) goes in to the nitty-gritty details. If you have questions, you can post them to [Stack Overflow](https://stackoverflow.com/questions/tagged/automapper) or in our [Gitter](https://gitter.im/AutoMapper/AutoMapper).
-
-### Where can I get it?
-
-First, [install NuGet](http://docs.nuget.org/docs/start-here/installing-nuget). Then, install [AutoMapper](https://www.nuget.org/packages/AutoMapper/) from the package manager console:
-
-```
-PM> Install-Package AutoMapper
+assembly.Save(assemblyFile);
 ```
 
-### Do you have an issue?
-
-First check if it's already fixed by trying the [MyGet build](https://automapper.readthedocs.io/en/latest/The-MyGet-build.html).
-
-You might want to know exactly what [your mapping does](https://automapper.readthedocs.io/en/latest/Understanding-your-mapping.html) at runtime.
-
-If you're still running into problems, file an issue above.
-
-### License, etc.
-
-This project has adopted the code of conduct defined by the Contributor Covenant to clarify expected behavior in our community.
-For more information see the [.NET Foundation Code of Conduct](https://dotnetfoundation.org/code-of-conduct).
-
-AutoMapper is Copyright &copy; 2009 [Jimmy Bogard](https://jimmybogard.com) and other contributors under the [MIT license](LICENSE.txt).
-
-### .NET Foundation
-
-This project is supported by the [.NET Foundation](https://dotnetfoundation.org).
+Note, that since it's not compiling in runtime, it dosen't have permissions to access to any of yours private or internal fields or methods.
+You can use internal fields if you specify the [InternalsVisibleToAttribute](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.compilerservices.internalsvisibletoattribute?view=net-5.0) to your assembly.

--- a/src/AutoMapper/Configuration/CtorParamConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/CtorParamConfigurationExpression.cs
@@ -24,10 +24,17 @@ namespace AutoMapper.Configuration
         public void MapFrom<TMember>(Expression<Func<TSource, TMember>> sourceMember) =>
             _ctorParamActions.Add(cpm => cpm.CustomMapExpression = sourceMember);
 
-        public void MapFrom<TMember>(Func<TSource, ResolutionContext, TMember> resolver)
+        public void MapFrom<TMember>(Expression<Func<TSource, ResolutionContext, TMember>> resolver)
         {
-            Expression<Func<TSource, TDestination, TMember, ResolutionContext, TMember>> resolverExpression = (src, dest, destMember, ctxt) => resolver(src, ctxt);
-            _ctorParamActions.Add(cpm => cpm.CustomMapFunction = resolverExpression);
+            ParameterExpression p1 = Expression.Parameter(typeof(TSource));
+            ParameterExpression p2 = Expression.Parameter(typeof(TDestination));
+            ParameterExpression p3 = Expression.Parameter(typeof(TMember));
+            ParameterExpression p4 = Expression.Parameter(typeof(ResolutionContext));
+
+            InvocationExpression inv = Expression.Invoke(resolver, p1, p4);
+            LambdaExpression exp = Expression.Lambda(inv, p1, p2, p3, p4);
+
+            _ctorParamActions.Add(cpm => cpm.CustomMapFunction = exp);
         }
 
         public void MapFrom(string sourceMembersPath)

--- a/src/AutoMapper/Configuration/IConfiguration.cs
+++ b/src/AutoMapper/Configuration/IConfiguration.cs
@@ -5,6 +5,7 @@ namespace AutoMapper.Configuration
 {
     public interface IConfiguration : IProfileConfiguration
     {
+        bool MustBeGeneratedCompatible { get; }
         Func<Type, object> ServiceCtor { get; }
         IEnumerable<IProfileConfiguration> Profiles { get; }
     }

--- a/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Reflection.Emit;
 using AutoMapper.Features;
 using AutoMapper.Mappers;
 
@@ -11,12 +12,17 @@ namespace AutoMapper.Configuration
     {
         private readonly IList<Profile> _profiles = new List<Profile>();
 
-        public MapperConfigurationExpression() : base()
+        public MapperConfigurationExpression(bool mustBeGeneratedCompatible = false)
         {
+            MustBeGeneratedCompatible = mustBeGeneratedCompatible;
             IncludeSourceExtensionMethods(typeof(Enumerable));
 
             Mappers = MapperRegistry.Mappers();
         }
+
+        public bool MustBeGeneratedCompatible { get; set; }
+
+        public Func<MapRequest, MethodBuilder> MethodBuilderFactory { get; set; }
 
         public IEnumerable<IProfileConfiguration> Profiles => _profiles;
         public Func<Type, object> ServiceCtor { get; private set; } = Activator.CreateInstance;

--- a/src/AutoMapper/Configuration/MappingExpressionBase.cs
+++ b/src/AutoMapper/Configuration/MappingExpressionBase.cs
@@ -260,27 +260,28 @@ namespace AutoMapper.Configuration
             return this as TMappingExpression;
         }
 
-        public TMappingExpression BeforeMap(Action<TSource, TDestination> beforeFunction)
+        public TMappingExpression BeforeMap(Expression<Action<TSource, TDestination>> beforeFunction)
         {
             TypeMapActions.Add(tm =>
             {
-                Expression<Action<TSource, TDestination, ResolutionContext>> expr =
-                    (src, dest, ctxt) => beforeFunction(src, dest);
+                var p1 = Parameter(typeof(TSource));
+                var p2 = Parameter(typeof(TDestination));
+                var p3 = Parameter(typeof(ResolutionContext));
 
-                tm.AddBeforeMapAction(expr);
+                var inv = Invoke(beforeFunction, p1, p2);
+                var exp = Lambda(inv, p1, p2, p3);
+
+                tm.AddBeforeMapAction(exp);
             });
 
             return this as TMappingExpression;
         }
 
-        public TMappingExpression BeforeMap(Action<TSource, TDestination, ResolutionContext> beforeFunction)
+        public TMappingExpression BeforeMap(Expression<Action<TSource, TDestination, ResolutionContext>> beforeFunction)
         {
             TypeMapActions.Add(tm =>
             {
-                Expression<Action<TSource, TDestination, ResolutionContext>> expr =
-                    (src, dest, ctxt) => beforeFunction(src, dest, ctxt);
-
-                tm.AddBeforeMapAction(expr);
+                tm.AddBeforeMapAction(beforeFunction);
             });
 
             return this as TMappingExpression;
@@ -288,33 +289,31 @@ namespace AutoMapper.Configuration
 
         public TMappingExpression BeforeMap<TMappingAction>() where TMappingAction : IMappingAction<TSource, TDestination>
         {
-            void BeforeFunction(TSource src, TDestination dest, ResolutionContext ctxt)
-                => ((TMappingAction)ctxt.Options.ServiceCtor(typeof(TMappingAction))).Process(src, dest, ctxt);
-
-            return BeforeMap(BeforeFunction);
+            return BeforeMap((src, dst, ctx) => ((TMappingAction)ctx.Options.ServiceCtor(typeof(TMappingAction))).Process(src, dst, ctx));
         }
 
-        public TMappingExpression AfterMap(Action<TSource, TDestination> afterFunction)
+        public TMappingExpression AfterMap(Expression<Action<TSource, TDestination>> afterFunction)
         {
             TypeMapActions.Add(tm =>
             {
-                Expression<Action<TSource, TDestination, ResolutionContext>> expr =
-                    (src, dest, ctxt) => afterFunction(src, dest);
+                var p1 = Parameter(typeof(TSource));
+                var p2 = Parameter(typeof(TDestination));
+                var p3 = Parameter(typeof(ResolutionContext));
 
-                tm.AddAfterMapAction(expr);
+                var inv = Invoke(afterFunction, p1, p2);
+                var exp = Lambda(inv, p1, p2, p3);
+
+                tm.AddAfterMapAction(exp);
             });
 
             return this as TMappingExpression;
         }
 
-        public TMappingExpression AfterMap(Action<TSource, TDestination, ResolutionContext> afterFunction)
+        public TMappingExpression AfterMap(Expression<Action<TSource, TDestination, ResolutionContext>> afterFunction)
         {
             TypeMapActions.Add(tm =>
             {
-                Expression<Action<TSource, TDestination, ResolutionContext>> expr =
-                    (src, dest, ctxt) => afterFunction(src, dest, ctxt);
-
-                tm.AddAfterMapAction(expr);
+                tm.AddAfterMapAction(afterFunction);
             });
 
             return this as TMappingExpression;
@@ -322,10 +321,7 @@ namespace AutoMapper.Configuration
 
         public TMappingExpression AfterMap<TMappingAction>() where TMappingAction : IMappingAction<TSource, TDestination>
         {
-            void AfterFunction(TSource src, TDestination dest, ResolutionContext ctxt)
-                => ((TMappingAction)ctxt.Options.ServiceCtor(typeof(TMappingAction))).Process(src, dest, ctxt);
-
-            return AfterMap(AfterFunction);
+            return AfterMap((src, dst, ctx) => ((TMappingAction)ctx.Options.ServiceCtor(typeof(TMappingAction))).Process(src, dst, ctx));
         }
 
         public TMappingExpression PreserveReferences()

--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -80,33 +80,43 @@ namespace AutoMapper.Configuration
             PropertyMapActions.Add(pm => pm.ValueResolverConfig = config);
         }
 
-        public void MapFrom<TResult>(Func<TSource, TDestination, TResult> mappingFunction)
+        public void MapFrom<TResult>(Expression<Func<TSource, TDestination, TResult>> mappingFunction)
         {
             PropertyMapActions.Add(pm =>
             {
-                Expression<Func<TSource, TDestination, TMember, ResolutionContext, TResult>> expr = (src, dest, destMember, ctxt) => mappingFunction(src, dest);
+                ParameterExpression p1 = Expression.Parameter(typeof(TSource));
+                ParameterExpression p2 = Expression.Parameter(typeof(TDestination));
+                ParameterExpression p3 = Expression.Parameter(typeof(TMember));
+                ParameterExpression p4 = Expression.Parameter(typeof(ResolutionContext));
 
-                pm.CustomMapFunction = expr;
+                InvocationExpression inv = Expression.Invoke(mappingFunction, p1, p2);
+                LambdaExpression exp = Expression.Lambda(inv, p1, p2, p3, p4);
+                
+                pm.CustomMapFunction = exp;
             });
         }
 
-        public void MapFrom<TResult>(Func<TSource, TDestination, TMember, TResult> mappingFunction)
+        public void MapFrom<TResult>(Expression<Func<TSource, TDestination, TMember, TResult>> mappingFunction)
         {
             PropertyMapActions.Add(pm =>
             {
-                Expression<Func<TSource, TDestination, TMember, ResolutionContext, TResult>> expr = (src, dest, destMember, ctxt) => mappingFunction(src, dest, destMember);
+                ParameterExpression p1 = Expression.Parameter(typeof(TSource));
+                ParameterExpression p2 = Expression.Parameter(typeof(TDestination));
+                ParameterExpression p3 = Expression.Parameter(typeof(TMember));
+                ParameterExpression p4 = Expression.Parameter(typeof(ResolutionContext));
 
-                pm.CustomMapFunction = expr;
+                InvocationExpression inv = Expression.Invoke(mappingFunction, p1, p2, p3);
+                LambdaExpression exp = Expression.Lambda(inv, p1, p2, p3, p4);
+                
+                pm.CustomMapFunction = exp;
             });
         }
 
-        public void MapFrom<TResult>(Func<TSource, TDestination, TMember, ResolutionContext, TResult> mappingFunction)
+        public void MapFrom<TResult>(Expression<Func<TSource, TDestination, TMember, ResolutionContext, TResult>> mappingFunction)
         {
             PropertyMapActions.Add(pm =>
             {
-                Expression<Func<TSource, TDestination, TMember, ResolutionContext, TResult>> expr = (src, dest, destMember, ctxt) => mappingFunction(src, dest, destMember, ctxt);
-
-                pm.CustomMapFunction = expr;
+                pm.CustomMapFunction = mappingFunction;
             });
         }
 
@@ -127,102 +137,139 @@ namespace AutoMapper.Configuration
             PropertyMapActions.Add(pm => pm.MapFrom(sourceMembersPath));
         }
 
-        public void Condition(Func<TSource, TDestination, TMember, TMember, ResolutionContext, bool> condition)
+        public void Condition(Expression<Func<TSource, TDestination, TMember, TMember, ResolutionContext, bool>> condition)
         {
             PropertyMapActions.Add(pm =>
             {
-                Expression<Func<TSource, TDestination, TMember, TMember, ResolutionContext, bool>> expr =
-                    (src, dest, srcMember, destMember, ctxt) => condition(src, dest, srcMember, destMember, ctxt);
-
-                pm.Condition = expr;
+                pm.Condition = condition;
             });
         }
 
-        public void Condition(Func<TSource, TDestination, TMember, TMember, bool> condition)
+        public void Condition(Expression<Func<TSource, TDestination, TMember, TMember, bool>> condition)
         {
             PropertyMapActions.Add(pm =>
             {
-                Expression<Func<TSource, TDestination, TMember, TMember, ResolutionContext, bool>> expr =
-                    (src, dest, srcMember, destMember, ctxt) => condition(src, dest, srcMember, destMember);
+                var src = Expression.Parameter(typeof(TSource));
+                var dst = Expression.Parameter(typeof(TDestination));
+                var mSrc = Expression.Parameter(typeof(TMember));
+                var mDst = Expression.Parameter(typeof(TMember));
+                var ctx = Expression.Parameter(typeof(ResolutionContext));
 
-                pm.Condition = expr;
+                var inv = Expression.Invoke(condition, src, dst, mSrc, mDst);
+                var lmb = Expression.Lambda(inv, src, dst, mSrc, mDst, ctx);
+                
+                pm.Condition = lmb;
             });
         }
 
-        public void Condition(Func<TSource, TDestination, TMember, bool> condition)
+        public void Condition(Expression<Func<TSource, TDestination, TMember, bool>> condition)
         {
             PropertyMapActions.Add(pm =>
             {
-                Expression<Func<TSource, TDestination, TMember, TMember, ResolutionContext, bool>> expr =
-                    (src, dest, srcMember, destMember, ctxt) => condition(src, dest, srcMember);
+                var src = Expression.Parameter(typeof(TSource));
+                var dst = Expression.Parameter(typeof(TDestination));
+                var mSrc = Expression.Parameter(typeof(TMember));
+                var mDst = Expression.Parameter(typeof(TMember));
+                var ctx = Expression.Parameter(typeof(ResolutionContext));
 
-                pm.Condition = expr;
+                var inv = Expression.Invoke(condition, src, dst, mSrc);
+                var lmb = Expression.Lambda(inv, src, dst, mSrc, mDst, ctx);
+
+                pm.Condition = lmb;
             });
         }
 
-        public void Condition(Func<TSource, TDestination, bool> condition)
+        public void Condition(Expression<Func<TSource, TDestination, bool>> condition)
         {
             PropertyMapActions.Add(pm =>
             {
-                Expression<Func<TSource, TDestination, TMember, TMember, ResolutionContext, bool>> expr =
-                    (src, dest, srcMember, destMember, ctxt) => condition(src, dest);
+                var src = Expression.Parameter(typeof(TSource));
+                var dst = Expression.Parameter(typeof(TDestination));
+                var mSrc = Expression.Parameter(typeof(TMember));
+                var mDst = Expression.Parameter(typeof(TMember));
+                var ctx = Expression.Parameter(typeof(ResolutionContext));
 
-                pm.Condition = expr;
+                var inv = Expression.Invoke(condition, src, dst);
+                var lmb = Expression.Lambda(inv, src, dst, mSrc, mDst, ctx);
+                
+                pm.Condition = lmb;
             });
         }
 
-        public void Condition(Func<TSource, bool> condition)
+        public void Condition(Expression<Func<TSource, bool>> condition)
         {
             PropertyMapActions.Add(pm =>
             {
-                Expression<Func<TSource, TDestination, TMember, TMember, ResolutionContext, bool>> expr =
-                    (src, dest, srcMember, destMember, ctxt) => condition(src);
+                var src = Expression.Parameter(typeof(TSource));
+                var dst = Expression.Parameter(typeof(TDestination));
+                var mSrc = Expression.Parameter(typeof(TMember));
+                var mDst = Expression.Parameter(typeof(TMember));
+                var ctx = Expression.Parameter(typeof(ResolutionContext));
 
-                pm.Condition = expr;
+                var inv = Expression.Invoke(condition, src);
+                var lmb = Expression.Lambda(inv, src, dst, mSrc, mDst, ctx);
+                
+                pm.Condition = lmb;
             });
         }
 
-        public void PreCondition(Func<TSource, bool> condition)
+        public void PreCondition(Expression<Func<TSource, bool>> condition)
         {
             PropertyMapActions.Add(pm =>
             {
-                Expression<Func<TSource, TDestination, ResolutionContext, bool>> expr =
-                    (src, dest, ctxt) => condition(src);
+                var src = Expression.Parameter(typeof(TSource));
+                var dst = Expression.Parameter(typeof(TDestination));
+                var ctx = Expression.Parameter(typeof(ResolutionContext));
 
-                pm.PreCondition = expr;
+                var inv = Expression.Invoke(condition, src);
+                var lmb = Expression.Lambda(inv, src, dst, ctx);
+                
+                pm.Condition = lmb;
             });
         }
 
-        public void PreCondition(Func<ResolutionContext, bool> condition)
+        public void PreCondition(Expression<Func<ResolutionContext, bool>> condition)
         {
             PropertyMapActions.Add(pm =>
             {
-                Expression<Func<TSource, TDestination, ResolutionContext, bool>> expr =
-                    (src, dest, ctxt) => condition(ctxt);
+                var src = Expression.Parameter(typeof(TSource));
+                var dst = Expression.Parameter(typeof(TDestination));
+                var ctx = Expression.Parameter(typeof(ResolutionContext));
 
-                pm.PreCondition = expr;
+                var inv = Expression.Invoke(condition, ctx);
+                var lmb = Expression.Lambda(inv, src, dst, ctx);
+                
+                pm.Condition = lmb;
             });
         }
 
-        public void PreCondition(Func<TSource, ResolutionContext, bool> condition)
+        public void PreCondition(Expression<Func<TSource, ResolutionContext, bool>> condition)
         {
             PropertyMapActions.Add(pm =>
             {
-                Expression<Func<TSource, TDestination, ResolutionContext, bool>> expr =
-                    (src, dest, ctxt) => condition(src, ctxt);
+                var src = Expression.Parameter(typeof(TSource));
+                var dst = Expression.Parameter(typeof(TDestination));
+                var ctx = Expression.Parameter(typeof(ResolutionContext));
 
-                pm.PreCondition = expr;
+                var inv = Expression.Invoke(condition, src, ctx);
+                var lmb = Expression.Lambda(inv, src, dst, ctx);
+                
+                pm.Condition = lmb;
             });
         }
 
-        public void PreCondition(Func<TSource, TDestination, ResolutionContext, bool> condition)
+        public void PreCondition(Expression<Func<TSource, TDestination, ResolutionContext, bool>> condition)
         {
             PropertyMapActions.Add(pm =>
             {
-                Expression<Func<TSource, TDestination, ResolutionContext, bool>> expr =
-                    (src, dest, ctxt) => condition(src, dest, ctxt);
+                var src = Expression.Parameter(typeof(TSource));
+                var dst = Expression.Parameter(typeof(TDestination));
+                var ctx = Expression.Parameter(typeof(ResolutionContext));
 
-                pm.PreCondition = expr;
+                var inv = Expression.Invoke(condition, src, dst, ctx);
+                var lmb = Expression.Lambda(inv, src, dst, ctx);
+                
+                pm.Condition = lmb;
             });
         }
 

--- a/src/AutoMapper/ConstructorParameterMap.cs
+++ b/src/AutoMapper/ConstructorParameterMap.cs
@@ -12,7 +12,7 @@ namespace AutoMapper
     public class ConstructorParameterMap : DefaultMemberMap
     {
         public ConstructorParameterMap(TypeMap typeMap, ParameterInfo parameter, IEnumerable<MemberInfo> sourceMembers,
-            bool canResolveValue)
+            bool canResolveValue) : base(typeMap.MustBeDownloadable)
         {
             TypeMap = typeMap;
             Parameter = parameter;

--- a/src/AutoMapper/DefaultMemberMap.cs
+++ b/src/AutoMapper/DefaultMemberMap.cs
@@ -16,9 +16,16 @@ namespace AutoMapper
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class DefaultMemberMap : IMemberMap
     {
-        protected DefaultMemberMap() { }
+        protected DefaultMemberMap(bool mustBeGeneratedCompatible)
+        {
+            MustBeGeneratedCompatible = mustBeGeneratedCompatible;
+        }
 
-        public static readonly IMemberMap Instance = new DefaultMemberMap();
+        public static readonly IMemberMap CompatibleInstance = new DefaultMemberMap(true);
+
+        public static readonly IMemberMap NonCompatibleInstance = new DefaultMemberMap(false);
+
+        public bool MustBeGeneratedCompatible { get; }
 
         public virtual TypeMap TypeMap => default;
         public virtual Type SourceType => default;

--- a/src/AutoMapper/Execution/DelegateFactory.cs
+++ b/src/AutoMapper/Execution/DelegateFactory.cs
@@ -101,8 +101,8 @@ namespace AutoMapper.Execution
 
         private static Expression InvalidType(Type type, string message)
         {
-            var ex = new ArgumentException(message, "type");
-            return Block(Throw(Constant(ex)), Constant(null, type));
+            var constr = typeof(ArgumentException).GetConstructor(new Type[] { typeof(string), typeof(string) });
+            return Block(Throw(New(constr, Constant(message), Constant("type"))), Constant(null, type));
         }
     }
 }

--- a/src/AutoMapper/IConfigurationProvider.cs
+++ b/src/AutoMapper/IConfigurationProvider.cs
@@ -115,6 +115,8 @@ namespace AutoMapper
         IEnumerable<IExpressionBinder> Binders { get; }
 
         int RecursiveQueriesMaxDepth { get; }
+        
+        bool MustBeGeneratedCompatible { get; }
 
         /// <summary>
         /// Create a mapper instance based on this configuration. Mapper instances are lightweight and can be created as needed.

--- a/src/AutoMapper/ICtorParamConfigurationExpression.cs
+++ b/src/AutoMapper/ICtorParamConfigurationExpression.cs
@@ -25,6 +25,6 @@ namespace AutoMapper
         /// </summary>
         /// <remarks>Not used for LINQ projection (ProjectTo)</remarks>
         /// <param name="resolver">Custom func</param>
-        void MapFrom<TMember>(Func<TSource, ResolutionContext, TMember> resolver);
+        void MapFrom<TMember>(Expression<Func<TSource, ResolutionContext, TMember>> resolver);
     }
 }

--- a/src/AutoMapper/IMapper.cs
+++ b/src/AutoMapper/IMapper.cs
@@ -140,7 +140,7 @@ namespace AutoMapper
     public interface IRuntimeMapper : IMapperBase
     {
     }
-    internal interface IInternalRuntimeMapper : IRuntimeMapper
+    public interface IInternalRuntimeMapper : IRuntimeMapper
     {
         TDestination Map<TSource, TDestination>(TSource source, TDestination destination, ResolutionContext context, Type sourceType = null, Type destinationType = null, IMemberMap memberMap = null);
         ResolutionContext DefaultContext { get; }

--- a/src/AutoMapper/IMappingExpressionBase.cs
+++ b/src/AutoMapper/IMappingExpressionBase.cs
@@ -54,7 +54,7 @@ namespace AutoMapper
         /// <remarks>Not used for LINQ projection (ProjectTo)</remarks>
         /// <param name="beforeFunction">Callback for the source/destination types</param>
         /// <returns>Itself</returns>
-        TMappingExpression BeforeMap(Action<TSource, TDestination> beforeFunction);
+        TMappingExpression BeforeMap(Expression<Action<TSource, TDestination>> beforeFunction);
 
         /// <summary>
         /// Execute a custom function to the source and/or destination types before member mapping
@@ -62,7 +62,7 @@ namespace AutoMapper
         /// <remarks>Not used for LINQ projection (ProjectTo)</remarks>
         /// <param name="beforeFunction">Callback for the source/destination types</param>
         /// <returns>Itself</returns>
-        TMappingExpression BeforeMap(Action<TSource, TDestination, ResolutionContext> beforeFunction);
+        TMappingExpression BeforeMap(Expression<Action<TSource, TDestination, ResolutionContext>> beforeFunction);
 
         /// <summary>
         /// Execute a custom mapping action before member mapping
@@ -79,7 +79,7 @@ namespace AutoMapper
         /// <remarks>Not used for LINQ projection (ProjectTo)</remarks>
         /// <param name="afterFunction">Callback for the source/destination types</param>
         /// <returns>Itself</returns>
-        TMappingExpression AfterMap(Action<TSource, TDestination> afterFunction);
+        TMappingExpression AfterMap(Expression<Action<TSource, TDestination>> afterFunction);
 
         /// <summary>
         /// Execute a custom function to the source and/or destination types after member mapping
@@ -87,7 +87,7 @@ namespace AutoMapper
         /// <remarks>Not used for LINQ projection (ProjectTo)</remarks>
         /// <param name="afterFunction">Callback for the source/destination types</param>
         /// <returns>Itself</returns>
-        TMappingExpression AfterMap(Action<TSource, TDestination, ResolutionContext> afterFunction);
+        TMappingExpression AfterMap(Expression<Action<TSource, TDestination, ResolutionContext>> afterFunction);
 
         /// <summary>
         /// Execute a custom mapping action after member mapping

--- a/src/AutoMapper/IMemberConfigurationExpression.cs
+++ b/src/AutoMapper/IMemberConfigurationExpression.cs
@@ -71,21 +71,21 @@ namespace AutoMapper
         /// </summary>
         /// <remarks>Not used for LINQ projection (ProjectTo)</remarks>
         /// <param name="mappingFunction">Function to map to destination member</param>
-        void MapFrom<TResult>(Func<TSource, TDestination, TResult> mappingFunction);
+        void MapFrom<TResult>(Expression<Func<TSource, TDestination, TResult>> mappingFunction);
 
         /// <summary>
         /// Map destination member using a custom function. Access the source, destination object, and destination member.
         /// </summary>
         /// <remarks>Not used for LINQ projection (ProjectTo)</remarks>
         /// <param name="mappingFunction">Function to map to destination member</param>
-        void MapFrom<TResult>(Func<TSource, TDestination, TMember, TResult> mappingFunction);
+        void MapFrom<TResult>(Expression<Func<TSource, TDestination, TMember, TResult>> mappingFunction);
 
         /// <summary>
         /// Map destination member using a custom function. Access the source, destination object, destination member, and context.
         /// </summary>
         /// <remarks>Not used for LINQ projection (ProjectTo)</remarks>
         /// <param name="mappingFunction">Function to map to destination member</param>
-        void MapFrom<TResult>(Func<TSource, TDestination, TMember, ResolutionContext, TResult> mappingFunction);
+        void MapFrom<TResult>(Expression<Func<TSource, TDestination, TMember, ResolutionContext, TResult>> mappingFunction);
 
         /// <summary>
         /// Map destination member using a custom expression. Used in LINQ projection (ProjectTo).
@@ -135,55 +135,55 @@ namespace AutoMapper
         /// Conditionally map this member against the source, destination, source and destination members
         /// </summary>
         /// <param name="condition">Condition to evaluate using the source object</param>
-        void Condition(Func<TSource, TDestination, TMember, TMember, ResolutionContext, bool> condition);
+        void Condition(Expression<Func<TSource, TDestination, TMember, TMember, ResolutionContext, bool>> condition);
 
         /// <summary>
         /// Conditionally map this member
         /// </summary>
         /// <param name="condition">Condition to evaluate using the source object</param>
-        void Condition(Func<TSource, TDestination, TMember, TMember, bool> condition);
+        void Condition(Expression<Func<TSource, TDestination, TMember, TMember, bool>> condition);
 
         /// <summary>
         /// Conditionally map this member
         /// </summary>
         /// <param name="condition">Condition to evaluate using the source object</param>
-        void Condition(Func<TSource, TDestination, TMember, bool> condition);
+        void Condition(Expression<Func<TSource, TDestination, TMember, bool>> condition);
        
         /// <summary>
         /// Conditionally map this member
         /// </summary>
         /// <param name="condition">Condition to evaluate using the source object</param>
-        void Condition(Func<TSource, TDestination, bool> condition);
+        void Condition(Expression<Func<TSource, TDestination, bool>> condition);
        
         /// <summary>
         /// Conditionally map this member
         /// </summary>
         /// <param name="condition">Condition to evaluate using the source object</param>
-        void Condition(Func<TSource, bool> condition);
+        void Condition(Expression<Func<TSource, bool>> condition);
        
         /// <summary>
         /// Conditionally map this member, evaluated before accessing the source value
         /// </summary>
         /// <param name="condition">Condition to evaluate using the source object</param>
-        void PreCondition(Func<TSource, bool> condition);
+        void PreCondition(Expression<Func<TSource, bool>> condition);
 
         /// <summary>
         /// Conditionally map this member, evaluated before accessing the source value
         /// </summary>
         /// <param name="condition">Condition to evaluate using the current resolution context</param>
-        void PreCondition(Func<ResolutionContext, bool> condition);
+        void PreCondition(Expression<Func<ResolutionContext, bool>> condition);
 
         /// <summary>
         /// Conditionally map this member, evaluated before accessing the source value
         /// </summary>
         /// <param name="condition">Condition to evaluate using the source object and the current resolution context</param>
-        void PreCondition(Func<TSource, ResolutionContext, bool> condition);
+        void PreCondition(Expression<Func<TSource, ResolutionContext, bool>> condition);
 
         /// <summary>
         /// Conditionally map this member, evaluated before accessing the source value
         /// </summary>
         /// <param name="condition">Condition to evaluate using the source object, the destination object, and the current resolution context</param>
-        void PreCondition(Func<TSource, TDestination, ResolutionContext, bool> condition);
+        void PreCondition(Expression<Func<TSource, TDestination, ResolutionContext, bool>> condition);
 
         /// <summary>
         /// Ignore this member for LINQ projections unless explicitly expanded during projection

--- a/src/AutoMapper/IMemberMap.cs
+++ b/src/AutoMapper/IMemberMap.cs
@@ -9,6 +9,8 @@ namespace AutoMapper
     [EditorBrowsable(EditorBrowsableState.Never)]
     public interface IMemberMap
     {
+        bool MustBeGeneratedCompatible { get; }
+        
         TypeMap TypeMap { get; }
         Type SourceType { get; }
         IReadOnlyCollection<MemberInfo> SourceMembers { get; }

--- a/src/AutoMapper/IObjectMapper.cs
+++ b/src/AutoMapper/IObjectMapper.cs
@@ -63,14 +63,22 @@ namespace AutoMapper
 
         public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap,
             IMemberMap memberMap, Expression sourceExpression, Expression destExpression,
-            Expression contextExpression) =>
-            Call(
+            Expression contextExpression)
+        {
+            if (profileMap.MustBeGeneratedCompatible)
+            {
+                throw new InvalidOperationException($"Can't use {nameof(ObjectMapper<TSource, TDestination>)} " +
+                                                    $"with {nameof(ProfileMap.MustBeGeneratedCompatible)} flag.");
+            }
+
+            return Call(
                 Constant(this),
                 MapMethod,
                 ToType(sourceExpression, typeof(TSource)),
                 ToType(destExpression, typeof(TDestination)),
-                Constant(sourceExpression.Type),
-                Constant(destExpression.Type),
+                Constant(sourceExpression.Type, typeof(Type)),
+                Constant(destExpression.Type, typeof(Type)),
                 contextExpression);
+        }
     }
 }

--- a/src/AutoMapper/Internal/ReflectionHelper.cs
+++ b/src/AutoMapper/Internal/ReflectionHelper.cs
@@ -49,11 +49,14 @@ namespace AutoMapper.Internal
             return parameter.DefaultValue;
         }
 
-        public static object MapMember(this ResolutionContext context, MemberInfo member, object value, object destination = null)
+        public static object MapMember(this ResolutionContext context, MemberInfo member, object value, bool mustBeGeneratedCompatible, object destination = null)
         {
             var memberType = GetMemberType(member);
             var destValue = destination == null ? null : GetMemberValue(member, destination);
-            return context.Map(value, destValue, value?.GetType() ?? typeof(object), memberType, DefaultMemberMap.Instance);
+            return context.Map(value, destValue, value?.GetType() ?? typeof(object), memberType,
+                mustBeGeneratedCompatible
+                    ? DefaultMemberMap.CompatibleInstance
+                    : DefaultMemberMap.NonCompatibleInstance);
         }
 
         public static void SetMemberValue(this MemberInfo propertyOrField, object target, object value)

--- a/src/AutoMapper/Mappers/EnumToEnumMapper.cs
+++ b/src/AutoMapper/Mappers/EnumToEnumMapper.cs
@@ -13,9 +13,9 @@ namespace AutoMapper.Mappers
         {
             var destinationType = destExpression.Type;
             var sourceToObject = sourceExpression.ToObject();
-            var toObject = Call(typeof(Enum), "ToObject", null, Constant(destinationType), sourceToObject);
+            var toObject = Call(typeof(Enum), "ToObject", Type.EmptyTypes, Constant(destinationType, typeof(Type)), sourceToObject);
             var castToObject = Convert(toObject, destinationType);
-            var isDefined = Call(typeof(Enum), "IsDefined", null, Constant(sourceExpression.Type), sourceToObject);
+            var isDefined = Call(typeof(Enum), "IsDefined", Type.EmptyTypes, Constant(sourceExpression.Type, typeof(Type)), sourceToObject);
             var sourceToString = Call(sourceExpression, "ToString", null);
             var result = Variable(destinationType, "destinationEnumValue");
             var ignoreCase = Constant(true);

--- a/src/AutoMapper/Mappers/FlagsEnumMapper.cs
+++ b/src/AutoMapper/Mappers/FlagsEnumMapper.cs
@@ -21,7 +21,7 @@ namespace AutoMapper.Mappers
             Expression contextExpression) =>
                 ToType(
                     Call(EnumParseMethod,
-                        Constant(destExpression.Type),
+                        Constant(destExpression.Type, typeof(Type)),
                         Call(sourceExpression, sourceExpression.Type.GetRuntimeMethod("ToString", Type.EmptyTypes)),
                         Constant(true)
                     ),

--- a/src/AutoMapper/Mappers/FromDynamicMapper.cs
+++ b/src/AutoMapper/Mappers/FromDynamicMapper.cs
@@ -29,7 +29,7 @@ namespace AutoMapper.Mappers
                 {
                     continue;
                 }
-                var destinationMemberValue = context.MapMember(member, sourceMemberValue, boxedDestination);
+                var destinationMemberValue = context.MapMember(member, sourceMemberValue, profileMap.MustBeGeneratedCompatible, boxedDestination);
                 member.SetMemberValue(boxedDestination, destinationMemberValue);
             }
             return (TDestination) boxedDestination;

--- a/src/AutoMapper/Mappers/FromStringDictionaryMapper.cs
+++ b/src/AutoMapper/Mappers/FromStringDictionaryMapper.cs
@@ -36,7 +36,7 @@ namespace AutoMapper.Mappers
                 {
                     throw new AutoMapperMappingException($"Multiple matching keys were found in the source dictionary for destination member {member}.", null, new TypePair(typeof(StringDictionary), destinationType));
                 }
-                var value = context.MapMember(member, match.Value, boxedDestination);
+                var value = context.MapMember(member, match.Value, profileMap.MustBeGeneratedCompatible, boxedDestination);
                 member.SetMemberValue(boxedDestination, value);
                 matchedCount++;
             }
@@ -70,7 +70,7 @@ namespace AutoMapper.Mappers
                         continue;
                     }
                     var lastMember = innerMembers[innerMembers.Length - 1];
-                    var value = context.MapMember(lastMember, source[memberPath], innerDestination);
+                    var value = context.MapMember(lastMember, source[memberPath], profileMap.MustBeGeneratedCompatible, innerDestination);
                     lastMember.SetMemberValue(innerDestination, value);
                 }
                 return;

--- a/src/AutoMapper/Mappers/MultidimensionalArrayMapper.cs
+++ b/src/AutoMapper/Mappers/MultidimensionalArrayMapper.cs
@@ -47,13 +47,21 @@ namespace AutoMapper.Mappers
 
         public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap,
             IMemberMap memberMap, Expression sourceExpression, Expression destExpression,
-            Expression contextExpression) =>
-            Call(null,
+            Expression contextExpression)
+        {
+            if (profileMap.MustBeGeneratedCompatible)
+            {
+                throw new InvalidOperationException($"Can't use {nameof(MultidimensionalArrayMapper)} " +
+                                                    $"with {nameof(ProfileMap.MustBeGeneratedCompatible)} flag.");
+            }
+
+            return Call(null,
                 MapMethodInfo.MakeGenericMethod(destExpression.Type, sourceExpression.Type,
                     ElementTypeHelper.GetElementType(sourceExpression.Type)),
                 sourceExpression,
                 contextExpression,
                 Constant(configurationProvider));
+        }
 
         public class MultidimensionalArrayFiller
         {

--- a/src/AutoMapper/Mappers/NullableDestinationMapper.cs
+++ b/src/AutoMapper/Mappers/NullableDestinationMapper.cs
@@ -16,6 +16,7 @@ namespace AutoMapper.Mappers
                 new TypePair(sourceExpression.Type, Nullable.GetUnderlyingType(destExpression.Type)),
                 sourceExpression,
                 contextExpression,
+                null,
                 memberMap
             );
 

--- a/src/AutoMapper/Mappers/NullableSourceMapper.cs
+++ b/src/AutoMapper/Mappers/NullableSourceMapper.cs
@@ -18,8 +18,8 @@ namespace AutoMapper.Mappers
                     new TypePair(Nullable.GetUnderlyingType(sourceExpression.Type), destExpression.Type),
                     Property(sourceExpression, sourceExpression.Type.GetProperty("Value")),
                     contextExpression,
-                    memberMap,
-                    destExpression
+                    destExpression,
+                    memberMap
                 );
 
         public TypePair GetAssociatedTypes(TypePair initialTypes)

--- a/src/AutoMapper/Mappers/StringToEnumMapper.cs
+++ b/src/AutoMapper/Mappers/StringToEnumMapper.cs
@@ -19,7 +19,7 @@ namespace AutoMapper.Mappers
             Expression contextExpression)
         {
             var destinationType = destExpression.Type;
-            var enumParse = Expression.Call(typeof(Enum), "Parse", null, Expression.Constant(destinationType),
+            var enumParse = Expression.Call(typeof(Enum), "Parse", null, Expression.Constant(destinationType, typeof(Type)),
                 sourceExpression, Expression.Constant(true));
             var switchCases = new List<SwitchCase>();
             var enumNames = destinationType.GetDeclaredMembers();

--- a/src/AutoMapper/Mappers/ToDynamicMapper.cs
+++ b/src/AutoMapper/Mappers/ToDynamicMapper.cs
@@ -28,7 +28,7 @@ namespace AutoMapper.Mappers
                 {
                     continue;
                 }
-                var destinationMemberValue = context.MapMember(member, sourceMemberValue);
+                var destinationMemberValue = context.MapMember(member, sourceMemberValue, profileMap.MustBeGeneratedCompatible);
                 SetDynamically(member.Name, destination, destinationMemberValue);
             }
             return destination;
@@ -51,8 +51,15 @@ namespace AutoMapper.Mappers
 
         public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap,
             IMemberMap memberMap, Expression sourceExpression, Expression destExpression,
-            Expression contextExpression) =>
-            Call(null,
+            Expression contextExpression)
+        {
+            if (profileMap.MustBeGeneratedCompatible)
+            {
+                throw new InvalidOperationException($"Can't use {nameof(ToDynamicMapper)} " +
+                                                    $"with {nameof(ProfileMap.MustBeGeneratedCompatible)} flag.");
+            }
+
+            return Call(null,
                 MapMethodInfo.MakeGenericMethod(sourceExpression.Type, destExpression.Type),
                 sourceExpression,
                 ToType(
@@ -60,5 +67,6 @@ namespace AutoMapper.Mappers
                         DelegateFactory.GenerateConstructorExpression(destExpression.Type)), destExpression.Type),
                 contextExpression,
                 Constant(profileMap));
+        }
     }
 }

--- a/src/AutoMapper/Mappers/ToStringDictionaryMapper.cs
+++ b/src/AutoMapper/Mappers/ToStringDictionaryMapper.cs
@@ -6,6 +6,7 @@ using AutoMapper.Internal;
 
 namespace AutoMapper.Mappers
 {
+    using System;
     using static Expression;
     using static CollectionMapperExpressionFactory;
 
@@ -18,9 +19,18 @@ namespace AutoMapper.Mappers
 
         public Expression MapExpression(IConfigurationProvider configurationProvider, ProfileMap profileMap,
             IMemberMap memberMap, Expression sourceExpression, Expression destExpression, Expression contextExpression)
-            => MapCollectionExpression(configurationProvider, profileMap, memberMap,
-                Call(MembersDictionaryMethodInfo, sourceExpression, Constant(profileMap)), destExpression, contextExpression, typeof(Dictionary<,>),
+        {
+            if (profileMap.MustBeGeneratedCompatible)
+            {
+                throw new InvalidOperationException($"Can't use {nameof(ToStringDictionaryMapper)} " +
+                                                    $"with {nameof(ProfileMap.MustBeGeneratedCompatible)} flag.");
+            }
+
+            return MapCollectionExpression(configurationProvider, profileMap, memberMap,
+                Call(MembersDictionaryMethodInfo, sourceExpression, Constant(profileMap)), destExpression,
+                contextExpression, typeof(Dictionary<,>),
                 MapKeyPairValueExpr);
+        }
 
         private static Dictionary<string, object> MembersDictionary(object source, ProfileMap profileMap)
         {

--- a/src/AutoMapper/PathMap.cs
+++ b/src/AutoMapper/PathMap.cs
@@ -11,7 +11,8 @@ namespace AutoMapper
     [EditorBrowsable(EditorBrowsableState.Never)]
     public class PathMap : DefaultMemberMap
     {
-        public PathMap(PathMap pathMap, TypeMap typeMap, IncludedMember includedMember) : this(pathMap.DestinationExpression, pathMap.MemberPath, typeMap)
+        public PathMap(PathMap pathMap, TypeMap typeMap, IncludedMember includedMember)
+            : this(pathMap.DestinationExpression, pathMap.MemberPath, typeMap)
         {
             IncludedMember = includedMember.Chain(pathMap.IncludedMember);
             CustomMapExpression = pathMap.CustomMapExpression;
@@ -20,6 +21,7 @@ namespace AutoMapper
         }
 
         public PathMap(LambdaExpression destinationExpression, MemberPath memberPath, TypeMap typeMap)
+            : base(typeMap.MustBeDownloadable)
         {
             MemberPath = memberPath;
             TypeMap = typeMap;

--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -31,6 +31,7 @@ namespace AutoMapper
             _typeDetails = new LockingConcurrentDictionary<Type, TypeDetails>(TypeDetailsFactory);
 
             Name = profile.ProfileName;
+            MustBeGeneratedCompatible = configuration?.MustBeGeneratedCompatible ?? false;
             AllowNullCollections = profile.AllowNullCollections ?? configuration?.AllowNullCollections ?? false;
             AllowNullDestinationValues = profile.AllowNullDestinationValues ?? configuration?.AllowNullDestinationValues ?? true;
             EnableNullPropagationForQueryMapping = profile.EnableNullPropagationForQueryMapping ?? configuration?.EnableNullPropagationForQueryMapping ?? false;
@@ -76,7 +77,7 @@ namespace AutoMapper
             _openTypeMapConfigs = profile.OpenTypeMapConfigs.ToArray();
         }
 
-
+        public bool MustBeGeneratedCompatible { get; set; }
         public bool AllowNullCollections { get; }
         public bool AllowNullDestinationValues { get; }
         public bool ConstructorMappingEnabled { get; }
@@ -170,7 +171,7 @@ namespace AutoMapper
 
         public TypeMap CreateClosedGenericTypeMap(ITypeMapConfiguration openMapConfig, TypePair closedTypes, IConfigurationProvider configurationProvider)
         {
-            var closedMap = TypeMapFactory.CreateTypeMap(closedTypes.SourceType, closedTypes.DestinationType, this);
+            var closedMap = TypeMapFactory.CreateTypeMap(closedTypes.SourceType, closedTypes.DestinationType, this, MustBeGeneratedCompatible);
             closedMap.IsClosedGeneric = true;
             openMapConfig.Configure(closedMap);
 

--- a/src/AutoMapper/PropertyMap.cs
+++ b/src/AutoMapper/PropertyMap.cs
@@ -20,6 +20,7 @@ namespace AutoMapper
         private readonly List<ValueTransformerConfiguration> _valueTransformerConfigs = new List<ValueTransformerConfiguration>();
 
         public PropertyMap(MemberInfo destinationMember, TypeMap typeMap)
+            : base(typeMap.MustBeDownloadable)
         {
             TypeMap = typeMap;
             DestinationMember = destinationMember;

--- a/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
+++ b/src/AutoMapper/QueryableExtensions/ExpressionBuilder.cs
@@ -291,8 +291,10 @@ namespace AutoMapper.QueryableExtensions
 
                 public ConstantExpressionReplacementVisitor(ParameterBag paramValues) => _paramValues = paramValues;
 
-                protected override Expression GetValue(string name) =>
-                    _paramValues.TryGetValue(name, out object parameterValue) ? Constant(parameterValue) : null;
+                protected override Expression GetValue(string name)
+                {
+                    return _paramValues.TryGetValue(name, out object parameterValue) ? Constant(parameterValue) : null;
+                }
             }
         }
         [EditorBrowsable(EditorBrowsableState.Never)]

--- a/src/AutoMapper/QueryableExtensions/Impl/NullableSourceExpressionBinder.cs
+++ b/src/AutoMapper/QueryableExtensions/Impl/NullableSourceExpressionBinder.cs
@@ -11,8 +11,7 @@ namespace AutoMapper.QueryableExtensions
     {
         public MemberAssignment Build(IConfigurationProvider configuration, PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionRequest request, ExpressionResolutionResult result, IDictionary<ExpressionRequest, int> typePairCount, LetPropertyMaps letPropertyMaps)
         {
-            var defaultDestination = Activator.CreateInstance(propertyMap.DestinationType);
-            return Bind(propertyMap.DestinationMember, Coalesce(result.ResolutionExpression, Constant(defaultDestination)));
+            return Bind(propertyMap.DestinationMember, Coalesce(result.ResolutionExpression, New(propertyMap.DestinationType)));
         }
 
         public bool IsMatch(PropertyMap propertyMap, TypeMap propertyTypeMap, ExpressionResolutionResult result) =>

--- a/src/AutoMapper/ResolutionContext.cs
+++ b/src/AutoMapper/ResolutionContext.cs
@@ -13,13 +13,13 @@ namespace AutoMapper
         private Dictionary<TypePair, int> _typeDepth;
         private readonly IInternalRuntimeMapper _inner;
 
-        internal ResolutionContext(IMappingOperationOptions options, IInternalRuntimeMapper mapper)
+        public ResolutionContext(IMappingOperationOptions options, IInternalRuntimeMapper mapper)
         {
             Options = options;
             _inner = mapper;
         }
 
-        internal ResolutionContext(IInternalRuntimeMapper mapper) : this(mapper.DefaultContext.Options, mapper) { }
+        public ResolutionContext(IInternalRuntimeMapper mapper) : this(mapper.DefaultContext.Options, mapper) { }
 
         /// <summary>
         /// Mapping operation options
@@ -70,14 +70,10 @@ namespace AutoMapper
         }
 
         TDestination IMapperBase.Map<TDestination>(object source) => ((IMapperBase)this).Map(source, default(TDestination));
-        TDestination IMapperBase.Map<TSource, TDestination>(TSource source)
-            => _inner.Map(source, default(TDestination), this);
-        TDestination IMapperBase.Map<TSource, TDestination>(TSource source, TDestination destination)
-            => _inner.Map(source, destination, this);
-        object IMapperBase.Map(object source, Type sourceType, Type destinationType)
-            => _inner.Map(source, (object)null, this, sourceType, destinationType);
-        object IMapperBase.Map(object source, object destination, Type sourceType, Type destinationType)
-            => _inner.Map(source, destination, this, sourceType, destinationType);
+        TDestination IMapperBase.Map<TSource, TDestination>(TSource source) => _inner.Map(source, default(TDestination), this);
+        TDestination IMapperBase.Map<TSource, TDestination>(TSource source, TDestination destination) => _inner.Map(source, destination, this);
+        object IMapperBase.Map(object source, Type sourceType, Type destinationType) => _inner.Map(source, (object)null, this, sourceType, destinationType);
+        object IMapperBase.Map(object source, object destination, Type sourceType, Type destinationType) => _inner.Map(source, destination, this, sourceType, destinationType);
         TDestination IInternalRuntimeMapper.Map<TSource, TDestination>(TSource source, TDestination destination, ResolutionContext context,
             Type sourceType, Type destinationType, IMemberMap memberMap)
             => _inner.Map(source, destination, context, sourceType, destinationType, memberMap);

--- a/src/AutoMapper/TypeMap.cs
+++ b/src/AutoMapper/TypeMap.cs
@@ -42,6 +42,8 @@ namespace AutoMapper
             Profile = profile;
         }
 
+        public bool MustBeDownloadable => Profile.MustBeGeneratedCompatible;
+
         private IEnumerable<SourceMemberConfig> SourceMemberConfigs => _sourceMemberConfigs.Values;
 
         public PathMap FindOrCreatePathMapFor(LambdaExpression destinationExpression, MemberPath path, TypeMap typeMap)


### PR DESCRIPTION
#3017

I was a bit late, we have no access to the internet on our work station so it's only for v10.
There is not much work to do for uploading binaries, it may be a bit scuffed, but it works fine in our enviroment.

<details>
<summary>User story</summary>
We used to have a cold start of 1 to 2 minutes because of automapper. This issue also accurred on not so old I5 processors, like 30 seconds. First mapping time was always giving pressure to the CPU and memmory. Ofcourse, we have a lot of entities (more than thousand, i didn't count) and graphs and stuff, but it didn't matter to the workers that have not the powerfulest machines.
</details>