### PR TITLE
Inherited source operators support for ConversionOperatorMapper

### DIFF
--- a/src/AutoMapper/Mappers/ConversionOperatorMapper.cs
+++ b/src/AutoMapper/Mappers/ConversionOperatorMapper.cs
@@ -11,7 +11,7 @@ namespace AutoMapper.Internal.Mappers
         public bool IsMatch(TypePair context) => GetConversionOperator(context.SourceType, context.DestinationType) != null;
         private MethodInfo GetConversionOperator(Type sourceType, Type destinationType)
         {
-            foreach (MethodInfo sourceMethod in sourceType.GetMember(_operatorName, MemberTypes.Method, TypeExtensions.StaticFlags))
+            foreach (MethodInfo sourceMethod in sourceType.GetMember(_operatorName, MemberTypes.Method, (TypeExtensions.StaticFlags & ~BindingFlags.DeclaredOnly) | BindingFlags.FlattenHierarchy))
             {
                 if (destinationType.IsAssignableFrom(sourceMethod.ReturnType))
                 {

--- a/src/AutoMapper/Mappers/ConversionOperatorMapper.cs
+++ b/src/AutoMapper/Mappers/ConversionOperatorMapper.cs
@@ -11,7 +11,7 @@ namespace AutoMapper.Internal.Mappers
         public bool IsMatch(TypePair context) => GetConversionOperator(context.SourceType, context.DestinationType) != null;
         private MethodInfo GetConversionOperator(Type sourceType, Type destinationType)
         {
-            foreach (MethodInfo sourceMethod in sourceType.GetMember(_operatorName, MemberTypes.Method, (TypeExtensions.StaticFlags & ~BindingFlags.DeclaredOnly) | BindingFlags.FlattenHierarchy))
+            foreach (MethodInfo sourceMethod in sourceType.GetMember(_operatorName, MemberTypes.Method, BindingFlags.Static | BindingFlags.Public | BindingFlags.FlattenHierarchy))
             {
                 if (destinationType.IsAssignableFrom(sourceMethod.ReturnType))
                 {

--- a/src/UnitTests/Mappers/ConversionOperators.cs
+++ b/src/UnitTests/Mappers/ConversionOperators.cs
@@ -82,6 +82,9 @@ namespace AutoMapper.UnitTests
 
         }
 
+        public class InheritedFoo : Foo
+        { }
+
         public class Bar
         {
             public string OtherValue { get; set; }
@@ -94,6 +97,17 @@ namespace AutoMapper.UnitTests
 
             var config = new MapperConfiguration(cfg => { });
             _bar = config.CreateMapper().Map<Foo, Bar>(source);
+
+            _bar.OtherValue.ShouldBe("Hello");
+        }
+
+        [Fact]
+        public void Should_use_the_inherited_implicit_conversion_operator()
+        {
+            var source = new InheritedFoo { Value = "Hello" };
+
+            var config = new MapperConfiguration(cfg => { });
+            _bar = config.CreateMapper().Map<InheritedFoo, Bar>(source);
 
             _bar.OtherValue.ShouldBe("Hello");
         }
@@ -147,6 +161,9 @@ namespace AutoMapper.UnitTests
             }
         }
 
+        public class InheritedFoo : Foo
+        { }
+
         public class Bar
         {
             public string OtherValue { get; set; }
@@ -157,6 +174,17 @@ namespace AutoMapper.UnitTests
         {
             var config = new MapperConfiguration(cfg => { });
             _bar = config.CreateMapper().Map<Foo, Bar>(new Foo { Value = "Hello" });
+            _bar.OtherValue.ShouldBe("Hello");
+        }
+
+        [Fact]
+        public void Should_use_the_inherited_implicit_conversion_operator()
+        {
+            var source = new InheritedFoo { Value = "Hello" };
+
+            var config = new MapperConfiguration(cfg => { });
+            _bar = config.CreateMapper().Map<InheritedFoo, Bar>(source);
+
             _bar.OtherValue.ShouldBe("Hello");
         }
     }

--- a/src/UnitTests/Mappers/ConversionOperators.cs
+++ b/src/UnitTests/Mappers/ConversionOperators.cs
@@ -178,7 +178,7 @@ namespace AutoMapper.UnitTests
         }
 
         [Fact]
-        public void Should_use_the_inherited_implicit_conversion_operator()
+        public void Should_use_the_inherited_explicit_conversion_operator()
         {
             var source = new InheritedFoo { Value = "Hello" };
 


### PR DESCRIPTION
This PR adds support for inherited operators conversion from the source type. Conversion operators on the destination type do not apply here (the operator needs to be about the enclosing type).

I used a modified value of [TypeExtensions.StaticFlags](https://github.com/AutoMapper/AutoMapper/blob/bdc0120497d192a2741183415543f6119f50a982/src/AutoMapper/Internal/TypeExtensions.cs#L12) in the same idea as [this line](https://github.com/AutoMapper/AutoMapper/blob/bdc0120497d192a2741183415543f6119f50a982/src/AutoMapper/Internal/TypeExtensions.cs#L16) to match already existing code.

For instance with these changes, such use case works out of the box.

```csharp
public class IntValue
{
    public IntValue(int value)
    {
        Value = value;
    }

    public int Value { get; }

    public static explicit operator int(IntValue intValue)
        => intValue.Value;
}

public class SomethingId : IntValue
{
    public SomethingId(int value)
        : base(value)
    { }
}
```

```csharp
var mapper = new MapperConfiguration(_ => {}).CreateMapper();
mapper.Map<int>(new SomethingId(3)); // works without further configuration
```

See https://github.com/AutoMapper/AutoMapper/discussions/3722