### PR TITLE
Add GetProjectionExpression method to IConfigurationProvider

### DIFF
--- a/src/AutoMapper/Configuration/MapperConfiguration.cs
+++ b/src/AutoMapper/Configuration/MapperConfiguration.cs
@@ -47,6 +47,14 @@ namespace AutoMapper
         /// Use if you want AutoMapper to compile all mappings up front instead of deferring expression compilation for each first map.
         /// </summary>
         void CompileMappings();
+
+        /// <summary>
+        /// Gets the projection expression which can then be fed into any expression capable data store regardless of IQueryable compatibility
+        /// </summary>
+        /// <typeparam name="TSource">Source type</typeparam>
+        /// <typeparam name="TDestination">Destination type</typeparam>
+        /// <returns>The underlying projection expression</returns>
+        Expression<Func<TSource, TDestination>> GetProjectionExpression<TSource, TDestination>();
     }
     public class MapperConfiguration : IGlobalConfiguration
     {
@@ -125,6 +133,10 @@ namespace AutoMapper
                 GetExecutionPlan(request);
             }
         }
+
+        public Expression<Func<TSource, TDestination>> GetProjectionExpression<TSource, TDestination>() =>
+            this.Internal().ProjectionBuilder.GetMapExpression<TSource, TDestination>();
+
         public LambdaExpression BuildExecutionPlan(Type sourceType, Type destinationType)
         {
             var typePair = new TypePair(sourceType, destinationType);


### PR DESCRIPTION
ProjectTo is nice but what is really needed is access to the underlying Expression<Func<TSource, TDestination>> which can then simply be passed into whatever expression capable API without having the encumbrance of IQueryable.

For example in Mongo you can pass projection expressions into their IFindFluent interface.  Even if you use the IMongoQueryable interface you have to cast it back to IMongoQueryable after you call ProjectTo.  This removes those barriers and makes using the projection capabilities easier and in a data store agnostic manner.