### PR TITLE
Mention that IncludeMembers doesn't do runtime mapping

### DIFF
--- a/docs/Mapping-inheritance.md
+++ b/docs/Mapping-inheritance.md
@@ -65,6 +65,12 @@ Assert.IsType<OnlineOrderDto>(mapped);
 
 You will notice that because the mapped object is a OnlineOrder, AutoMapper has seen you have a more specific mapping for OnlineOrder than OrderDto, and automatically chosen that.
 
+Note that this does not apply to situations where the mapping happens at configuration time, like `IncludeMembers` does. To get the runtime-mapping behavior in that case, a solution is to use `AfterMap`:
+```c#
+CreateMap<Source, Destination>()
+    .AfterMap((source, destination, context) => context.Mapper.Map(source.InnerSource, destination));
+```
+
 ## Specifying inheritance in derived classes
 
 Instead of configuring inheritance from the base class, you can specify inheritance from the derived classes:


### PR DESCRIPTION
Applying the learnings from https://stackoverflow.com/questions/63292509/map-class-with-abstract-property-to-destination/63304821?noredirect=1#answer-63304821