### PR TITLE
Instantiation of Mapper object was missing

### DIFF
--- a/docs/Flattening.md
+++ b/docs/Flattening.md
@@ -90,6 +90,7 @@ var configuration = new MapperConfiguration(cfg => cfg.CreateMap<Order, OrderDto
 
 // Perform mapping
 
+var mapper = new Mapper(configuration);
 OrderDto dto = mapper.Map<Order, OrderDto>(order);
 
 dto.CustomerName.ShouldEqual("George Costanza");


### PR DESCRIPTION
The instantiation of the mapper class for mapping the OrderDto was missing in the example.