### PR TITLE
Support multiple .NET Frameworks (add net6.0)

### DIFF
--- a/src/AutoMapper/AutoMapper.csproj
+++ b/src/AutoMapper/AutoMapper.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Summary>A convention-based object-object mapper.</Summary>
     <Description>A convention-based object-object mapper.</Description>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netstandard2.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>AutoMapper</AssemblyName>
     <AssemblyOriginatorKeyFile>..\..\AutoMapper.snk</AssemblyOriginatorKeyFile>
@@ -36,11 +36,14 @@
     <None Include="..\..\README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="MinVer" Version="2.5.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="7.0.0-beta.22074.1" PrivateAssets="All" />  
+    <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="7.0.0-beta.22074.1" PrivateAssets="All" />
   </ItemGroup>
 
   <Target Name="PreBuild" AfterTargets="GetAssemblyVersion">

--- a/src/AutoMapper/Configuration/Profile.cs
+++ b/src/AutoMapper/Configuration/Profile.cs
@@ -186,7 +186,7 @@ namespace AutoMapper
         {
             _sourceExtensionMethods ??= new();
             _sourceExtensionMethods.AddRange(
-                type.GetMethods(TypeExtensions.StaticFlags).Where(m => m.GetParameters().Length == 1 && m.Has<ExtensionAttribute>()));
+                type.GetMethods(Internal.TypeExtensions.StaticFlags).Where(m => m.GetParameters().Length == 1 && m.Has<ExtensionAttribute>()));
         }
     }
 }


### PR DESCRIPTION
Right now it only targets netstandard2.1 and makes it dependent on: Microsoft.CSharp (>= 4.7.0).

That dependency is very old (2019): https://www.nuget.org/packages/Microsoft.CSharp/#versions-body-tab

As of .net5.0+ it is no longer needed so it can be removed.

In our case this dependency is a problem because it has dependencies of packages of System.* 4.3 that have **vulnerabilities** that obviously we do not want.