### PR TITLE
EF inheritance is not supported

### DIFF
--- a/docs/Queryable-Extensions.md
+++ b/docs/Queryable-Extensions.md
@@ -223,4 +223,4 @@ Not supported:
 * Value converters
 * **Any calculated property on your domain object**
 
-Additionally, recursive or self-referencing destination types are not supported as LINQ providers do not support this. Typically hierarchical relational data models require common table expressions (CTEs) to correctly resolve a recursive join.
+Additionally, recursive or self-referencing destination types are not supported as LINQ providers do not support this. Typically hierarchical relational data models require common table expressions (CTEs) to correctly resolve a recursive join. Finally, EntityFramework (Core) inheritance is also not supported, as it is not supported by LINQ.


### PR DESCRIPTION
I recently stumbled into a limitation of `ProjectTo` that has been [reported several times](https://github.com/AutoMapper/AutoMapper/issues?q=is%3Aissue+projectto+inheritance+is%3Aclosed). However the documentation doesn't address this and this should resolve any future confusion.

Note:
The line endings in the file are mixed, that's why my diff shows additional 'changes'. These were created by GitHub:

> We’ve detected the file has mixed line endings. When you commit changes we will normalize them to Windows-style (`CR` `LF`).