### PR TITLE
Replace Expression.Default with Expression.Constant

### DIFF
--- a/src/AutoMapper/Execution/ExpressionBuilder.cs
+++ b/src/AutoMapper/Execution/ExpressionBuilder.cs
@@ -6,11 +6,20 @@ using static Internal.ReflectionHelper;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public static class ExpressionBuilder
 {
+    public static object GetDefault(this Type type)
+    {
+        if (type.IsValueType)
+        {
+            return Activator.CreateInstance(type);
+        }
+        return null;
+    }
+
     public static readonly MethodInfo ObjectToString = typeof(object).GetMethod(nameof(object.ToString));
     public static readonly Expression True = Constant(true, typeof(bool));
-    public static readonly Expression Null = Expression.Default(typeof(object));
+    public static readonly Expression Null = Expression.Constant(typeof(object).GetDefault(), typeof(object));
     public static readonly Expression Empty = Empty();
-    public static readonly Expression Zero = Expression.Default(typeof(int));
+    public static readonly Expression Zero = Expression.Constant(typeof(int).GetDefault(), typeof(int)); 
     public static readonly ParameterExpression ExceptionParameter = Parameter(typeof(Exception), "ex");
     public static readonly ParameterExpression ContextParameter = Parameter(typeof(ResolutionContext), "context");
     public static readonly MethodInfo IListClear = typeof(IList).GetMethod(nameof(IList.Clear));
@@ -35,8 +44,8 @@ public static class ExpressionBuilder
         configuration.ConvertParameterReplaceVisitor().Replace(initialLambda, newParameter);
     public static Expression ConvertReplaceParameters(this IGlobalConfiguration configuration, LambdaExpression initialLambda, Expression[] newParameters) =>
         configuration.ConvertParameterReplaceVisitor().Replace(initialLambda, newParameters);
-    public static DefaultExpression Default(this IGlobalConfiguration configuration, Type type) =>
-        configuration == null ? Expression.Default(type) : configuration.GetDefault(type);
+    public static ConstantExpression Default(this IGlobalConfiguration configuration, Type type) =>
+        configuration == null ? Expression.Constant(type.GetDefault(), type) : configuration.GetDefault(type);
     public static (List<ParameterExpression> Variables, List<Expression> Expressions) Scratchpad(this IGlobalConfiguration configuration)
     {
         var variables = configuration?.Variables;

--- a/src/AutoMapper/Internal/InternalApi.cs
+++ b/src/AutoMapper/Internal/InternalApi.cs
@@ -155,7 +155,7 @@ public interface IGlobalConfiguration : IConfigurationProvider
     List<Expression> Expressions { get; }
     HashSet<TypeMap> TypeMapsPath { get; }
     CatchBlock[] Catches { get; }
-    DefaultExpression GetDefault(Type type);
+    ConstantExpression GetDefault(Type type);
     ParameterReplaceVisitor ParameterReplaceVisitor();
     ConvertParameterReplaceVisitor ConvertParameterReplaceVisitor();
 }

--- a/src/AutoMapper/QueryableExtensions/NullsafeQueryRewriter.cs
+++ b/src/AutoMapper/QueryableExtensions/NullsafeQueryRewriter.cs
@@ -103,7 +103,7 @@ internal class NullsafeQueryRewriter : ExpressionVisitor
 
         // expression can be default or null, which is basically the same...
         var expressionFallback = !IsNullableOrReferenceType(expression.Type)
-            ? (Expression)Default(expression.Type) : Constant(null, expression.Type);
+            ? (Expression)Expression.Constant(expression.Type.GetDefault(), expression.Type) : Constant(null, expression.Type);
 
         return Condition(Equal(target, targetFallback), expressionFallback, expression);
     }


### PR DESCRIPTION
This is a change to resolve the issues in https://github.com/AutoMapper/AutoMapper/discussions/4265

Essentially it replaces Expression.Default with a hopefully equivalent Expression.Constant.

Seems to work. Passes tests.