### PR TITLE
Use `TryAdd` in `OpenTypeMapConfigs`

### DIFF
--- a/src/AutoMapper/ProfileMap.cs
+++ b/src/AutoMapper/ProfileMap.cs
@@ -61,11 +61,11 @@ public class ProfileMap
             _openTypeMapConfigs = new(profile.OpenTypeMapConfigs.Count);
             foreach (var openTypeMapConfig in profile.OpenTypeMapConfigs)
             {
-                _openTypeMapConfigs.Add(openTypeMapConfig.Types, openTypeMapConfig);
+                _openTypeMapConfigs.TryAdd(openTypeMapConfig.Types, openTypeMapConfig);
                 var reverseMap = openTypeMapConfig.ReverseTypeMap;
                 if (reverseMap != null)
                 {
-                    _openTypeMapConfigs.Add(reverseMap.Types, reverseMap);
+                    _openTypeMapConfigs.TryAdd(reverseMap.Types, reverseMap);
                 }
             }
         }


### PR DESCRIPTION
Summary of the changes
 - Use `TryAdd` when adding to `OpenTypeMapConfigs`, to prevent exception being thrown when not calling `AssertConfigurationIsValid`. 
 