### PR TITLE
add options to disable and override ExplicitExpansion

### DIFF
--- a/src/AutoMapper/Configuration/CtorParamConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/CtorParamConfigurationExpression.cs
@@ -9,7 +9,8 @@ public interface ICtorParamConfigurationExpression
     /// <summary>
     /// Ignore this member for LINQ projections unless explicitly expanded during projection
     /// </summary>
-    void ExplicitExpansion();
+    /// <param name="explicitExpansion">Is explicitExpansion active</param>
+    void ExplicitExpansion(Boolean explicitExpansion = true);
 }
 public interface ICtorParamConfigurationExpression<TSource> : ICtorParamConfigurationExpression
 {
@@ -61,7 +62,7 @@ public class CtorParamConfigurationExpression<TSource, TDestination> : ICtorPara
         _ctorParamActions.Add(cpm => cpm.MapFrom(sourceMembersPath, sourceMembers));
     }
 
-    public void ExplicitExpansion() => _ctorParamActions.Add(cpm => cpm.ExplicitExpansion = true);
+    public void ExplicitExpansion(Boolean explicitExpansion = true) => _ctorParamActions.Add(cpm => cpm.ExplicitExpansion = explicitExpansion);
 
     public void Configure(TypeMap typeMap)
     {

--- a/src/AutoMapper/Configuration/IMemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/IMemberConfigurationExpression.cs
@@ -290,7 +290,9 @@ public interface IProjectionMemberConfiguration<TSource, TDestination, TMember>
     /// <summary>
     /// Ignore this member for LINQ projections unless explicitly expanded during projection
     /// </summary>
-    void ExplicitExpansion();
+    /// <param name="explicitExpansion">Is explicitExpansion active</param>
+    /// <param name="overrideExpansion">Does explicitExpansion can override settings already set by another ExplicitExpansion call</param>
+    void ExplicitExpansion(Boolean explicitExpansion = true, Boolean overrideExpansion = true);
     /// <summary>
     /// Apply a transformation function after any resolved destination member value with the given type
     /// </summary>

--- a/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MemberConfigurationExpression.cs
@@ -80,7 +80,7 @@ public class MemberConfigurationExpression<TSource, TDestination, TMember> : IMe
         PropertyMapActions.Add(pm => pm.PreCondition = expr);
     public void AddTransform(Expression<Func<TMember, TMember>> transformer) =>
         PropertyMapActions.Add(pm => pm.AddValueTransformation(new ValueTransformerConfiguration(pm.DestinationType, transformer)));
-    public void ExplicitExpansion() => PropertyMapActions.Add(pm => pm.ExplicitExpansion = true);
+    public void ExplicitExpansion(Boolean explicitExpansion = true, Boolean overrideExpansion = true) => PropertyMapActions.Add(pm => pm.ExplicitExpansion = overrideExpansion || pm.ExplicitExpansion == null ? explicitExpansion : pm.ExplicitExpansion);
     public void Ignore() => Ignore(ignorePaths: true);
     public void Ignore(bool ignorePaths)
     {

--- a/src/IntegrationTests/ExplicitExpansion/DisableExplicitExpansion.cs
+++ b/src/IntegrationTests/ExplicitExpansion/DisableExplicitExpansion.cs
@@ -1,0 +1,130 @@
+﻿using System.Text.RegularExpressions;
+
+namespace AutoMapper.IntegrationTests.ExplicitExpansion;
+
+public class DisableExplicitExpansion : IntegrationTest<DisableExplicitExpansion.DatabaseInitializer>
+{
+    public class Source
+    {   [Key, DatabaseGenerated(DatabaseGeneratedOption.None)]
+        public Int32 Desc { get; set; }
+        public String Name { get; set; }
+        public String Code { get; set; }
+    }
+    public class DtoWithoutOverride
+    {
+        public String Name { get; set; }
+        public String Code { get; set; }
+        public Nullable<int> Desc { get; set; }
+    }
+
+    public class DtoWithOverride {
+        public String Name { get; set; }
+        public String Code { get; set; }
+        public Nullable<int> Desc { get; set; }
+    }
+
+    public class Context : LocalDbContext
+    {
+        public List<string> Log = new List<string>();
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.LogTo(s => Log.Add(s));
+            base.OnConfiguring(optionsBuilder);
+        }
+
+        public DbSet<Source> Sources { get; set; }
+
+        public string GetLastSelectSqlLogEntry() => Log.LastOrDefault(_ => _.Contains("SELECT"));
+    }
+
+    private static readonly IQueryable<Source> _iq = new List<Source> {
+        new Source() { Name = "Name1", Code = "Code1", Desc = -12 },
+    } .AsQueryable();
+
+    private static readonly Source _iqf = _iq.First();
+
+    public class DatabaseInitializer : DropCreateDatabaseAlways<Context>
+    {
+        protected override void Seed(Context context)
+        {
+            context.Sources.Add(_iqf);
+            base.Seed(context);
+        }
+    }
+
+    protected override MapperConfiguration CreateConfiguration() => new(cfg =>
+    {
+        cfg.CreateMap<Source, DtoWithOverride>()
+            .ForMember(dto => dto.Desc, conf => conf.ExplicitExpansion())
+            .ForMember(dto => dto.Name, conf => conf.MapFrom(src => src.Name))
+            .ForMember(dto => dto.Code, conf => conf.ExplicitExpansion(false))
+            .ForAllMembers(conf => conf.ExplicitExpansion())
+            ;
+
+        cfg.CreateMap<Source, DtoWithoutOverride>()
+            .ForMember(dto => dto.Desc, conf => conf.ExplicitExpansion())
+            .ForMember(dto => dto.Name, conf => conf.MapFrom(src => src.Name))
+            .ForMember(dto => dto.Code, conf => conf.ExplicitExpansion(false))
+            .ForAllMembers(conf => conf.ExplicitExpansion(overrideExpansion: false))
+            ;});
+
+    [Fact]
+    public void NoExplicitExpansion() {
+        using (var ctx = new Context()) {
+            var dto = ProjectTo<DtoWithOverride>(ctx.Sources).ToList().First();
+            var sqlSelect = ctx.GetLastSelectSqlLogEntry();
+            sqlSelect.SqlFromShouldStartWith(nameof(ctx.Sources));
+            sqlSelect.ShouldNotContain("JOIN");
+
+            sqlSelect.SqlShouldNotSelectColumn(nameof(_iqf.Name)); dto.Name.ShouldBeNull();
+            sqlSelect.SqlShouldNotSelectColumn(nameof(_iqf.Code)); dto.Code.ShouldBeNull();
+            sqlSelect.SqlShouldNotSelectColumn(nameof(_iqf.Desc)); dto.Desc.ShouldBeNull();
+        }
+    }
+
+    [Fact]
+    public void OnlyExplicitExpansionForCode()
+    {
+        using (var ctx = new Context())
+        {
+            var dto = ProjectTo<DtoWithoutOverride>(ctx.Sources).ToList().First();
+            var sqlSelect = ctx.GetLastSelectSqlLogEntry();
+            sqlSelect.SqlFromShouldStartWith(nameof(ctx.Sources));
+            sqlSelect.ShouldNotContain("JOIN");
+            
+            sqlSelect.SqlShouldNotSelectColumn(nameof(_iqf.Name));   dto.Name.ShouldBeNull();
+            sqlSelect.SqlShouldSelectColumn(nameof(_iqf.Code));      dto.Code.ShouldNotBeNull();
+            sqlSelect.SqlShouldNotSelectColumn(nameof(_iqf.Desc));   dto.Desc.ShouldBeNull();
+        }
+    }
+
+    [Fact]
+    public void ProjectNoExplicit() {
+        using (var ctx = new Context()) {
+            var dto = ProjectTo<DtoWithOverride>(ctx.Sources, null, _ => _.Name).First();
+            var sqlSelect = ctx.GetLastSelectSqlLogEntry();
+            sqlSelect.SqlFromShouldStartWith(nameof(ctx.Sources));
+            sqlSelect.ShouldNotContain("JOIN");
+            
+            dto.Name.ShouldBe(_iqf.Name); sqlSelect.SqlShouldSelectColumn(nameof(_iqf.Name));
+            dto.Code.ShouldBeNull(_iqf.Code); sqlSelect.SqlShouldNotSelectColumn(nameof(_iqf.Code));
+            dto.Desc.ShouldBeNull(); sqlSelect.SqlShouldNotSelectColumn(nameof(_iqf.Desc));
+        }
+    }
+
+    [Fact]
+    public void ProjectWithCodeImplicit() {
+        using (var ctx = new Context()) {
+            var dto = ProjectTo<DtoWithoutOverride>(ctx.Sources, null, _ => _.Name).First();
+            var sqlSelect = ctx.GetLastSelectSqlLogEntry();
+            sqlSelect.SqlFromShouldStartWith(nameof(ctx.Sources));
+            sqlSelect.ShouldNotContain("JOIN");
+
+            dto.Name.ShouldBe(_iqf.Name); sqlSelect.SqlShouldSelectColumn(nameof(_iqf.Name));
+            dto.Code.ShouldBe(_iqf.Code); sqlSelect.SqlShouldSelectColumn(nameof(_iqf.Code));
+            dto.Desc.ShouldBeNull(); sqlSelect.SqlShouldNotSelectColumn(nameof(_iqf.Desc));
+        }
+    }
+
+}


### PR DESCRIPTION
Pr to implement #4325
from discussion from here : https://github.com/AutoMapper/AutoMapper/discussions/4323

The idea is to add 2 parameters to the ExplicitExpansion call : 

```
Boolean explicitExpansion = true : instead of the hardcode true value we can control the value there
Boolean overrideExpansion = true: only used inside `ForAllMembers` like that we can decide if we override all the previous call to explicitExpansion or keep the value
```

and now we could do something like that 

```
cfg.CreateMap<Source, Dto>()
        .ForMember(dto => dto.Desc, conf => conf.ExplicitExpansion())
        .ForMember(dto => dto.Name, conf => conf.MapFrom(src => src.Name))
        .ForMember(dto => dto.Code, conf => conf.ExplicitExpansion(false))
        .ForAllMembers(conf => conf.ExplicitExpansion(overrideExpansion: false));
});
```

and only the `Code` field will be implicitly expanded.

From my point of view, all tests passe (DI, Intergration, Unit) and some simple test were added to demonstrate.

I'm pretty sure this request misses something to be me merge as it is, but i hope that you will help.