### PR TITLE
fix: error in Build.ps1 - the wrong target to the copy compat version

### DIFF
--- a/src/AutoMapper/ApiCompat/PreBuild.ps1
+++ b/src/AutoMapper/ApiCompat/PreBuild.ps1
@@ -10,4 +10,4 @@ if($versionNumbers[1] -eq "0" -AND $versionNumbers[2] -eq "0")
 $oldVersion = $oldVersion.ToString() +".0.0"
 echo $oldVersion
 & ..\..\nuget install AutoMapper -Version $oldVersion -OutputDirectory ..\LastMajorVersionBinary
-& copy ..\LastMajorVersionBinary\AutoMapper.$oldVersion\lib\net6.0\AutoMapper.dll ..\LastMajorVersionBinary
+& copy ..\LastMajorVersionBinary\AutoMapper.$oldVersion\lib\netstandard2.0\AutoMapper.dll ..\LastMajorVersionBinary


### PR DESCRIPTION
I was not able to `.\Build.ps1` the project after cloning until I fixed the path. 