### PR TITLE
Set html_baseurl

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ intersphinx_disabled_domains = ['std']
 templates_path = ['_templates']
 
 # -- Options for HTML output
-
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
 html_theme = 'sphinx_rtd_theme'
 html_theme_options = {
     'logo_only': True,


### PR DESCRIPTION
Maybe give this a try.
Another idea to try is setting [default_role](https://www.sphinx-doc.org/en/master/usage/referencing.html#cross-referencing-anything) to `any` or `doc`.