### PR TITLE
Allow package version ranges

### DIFF
--- a/src/AutoMapper/AutoMapper.csproj
+++ b/src/AutoMapper/AutoMapper.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options" Version="[6.0.0,9)" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[6.0.0,)" />
     <PackageReference Include="MinVer" Version="[4.3.0,5)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="[8.0.0,9)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="7.0.0-beta.22074.1" PrivateAssets="All" />  

--- a/src/AutoMapper/AutoMapper.csproj
+++ b/src/AutoMapper/AutoMapper.csproj
@@ -38,9 +38,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options" Version="6.0.0" />
-    <PackageReference Include="MinVer" Version="4.3.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="[6.0.0,9)" />
+    <PackageReference Include="MinVer" Version="[4.3.0,5)" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="[8.0.0,9)" PrivateAssets="All" />
     <PackageReference Include="Microsoft.DotNet.ApiCompat" Version="7.0.0-beta.22074.1" PrivateAssets="All" />  
   </ItemGroup>
 


### PR DESCRIPTION
One good practice that will allow projects referencing different versions of MinVer/options to be resolved during build without conflicts is to use version ranges
https://blog.inedo.com/nuget/package-versioning/
MinVer not allowed beyond 5 
rest is safe to have 9 as upper bound.
I couldn't run integration tests, since the the debian is not supported as platform for `LocalDb`
