### PR TITLE
Throw all configuration errors together

### DIFF
--- a/src/AutoMapper/Configuration/ConfigurationValidator.cs
+++ b/src/AutoMapper/Configuration/ConfigurationValidator.cs
@@ -27,6 +27,8 @@ public readonly record struct ConfigurationValidator(IGlobalConfigurationExpress
     }
     public void AssertConfigurationIsValid(IGlobalConfiguration config, TypeMap[] typeMaps)
     {
+        List<Exception> configExceptions = [];
+
         var badTypeMaps =
             (from typeMap in typeMaps
                 where typeMap.ShouldCheckForValid
@@ -37,10 +39,11 @@ public readonly record struct ConfigurationValidator(IGlobalConfigurationExpress
                 ).ToArray();
         if (badTypeMaps.Length > 0)
         {
-            throw new AutoMapperConfigurationException(badTypeMaps);
+            configExceptions.Add(new AutoMapperConfigurationException(badTypeMaps));
         }
+
         HashSet<TypeMap> typeMapsChecked = [];
-        List<Exception> configExceptions = [];
+
         foreach (var typeMap in typeMaps)
         {
             try

--- a/src/AutoMapper/Configuration/ConfigurationValidator.cs
+++ b/src/AutoMapper/Configuration/ConfigurationValidator.cs
@@ -37,10 +37,10 @@ public readonly record struct ConfigurationValidator(IGlobalConfigurationExpress
 
         foreach (var typeMap in typeMaps)
         {
-            var invalidMemberMaps = GetInvalidMemberMaps(typeMap.Types, typeMap, Expression.Validators);
-
-            configExceptions.AddRange(invalidMemberMaps.Select(memberMap => 
-                new AutoMapperConfigurationException(memberMap.TypeMap.Types) { MemberMap = memberMap }));
+            var badMemberMaps = GetInvalidMemberMaps(typeMap.Types, typeMap, Expression.Validators)
+                .Select(memberMap =>
+                    new AutoMapperConfigurationException(memberMap.TypeMap.Types) { MemberMap = memberMap });
+            configExceptions.AddRange(badMemberMaps);
         }
         if (configExceptions.Count > 1)
         {
@@ -122,15 +122,9 @@ public readonly record struct ConfigurationValidator(IGlobalConfigurationExpress
                 {
                     return false;
                 }
-
                 var sourceType = memberMap.SourceType;
                 // when we don't know what the source type is, bail
-                if (sourceType.IsGenericParameter || sourceType == typeof(object))
-                {
-                    return false;
-                }
-
-                return true;
+                return !sourceType.IsGenericParameter && sourceType != typeof(object);
             });
         }
     }

--- a/src/UnitTests/ConfigurationValidation.cs
+++ b/src/UnitTests/ConfigurationValidation.cs
@@ -407,6 +407,43 @@ public class When_testing_a_dto_with_matching_member_names_but_mismatched_types 
     }
 }
 
+public class When_testing_a_dto_with_mismatched_member_names_and_mismatched_types : NonValidatingSpecBase
+{
+    public class Source
+    {
+        public decimal Foo { get; set; }
+    }
+
+    public class Destination
+    {
+        public Type Foo { get; set; }
+        public string Bar { get; set; }
+    }
+
+    protected override MapperConfiguration CreateConfiguration() =>
+        new(cfg => { cfg.CreateMap<Source, Destination>(); });
+
+    [Fact]
+    public void Should_throw_unmapped_member_and_mismatched_type_exceptions()
+    {
+        new Action(AssertConfigurationIsValid)
+            .ShouldThrow<AggregateException>()
+            .ShouldSatisfyAllConditions(
+                aex => aex.InnerExceptions.ShouldBeOfLength(2),
+                aex => aex.InnerExceptions[0]
+                    .ShouldBeOfType<AutoMapperConfigurationException>()
+                    .ShouldSatisfyAllConditions(
+                        ex => ex.Errors.ShouldBeOfLength(1),
+                        ex => ex.Errors[0].UnmappedPropertyNames.ShouldContain("Bar")),
+                aex => aex.InnerExceptions[1]
+                    .ShouldBeOfType<AutoMapperConfigurationException>()
+                    .ShouldSatisfyAllConditions(
+                        ex => ex.MemberMap.ShouldNotBeNull(),
+                        ex => ex.MemberMap.DestinationName.ShouldBe("Foo"))
+            );
+    }
+}
+
 public class When_testing_a_dto_with_member_type_mapped_mappings : AutoMapperSpecBase
 {
     private AutoMapperConfigurationException _exception;


### PR DESCRIPTION
Previously, if the configuration contained bad type maps, `AssertConfigurationIsValid` would throw immediately without performing a dry run. Now, type map errors are thrown alongside any dry run errors.

#4524 