### PR TITLE
Update Microsoft.Sbom.DotNetTool to 4.1.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           reporter: dotnet-trx
       - name: Generate SBOM
         run: |
-          dotnet tool install --global Microsoft.Sbom.DotNetTool --version 1.2.0
+          dotnet tool install --global Microsoft.Sbom.DotNetTool --version 4.1.5
           sbom-tool generate -b artifacts -bc src/AutoMapper -pn AutoMapper -pv ${{ github.ref_name }} -ps LuckyPennySoftware -nsb https://automapper.io/sbom
         shell: pwsh
       - name: Sign packages


### PR DESCRIPTION
## Summary
- Updates `Microsoft.Sbom.DotNetTool` from `1.2.0` to `4.1.5` in the release workflow
- The old version was causing build failures

## Test plan
- [ ] Verify the release workflow runs successfully with the updated SBOM tool version

🤖 Generated with [Claude Code](https://claude.com/claude-code)