### PR TITLE
Support LicenseKey via environment variable fallback

### DIFF
--- a/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
+++ b/src/AutoMapper/Configuration/MapperConfigurationExpression.cs
@@ -127,7 +127,13 @@ public sealed class MapperConfigurationExpression : Profile, IGlobalConfiguratio
     /// </summary>
     int IGlobalConfigurationExpression.RecursiveQueriesMaxDepth { get; set; }
 
-    public string LicenseKey { get; set; }
+    private string _licenseKey;
+
+    public string LicenseKey
+    {
+        get => _licenseKey ?? Environment.GetEnvironmentVariable("AUTOMAPPER_LICENSE_KEY");
+        set => _licenseKey = value;
+    }
 
     public ServiceLifetime ServiceLifetime { get; set; } = ServiceLifetime.Transient;
 

--- a/src/UnitTests/AutoMapper.UnitTests.csproj
+++ b/src/UnitTests/AutoMapper.UnitTests.csproj
@@ -15,6 +15,8 @@
   <ItemGroup>
     <ProjectReference Include="..\AutoMapper\AutoMapper.csproj" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[10.0.0, )" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="[10.0.0, )" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="All" />

--- a/src/UnitTests/LicenseKeyEnvironmentVariableTests.cs
+++ b/src/UnitTests/LicenseKeyEnvironmentVariableTests.cs
@@ -1,0 +1,229 @@
+using Xunit;
+using AutoMapper;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace AutoMapper.UnitTests.Licensing;
+
+public class LicenseKeyEnvironmentVariableTests
+{
+    #region Environment Variable Auto-Detection Tests
+
+    [Fact]
+    public void LicenseKey_ReadsFromEnvironmentVariable_WhenNotExplicitlySet()
+    {
+        // Arrange
+        const string expectedKey = "test-license-key-12345";
+        Environment.SetEnvironmentVariable("AUTOMAPPER_LICENSE_KEY", expectedKey);
+        
+        try
+        {
+            var config = new MapperConfigurationExpression();
+
+            // Act
+            var actualKey = config.LicenseKey;
+
+            // Assert
+            Assert.Equal(expectedKey, actualKey);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AUTOMAPPER_LICENSE_KEY", null);
+        }
+    }
+
+    [Fact]
+    public void LicenseKey_ReturnsNull_WhenEnvironmentVariableNotSet()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("AUTOMAPPER_LICENSE_KEY", null);
+        var config = new MapperConfigurationExpression();
+
+        // Act
+        var actualKey = config.LicenseKey;
+
+        // Assert
+        Assert.Null(actualKey);
+    }
+
+    #endregion
+
+    #region Backward Compatibility - Old Way Tests
+
+    [Fact]
+    public void LicenseKey_SupportsOldWay_DirectAssignment()
+    {
+        // Arrange
+        const string licenseKey = "old-way-explicit-key";
+        var config = new MapperConfigurationExpression();
+
+        // Act
+        config.LicenseKey = licenseKey;
+        var actualKey = config.LicenseKey;
+
+        // Assert
+        Assert.Equal(licenseKey, actualKey);
+    }
+
+    [Fact]
+    public void LicenseKey_PrioritizesExplicitValue_OverEnvironmentVariable()
+    {
+        // Arrange
+        const string envKey = "env-license-key";
+        const string explicitKey = "explicit-license-key";
+        Environment.SetEnvironmentVariable("AUTOMAPPER_LICENSE_KEY", envKey);
+        
+        try
+        {
+            var config = new MapperConfigurationExpression();
+
+            // Act
+            config.LicenseKey = explicitKey;
+            var actualKey = config.LicenseKey;
+
+            // Assert
+            Assert.Equal(explicitKey, actualKey);
+            Assert.NotEqual(envKey, actualKey);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AUTOMAPPER_LICENSE_KEY", null);
+        }
+    }
+
+    [Fact]
+    public void LicenseKey_OldWayOverridesEnvironmentVariable_InConfigAction()
+    {
+        // Arrange
+        const string envKey = "env-license-key";
+        const string explicitKey = "explicit-override-key";
+        Environment.SetEnvironmentVariable("AUTOMAPPER_LICENSE_KEY", envKey);
+        
+        try
+        {
+            var config = new MapperConfigurationExpression();
+            
+            // Act - Old way: set it in the config action
+            config.LicenseKey = explicitKey;
+
+            // Assert
+            Assert.Equal(explicitKey, config.LicenseKey);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AUTOMAPPER_LICENSE_KEY", null);
+        }
+    }
+
+    #endregion
+
+    #region Integration Tests - Old Way with DI
+
+    [Fact]
+    public void AddAutoMapper_SupportsOldWay_ExplicitLicenseKey()
+    {
+        // Arrange
+        const string licenseKey = "old-way-integration-key";
+        
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAutoMapper(cfg => 
+        {
+            cfg.LicenseKey = licenseKey;
+            cfg.CreateMap<TestSource, TestDestination>();
+        });
+
+        var provider = services.BuildServiceProvider();
+        var mapper = provider.GetRequiredService<IMapper>();
+
+        // Act
+        var result = mapper.Map<TestDestination>(new TestSource { Name = "Test" });
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Test", result.Name);
+    }
+
+    [Fact]
+    public void AddAutoMapper_UsesEnvironmentVariable_WhenNoExplicitKeySet()
+    {
+        // Arrange
+        const string licenseKey = "env-integration-key";
+        Environment.SetEnvironmentVariable("AUTOMAPPER_LICENSE_KEY", licenseKey);
+        
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddAutoMapper(cfg => 
+            {
+                // No explicit LicenseKey assignment - should use env var
+                cfg.CreateMap<TestSource, TestDestination>();
+            });
+
+            var provider = services.BuildServiceProvider();
+            var mapper = provider.GetRequiredService<IMapper>();
+
+            // Act
+            var result = mapper.Map<TestDestination>(new TestSource { Name = "Test" });
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Test", result.Name);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AUTOMAPPER_LICENSE_KEY", null);
+        }
+    }
+
+    [Fact]
+    public void AddAutoMapper_OldWayTakesPrecedence_OverEnvironmentVariable()
+    {
+        // Arrange
+        const string envKey = "env-license-key";
+        const string explicitKey = "explicit-license-key-from-old-way";
+        Environment.SetEnvironmentVariable("AUTOMAPPER_LICENSE_KEY", envKey);
+        
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+            services.AddAutoMapper(cfg => 
+            {
+                cfg.LicenseKey = explicitKey;
+                cfg.CreateMap<TestSource, TestDestination>();
+            });
+
+            var provider = services.BuildServiceProvider();
+            var mapper = provider.GetRequiredService<IMapper>();
+
+            // Act
+            var result = mapper.Map<TestDestination>(new TestSource { Name = "Test" });
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Test", result.Name);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AUTOMAPPER_LICENSE_KEY", null);
+        }
+    }
+
+    #endregion
+
+    #region Test Helper Classes
+
+    private class TestSource
+    {
+        public string Name { get; set; }
+    }
+
+    private class TestDestination
+    {
+        public string Name { get; set; }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
# PR: Auto-Detect License Key from Environment Variables Fixes

## What Changed
Added support for reading the AutoMapper license key from an environment variable instead of requiring manual configuration in code.

## Why
In containerized and cloud environments, it's better to use environment variables for sensitive configuration instead of hardcoding values in code.

## How It Works

The LicenseKey property now checks for values in this order:
1. Explicit value set in code (cfg.LicenseKey = "key") - highest priority
2. Environment variable AUTOMAPPER_LICENSE_KEY - fallback
3. Null if neither is set - lowest priority

## Usage

NEW WAY - Using Environment Variable:
Set environment variable AUTOMAPPER_LICENSE_KEY before running your app
Then just add AutoMapper without setting the license key:

    services.AddAutoMapper(cfg => 
    {
        cfg.CreateMap<Foo, FooDto>();
    });

OLD WAY - Still Works (Backward Compatible):

    services.AddAutoMapper(cfg => 
    {
        cfg.LicenseKey = "your-license-key";
        cfg.CreateMap<Foo, FooDto>();
    });

BOTH SET - Code value wins:
If you set both the environment variable AND code value, the code value is used.

## Tests Added
- Tests for environment variable auto-detection
- Tests for old explicit assignment (backward compatibility)
- Tests for precedence when both are set
- Integration tests with dependency injection

## Backward Compatibility
100% backward compatible. All existing code continues to work exactly the same way.